### PR TITLE
Disable default features for substrate-primitives

### DIFF
--- a/test/testers/rust-tester/pdre-tester-wasm-blob/Cargo.toml
+++ b/test/testers/rust-tester/pdre-tester-wasm-blob/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
-substrate-primitives = { git = "https://github.com/paritytech/substrate" }
+substrate-primitives = { git = "https://github.com/paritytech/substrate", default-features = false }
 parity-scale-codec={path = "../../../../implementations/rust/parity-codec"}
 
 


### PR DESCRIPTION
Required in order to fix the breaking build script, as reported by the Kagome team.