### PR TITLE
Spec child storage APIs

### DIFF
--- a/runtime-environment-spec/polkadot_re_spec.tm
+++ b/runtime-environment-spec/polkadot_re_spec.tm
@@ -4205,7 +4205,7 @@
 
     \ \ \ \ \ \ (param $storage_key_data i32) (param $storage_key_len i32)
 
-    \ \ \ \ \ \ (param $key_data i32) (param $key_len i32))
+    \ \ \ \ \ \ (param $key_data i32) (param $key_len i32) (result i32))
   </verbatim>
 
   \;
@@ -4224,6 +4224,55 @@
 
     <item><verbatim|key_len>: the length of the key byte array in number of
     bytes.
+
+    <item><verbatim|result>: an i32 integer which is equal to 1 verifies if
+    an entry with the given key exists in the child storage or 0 if the child
+    storage does not contain an entry with the given key.
+  </itemize>
+
+  <subsection|<verbatim|ext_get_allocated_child_storage>>
+
+  Given a byte array, this function allocates a large enough buffer in the
+  memory and retrieves the value stored under the key that is specified in
+  the array. Then, it stores in in the allocated buffer if the entry exists
+  in the child storage.
+
+  \;
+
+  <strong|Prototype:>
+
+  <\verbatim>
+    \ \ \ \ (func $ext_get_allocated_child_storage
+
+    \ \ \ \ \ \ (param $storage_key_data i32) (param $storage_key_len i32)
+    (param $key_data i32) \ \ \ \ \ \ \ \ \ \ \ \ (param $key_len i32) (param
+    $written_out) (result i32))
+  </verbatim>
+
+  \;
+
+  <strong|Arguments>:
+
+  <\itemize>
+    <item><verbatim|storage_key_data>: a memory address pointing at the
+    buffer of the byte array containing the child storage key.
+
+    <item><verbatim|storage_key_len>: the length of the child storage key
+    byte array in number of bytes.
+
+    <item><verbatim|key_data>: a memory address pointing at the buffer of the
+    byte array containing the key value.
+
+    <item><verbatim|key_len>: the length of the key byte array in number of
+    bytes.
+
+    <item><verbatim|written_out>: the function stores the length of the
+    retrieved value in number of bytes if the enty exists. If the entry does
+    not exist, it returns <math|2<rsup|32>-1>.
+
+    <item><verbatim|result>: A pointer to the buffer in which the function
+    allocates and stores the value corresponding to the given key if such an
+    entry exist; otherwise it is equal to 0.
   </itemize>
 
   <subsection|To Be Specced>
@@ -4233,7 +4282,7 @@
 
     <item><verbatim|>
 
-    <item><verbatim|ext_get_allocated_child_storage>
+    <item><verbatim|>
 
     <item><verbatim|ext_get_child_storage_into>
 
@@ -5693,63 +5742,64 @@
     <associate|auto-123|<tuple|F.1.8|56>>
     <associate|auto-124|<tuple|F.1.9|56>>
     <associate|auto-125|<tuple|F.1.10|56>>
-    <associate|auto-126|<tuple|F.1.10.1|57>>
-    <associate|auto-127|<tuple|F.1.10.2|57>>
-    <associate|auto-128|<tuple|F.1.10.3|57>>
-    <associate|auto-129|<tuple|F.1.11|57>>
+    <associate|auto-126|<tuple|F.1.11|57>>
+    <associate|auto-127|<tuple|F.1.11.1|57>>
+    <associate|auto-128|<tuple|F.1.11.2|57>>
+    <associate|auto-129|<tuple|F.1.11.3|57>>
     <associate|auto-13|<tuple|1.9|9>>
-    <associate|auto-130|<tuple|F.1.11.1|57>>
-    <associate|auto-131|<tuple|F.1.11.2|58>>
-    <associate|auto-132|<tuple|F.1.11.3|58>>
-    <associate|auto-133|<tuple|F.1.11.4|59>>
-    <associate|auto-134|<tuple|F.1.11.5|59>>
-    <associate|auto-135|<tuple|F.1.11.6|59>>
-    <associate|auto-136|<tuple|F.1.12|60>>
-    <associate|auto-137|<tuple|F.1.12.1|60>>
-    <associate|auto-138|<tuple|F.1.12.2|60>>
-    <associate|auto-139|<tuple|F.1.12.3|61>>
+    <associate|auto-130|<tuple|F.1.12|57>>
+    <associate|auto-131|<tuple|F.1.12.1|58>>
+    <associate|auto-132|<tuple|F.1.12.2|58>>
+    <associate|auto-133|<tuple|F.1.12.3|59>>
+    <associate|auto-134|<tuple|F.1.12.4|59>>
+    <associate|auto-135|<tuple|F.1.12.5|59>>
+    <associate|auto-136|<tuple|F.1.12.6|60>>
+    <associate|auto-137|<tuple|F.1.13|60>>
+    <associate|auto-138|<tuple|F.1.13.1|60>>
+    <associate|auto-139|<tuple|F.1.13.2|61>>
     <associate|auto-14|<tuple|1.2.1|9>>
-    <associate|auto-140|<tuple|F.1.12.4|61>>
-    <associate|auto-141|<tuple|F.1.12.5|61>>
-    <associate|auto-142|<tuple|F.1.12.6|62>>
-    <associate|auto-143|<tuple|F.1.12.7|62>>
-    <associate|auto-144|<tuple|F.1.12.8|62>>
-    <associate|auto-145|<tuple|F.1.12.9|63>>
-    <associate|auto-146|<tuple|F.1.12.10|63>>
-    <associate|auto-147|<tuple|F.1.12.11|64>>
-    <associate|auto-148|<tuple|F.1.12.12|64>>
-    <associate|auto-149|<tuple|F.1.12.13|65>>
+    <associate|auto-140|<tuple|F.1.13.3|61>>
+    <associate|auto-141|<tuple|F.1.13.4|61>>
+    <associate|auto-142|<tuple|F.1.13.5|62>>
+    <associate|auto-143|<tuple|F.1.13.6|62>>
+    <associate|auto-144|<tuple|F.1.13.7|62>>
+    <associate|auto-145|<tuple|F.1.13.8|63>>
+    <associate|auto-146|<tuple|F.1.13.9|63>>
+    <associate|auto-147|<tuple|F.1.13.10|64>>
+    <associate|auto-148|<tuple|F.1.13.11|64>>
+    <associate|auto-149|<tuple|F.1.13.12|65>>
     <associate|auto-15|<tuple|1.11|9>>
-    <associate|auto-150|<tuple|F.1.12.14|65>>
-    <associate|auto-151|<tuple|F.1.12.15|65>>
-    <associate|auto-152|<tuple|F.1.13|65>>
-    <associate|auto-153|<tuple|F.1.13.1|65>>
-    <associate|auto-154|<tuple|F.1.14|66>>
-    <associate|auto-155|<tuple|F.1.14.1|66>>
-    <associate|auto-156|<tuple|F.1.14.2|66>>
-    <associate|auto-157|<tuple|F.1.15|66>>
-    <associate|auto-158|<tuple|F.1.15.1|66>>
-    <associate|auto-159|<tuple|F.1.16|67>>
+    <associate|auto-150|<tuple|F.1.13.13|65>>
+    <associate|auto-151|<tuple|F.1.13.14|65>>
+    <associate|auto-152|<tuple|F.1.13.15|65>>
+    <associate|auto-153|<tuple|F.1.14|65>>
+    <associate|auto-154|<tuple|F.1.14.1|66>>
+    <associate|auto-155|<tuple|F.1.15|66>>
+    <associate|auto-156|<tuple|F.1.15.1|66>>
+    <associate|auto-157|<tuple|F.1.15.2|66>>
+    <associate|auto-158|<tuple|F.1.16|66>>
+    <associate|auto-159|<tuple|F.1.16.1|67>>
     <associate|auto-16|<tuple|1.12|9>>
-    <associate|auto-160|<tuple|F.2|67>>
-    <associate|auto-161|<tuple|G|67>>
-    <associate|auto-162|<tuple|G.1|68>>
+    <associate|auto-160|<tuple|F.1.17|67>>
+    <associate|auto-161|<tuple|F.2|67>>
+    <associate|auto-162|<tuple|G|68>>
     <associate|auto-163|<tuple|G.1|68>>
-    <associate|auto-164|<tuple|G.2|68>>
-    <associate|auto-165|<tuple|G.2.1|68>>
-    <associate|auto-166|<tuple|G.1|68>>
-    <associate|auto-167|<tuple|G.2.2|68>>
-    <associate|auto-168|<tuple|G.2.3|69>>
-    <associate|auto-169|<tuple|G.2.4|69>>
+    <associate|auto-164|<tuple|G.1|68>>
+    <associate|auto-165|<tuple|G.2|68>>
+    <associate|auto-166|<tuple|G.2.1|68>>
+    <associate|auto-167|<tuple|G.1|68>>
+    <associate|auto-168|<tuple|G.2.2|69>>
+    <associate|auto-169|<tuple|G.2.3|69>>
     <associate|auto-17|<tuple|1.12|9>>
-    <associate|auto-170|<tuple|G.2.5|69>>
-    <associate|auto-171|<tuple|G.2.6|70>>
-    <associate|auto-172|<tuple|G.2.7|70>>
-    <associate|auto-173|<tuple|G.2|71>>
-    <associate|auto-174|<tuple|G.3|73>>
+    <associate|auto-170|<tuple|G.2.4|69>>
+    <associate|auto-171|<tuple|G.2.5|70>>
+    <associate|auto-172|<tuple|G.2.6|70>>
+    <associate|auto-173|<tuple|G.2.7|71>>
+    <associate|auto-174|<tuple|G.2|73>>
     <associate|auto-175|<tuple|G.3|75>>
     <associate|auto-176|<tuple|G.3|?>>
-    <associate|auto-177|<tuple|Tec19|?>>
+    <associate|auto-177|<tuple|G.3|?>>
+    <associate|auto-178|<tuple|Tec19|?>>
     <associate|auto-18|<tuple|1.13|9>>
     <associate|auto-19|<tuple|1.13|9>>
     <associate|auto-2|<tuple|1.1|7>>

--- a/runtime-environment-spec/polkadot_re_spec.tm
+++ b/runtime-environment-spec/polkadot_re_spec.tm
@@ -4191,12 +4191,47 @@
     bytes.
   </itemize>
 
+  <subsection|<verbatim|ext_exists_child_storage>>
+
+  Given a byte array, this function checks if the child storage entry
+  corresponding to the key specified in the array exists.
+
+  \;
+
+  <strong|Prototype:>
+
+  <\verbatim>
+    \ \ \ \ (func $ext_exists_child_storage
+
+    \ \ \ \ \ \ (param $storage_key_data i32) (param $storage_key_len i32)
+
+    \ \ \ \ \ \ (param $key_data i32) (param $key_len i32))
+  </verbatim>
+
+  \;
+
+  <strong|Arguments>:
+
+  <\itemize>
+    <item><verbatim|storage_key_data>: a memory address pointing at the
+    buffer of the byte array containing the child storage key.
+
+    <item><verbatim|storage_key_len>: the length of the child storage key
+    byte array in number of bytes.
+
+    <item><verbatim|key_data>: a memory address pointing at the buffer of the
+    byte array containing the key value.
+
+    <item><verbatim|key_len>: the length of the key byte array in number of
+    bytes.
+  </itemize>
+
   <subsection|To Be Specced>
 
   <\itemize>
     <item><verbatim|>
 
-    <item><verbatim|ext_exists_child_storage>
+    <item><verbatim|>
 
     <item><verbatim|ext_get_allocated_child_storage>
 
@@ -5657,63 +5692,64 @@
     <associate|auto-122|<tuple|F.1.7|56>>
     <associate|auto-123|<tuple|F.1.8|56>>
     <associate|auto-124|<tuple|F.1.9|56>>
-    <associate|auto-125|<tuple|F.1.9.1|56>>
-    <associate|auto-126|<tuple|F.1.9.2|57>>
-    <associate|auto-127|<tuple|F.1.9.3|57>>
-    <associate|auto-128|<tuple|F.1.10|57>>
-    <associate|auto-129|<tuple|F.1.10.1|57>>
+    <associate|auto-125|<tuple|F.1.10|56>>
+    <associate|auto-126|<tuple|F.1.10.1|57>>
+    <associate|auto-127|<tuple|F.1.10.2|57>>
+    <associate|auto-128|<tuple|F.1.10.3|57>>
+    <associate|auto-129|<tuple|F.1.11|57>>
     <associate|auto-13|<tuple|1.9|9>>
-    <associate|auto-130|<tuple|F.1.10.2|57>>
-    <associate|auto-131|<tuple|F.1.10.3|58>>
-    <associate|auto-132|<tuple|F.1.10.4|58>>
-    <associate|auto-133|<tuple|F.1.10.5|59>>
-    <associate|auto-134|<tuple|F.1.10.6|59>>
-    <associate|auto-135|<tuple|F.1.11|59>>
-    <associate|auto-136|<tuple|F.1.11.1|60>>
-    <associate|auto-137|<tuple|F.1.11.2|60>>
-    <associate|auto-138|<tuple|F.1.11.3|60>>
-    <associate|auto-139|<tuple|F.1.11.4|61>>
+    <associate|auto-130|<tuple|F.1.11.1|57>>
+    <associate|auto-131|<tuple|F.1.11.2|58>>
+    <associate|auto-132|<tuple|F.1.11.3|58>>
+    <associate|auto-133|<tuple|F.1.11.4|59>>
+    <associate|auto-134|<tuple|F.1.11.5|59>>
+    <associate|auto-135|<tuple|F.1.11.6|59>>
+    <associate|auto-136|<tuple|F.1.12|60>>
+    <associate|auto-137|<tuple|F.1.12.1|60>>
+    <associate|auto-138|<tuple|F.1.12.2|60>>
+    <associate|auto-139|<tuple|F.1.12.3|61>>
     <associate|auto-14|<tuple|1.2.1|9>>
-    <associate|auto-140|<tuple|F.1.11.5|61>>
-    <associate|auto-141|<tuple|F.1.11.6|61>>
-    <associate|auto-142|<tuple|F.1.11.7|62>>
-    <associate|auto-143|<tuple|F.1.11.8|62>>
-    <associate|auto-144|<tuple|F.1.11.9|62>>
-    <associate|auto-145|<tuple|F.1.11.10|63>>
-    <associate|auto-146|<tuple|F.1.11.11|63>>
-    <associate|auto-147|<tuple|F.1.11.12|64>>
-    <associate|auto-148|<tuple|F.1.11.13|64>>
-    <associate|auto-149|<tuple|F.1.11.14|65>>
+    <associate|auto-140|<tuple|F.1.12.4|61>>
+    <associate|auto-141|<tuple|F.1.12.5|61>>
+    <associate|auto-142|<tuple|F.1.12.6|62>>
+    <associate|auto-143|<tuple|F.1.12.7|62>>
+    <associate|auto-144|<tuple|F.1.12.8|62>>
+    <associate|auto-145|<tuple|F.1.12.9|63>>
+    <associate|auto-146|<tuple|F.1.12.10|63>>
+    <associate|auto-147|<tuple|F.1.12.11|64>>
+    <associate|auto-148|<tuple|F.1.12.12|64>>
+    <associate|auto-149|<tuple|F.1.12.13|65>>
     <associate|auto-15|<tuple|1.11|9>>
-    <associate|auto-150|<tuple|F.1.11.15|65>>
-    <associate|auto-151|<tuple|F.1.12|65>>
-    <associate|auto-152|<tuple|F.1.12.1|65>>
-    <associate|auto-153|<tuple|F.1.13|65>>
-    <associate|auto-154|<tuple|F.1.13.1|66>>
-    <associate|auto-155|<tuple|F.1.13.2|66>>
-    <associate|auto-156|<tuple|F.1.14|66>>
-    <associate|auto-157|<tuple|F.1.14.1|66>>
-    <associate|auto-158|<tuple|F.1.15|66>>
-    <associate|auto-159|<tuple|F.2|67>>
+    <associate|auto-150|<tuple|F.1.12.14|65>>
+    <associate|auto-151|<tuple|F.1.12.15|65>>
+    <associate|auto-152|<tuple|F.1.13|65>>
+    <associate|auto-153|<tuple|F.1.13.1|65>>
+    <associate|auto-154|<tuple|F.1.14|66>>
+    <associate|auto-155|<tuple|F.1.14.1|66>>
+    <associate|auto-156|<tuple|F.1.14.2|66>>
+    <associate|auto-157|<tuple|F.1.15|66>>
+    <associate|auto-158|<tuple|F.1.15.1|66>>
+    <associate|auto-159|<tuple|F.1.16|67>>
     <associate|auto-16|<tuple|1.12|9>>
-    <associate|auto-160|<tuple|G|67>>
-    <associate|auto-161|<tuple|G.1|67>>
+    <associate|auto-160|<tuple|F.2|67>>
+    <associate|auto-161|<tuple|G|67>>
     <associate|auto-162|<tuple|G.1|68>>
-    <associate|auto-163|<tuple|G.2|68>>
-    <associate|auto-164|<tuple|G.2.1|68>>
-    <associate|auto-165|<tuple|G.1|68>>
-    <associate|auto-166|<tuple|G.2.2|68>>
-    <associate|auto-167|<tuple|G.2.3|68>>
-    <associate|auto-168|<tuple|G.2.4|69>>
-    <associate|auto-169|<tuple|G.2.5|69>>
+    <associate|auto-163|<tuple|G.1|68>>
+    <associate|auto-164|<tuple|G.2|68>>
+    <associate|auto-165|<tuple|G.2.1|68>>
+    <associate|auto-166|<tuple|G.1|68>>
+    <associate|auto-167|<tuple|G.2.2|68>>
+    <associate|auto-168|<tuple|G.2.3|69>>
+    <associate|auto-169|<tuple|G.2.4|69>>
     <associate|auto-17|<tuple|1.12|9>>
-    <associate|auto-170|<tuple|G.2.6|69>>
-    <associate|auto-171|<tuple|G.2.7|70>>
-    <associate|auto-172|<tuple|G.2|70>>
-    <associate|auto-173|<tuple|G.3|71>>
+    <associate|auto-170|<tuple|G.2.5|69>>
+    <associate|auto-171|<tuple|G.2.6|70>>
+    <associate|auto-172|<tuple|G.2.7|70>>
+    <associate|auto-173|<tuple|G.2|71>>
     <associate|auto-174|<tuple|G.3|73>>
     <associate|auto-175|<tuple|G.3|75>>
-    <associate|auto-176|<tuple|Tec19|?>>
+    <associate|auto-176|<tuple|G.3|?>>
+    <associate|auto-177|<tuple|Tec19|?>>
     <associate|auto-18|<tuple|1.13|9>>
     <associate|auto-19|<tuple|1.13|9>>
     <associate|auto-2|<tuple|1.1|7>>

--- a/runtime-environment-spec/polkadot_re_spec.tm
+++ b/runtime-environment-spec/polkadot_re_spec.tm
@@ -4131,8 +4131,8 @@
   <subsection|<verbatim|ext_get_storage_into>>
 
   Given a byte array, this function retrieves the value stored under the key
-  specified in the array and stores a specified chunk of it in the provided
-  buffer, if the entry exists in the storage.
+  specified in the array and stores the specified chunk starting at the
+  offset into the provided buffer, if the entry exists in the storage.
 
   \;
 
@@ -4174,6 +4174,45 @@
     <item><verbatim|result>: The number of bytes the function writes in
     <verbatim|value_data> if the value exists or <math|2<rsup|32>-1> if the
     entry does not exist under the specified key.
+  </itemize>
+
+  <subsection|<verbatim|ext_set_child_storage>>
+
+  Sets the value of a specific key in the child state storage.
+
+  \;
+
+  <strong|Prototype:>
+
+  <\verbatim>
+    (func $ext_set_child_storage
+
+    \ \ (param $storage_key_data i32) (param $storage_key_len i32) (param
+    $key_data i32)
+
+    \ \ (param $key_len i32) (param $value_data i32) (param $value_len i32))
+  </verbatim>
+
+  \;
+
+  <strong|Arguments>:
+
+  <\itemize>
+    <item><verbatim|storage_key_data>: a memory address pointing at the
+    buffer of the byte array containing the child storage key. This key
+    <strong|must> be prefixed with <code|<code*|:child_storage:default:>>
+
+    <item><verbatim|storage_key_len>: the length of the child storage key
+    byte array in number of bytes.
+
+    <item><verbatim|key>: a pointer indicating the buffer containing the key.
+
+    <item><verbatim|key_len>: the key length in bytes.
+
+    <item><verbatim|value>: a pointer indicating the buffer containing the
+    value to be stored under the key.
+
+    <item><verbatim|value_len>: the length of the value buffer in bytes.
   </itemize>
 
   <subsection|<verbatim|ext_clear_child_storage>>
@@ -4288,7 +4327,7 @@
 
     <item><verbatim|written_out>: the function stores the length of the
     retrieved value in number of bytes if the enty exists. If the entry does
-    not exist, it returns <math|2<rsup|32>-1>.
+    not exist, it stores <math|2<rsup|32>-1>.
 
     <item><verbatim|result>: A pointer to the buffer in which the function
     allocates and stores the value corresponding to the given key if such an
@@ -4298,8 +4337,8 @@
   <subsection|<verbatim|ext_get_child_storage_into>>
 
   Given a byte array, this function retrieves the child value stored under
-  the key specified in the array and stores a specified chunk of it in the
-  provided buffer, if the entry exists in the storage.
+  the key specified in the array and stores the specified chunk starting the
+  offset into the provided buffer, if the entry exists in the storage.
 
   \;
 
@@ -4376,44 +4415,6 @@
 
     <item><verbatim|storage_key_len>: the length of the child storage key
     byte array in number of bytes.
-  </itemize>
-
-  <subsection|<verbatim|ext_set_child_storage>>
-
-  Sets the value of a specific key in the child state storage.
-
-  \;
-
-  <strong|Prototype:>
-
-  <\verbatim>
-    (func $ext_set_child_storage
-
-    \ \ (param $storage_key_data i32) (param $storage_key_len i32) (param
-    $key_data i32)
-
-    \ \ (param $key_len i32) (param $value_data i32) (param $value_len i32))
-  </verbatim>
-
-  \;
-
-  <strong|Arguments>:
-
-  <\itemize>
-    <item><verbatim|storage_key_data>: a memory address pointing at the
-    buffer of the byte array containing the child storage key.
-
-    <item><verbatim|storage_key_len>: the length of the child storage key
-    byte array in number of bytes.
-
-    <item><verbatim|key>: a pointer indicating the buffer containing the key.
-
-    <item><verbatim|key_len>: the key length in bytes.
-
-    <item><verbatim|value>: a pointer indicating the buffer containing the
-    value to be stored under the key.
-
-    <item><verbatim|value_len>: the length of the value buffer in bytes.
   </itemize>
 
   <subsection|Memory>

--- a/runtime-environment-spec/polkadot_re_spec.tm
+++ b/runtime-environment-spec/polkadot_re_spec.tm
@@ -350,228 +350,248 @@
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-115>>
 
-    <with|par-left|2tab|F.1.2.1.<space|2spc><with|font-family|tt|language|verbatim|ext_blake2_256_enumerated_trie_root>
+    <with|par-left|1tab|F.1.3.<space|2spc><with|font-family|tt|language|verbatim|ext_blake2_256_enumerated_trie_root>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-116>>
 
-    <with|par-left|1tab|F.1.3.<space|2spc><with|font-family|tt|language|verbatim|ext_clear_prefix>
+    <with|par-left|1tab|F.1.4.<space|2spc><with|font-family|tt|language|verbatim|ext_clear_prefix>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-117>>
 
-    <with|par-left|1tab|F.1.4.<space|2spc><with|font-family|tt|language|verbatim|><with|font-family|tt|language|verbatim|ext_clear_storage>
+    <with|par-left|1tab|F.1.5.<space|2spc><with|font-family|tt|language|verbatim|><with|font-family|tt|language|verbatim|ext_clear_storage>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-118>>
 
-    <with|par-left|2tab|F.1.4.1.<space|2spc><with|font-family|tt|language|verbatim|ext_exists_storage>
+    <with|par-left|1tab|F.1.6.<space|2spc><with|font-family|tt|language|verbatim|ext_exists_storage>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-119>>
 
-    <with|par-left|1tab|F.1.5.<space|2spc><with|font-family|tt|language|verbatim|ext_get_allocated_storage>
+    <with|par-left|1tab|F.1.7.<space|2spc><with|font-family|tt|language|verbatim|ext_get_allocated_storage>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-120>>
 
-    <with|par-left|1tab|F.1.6.<space|2spc><with|font-family|tt|language|verbatim|ext_get_storage_into>
+    <with|par-left|1tab|F.1.8.<space|2spc><with|font-family|tt|language|verbatim|ext_get_storage_into>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-121>>
 
-    <with|par-left|1tab|F.1.7.<space|2spc>To Be Specced
+    <with|par-left|1tab|F.1.9.<space|2spc><with|font-family|tt|language|verbatim|ext_clear_child_storage>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-122>>
 
-    <with|par-left|1tab|F.1.8.<space|2spc>Memory
+    <with|par-left|1tab|F.1.10.<space|2spc><with|font-family|tt|language|verbatim|ext_exists_child_storage>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-123>>
 
-    <with|par-left|2tab|F.1.8.1.<space|2spc><with|font-family|tt|language|verbatim|ext_malloc>
+    <with|par-left|1tab|F.1.11.<space|2spc><with|font-family|tt|language|verbatim|ext_get_allocated_child_storage>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-124>>
 
-    <with|par-left|2tab|F.1.8.2.<space|2spc><with|font-family|tt|language|verbatim|ext_free>
+    <with|par-left|1tab|F.1.12.<space|2spc><with|font-family|tt|language|verbatim|ext_get_child_storage_into>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-125>>
 
-    <with|par-left|2tab|F.1.8.3.<space|2spc>Input/Output
+    <with|par-left|1tab|F.1.13.<space|2spc><with|font-family|tt|language|verbatim|ext_kill_child_storage>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-126>>
 
-    <with|par-left|1tab|F.1.9.<space|2spc>Cryptograhpic Auxiliary Functions
+    <with|par-left|1tab|F.1.14.<space|2spc><with|font-family|tt|language|verbatim|ext_set_child_storage>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-127>>
 
-    <with|par-left|2tab|F.1.9.1.<space|2spc><with|font-family|tt|language|verbatim|ext_blake2_256>
+    <with|par-left|1tab|F.1.15.<space|2spc>Memory
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-128>>
 
-    <with|par-left|2tab|F.1.9.2.<space|2spc><with|font-family|tt|language|verbatim|ext_keccak_256>
+    <with|par-left|2tab|F.1.15.1.<space|2spc><with|font-family|tt|language|verbatim|ext_malloc>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-129>>
 
-    <with|par-left|2tab|F.1.9.3.<space|2spc><with|font-family|tt|language|verbatim|ext_twox_128>
+    <with|par-left|2tab|F.1.15.2.<space|2spc><with|font-family|tt|language|verbatim|ext_free>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-130>>
 
-    <with|par-left|2tab|F.1.9.4.<space|2spc><with|font-family|tt|language|verbatim|ext_ed25519_verify>
+    <with|par-left|2tab|F.1.15.3.<space|2spc>Input/Output
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-131>>
 
-    <with|par-left|2tab|F.1.9.5.<space|2spc><with|font-family|tt|language|verbatim|ext_sr25519_verify>
+    <with|par-left|1tab|F.1.16.<space|2spc>Cryptograhpic Auxiliary Functions
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-132>>
 
-    <with|par-left|2tab|F.1.9.6.<space|2spc>To be Specced
+    <with|par-left|2tab|F.1.16.1.<space|2spc><with|font-family|tt|language|verbatim|ext_blake2_256>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-133>>
 
-    <with|par-left|1tab|F.1.10.<space|2spc>Offchain Worker
-    \ <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+    <with|par-left|2tab|F.1.16.2.<space|2spc><with|font-family|tt|language|verbatim|ext_keccak_256>
+    <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-134>>
 
-    <with|par-left|2tab|F.1.10.1.<space|2spc><with|font-family|tt|language|verbatim|ext_is_validator>
+    <with|par-left|2tab|F.1.16.3.<space|2spc><with|font-family|tt|language|verbatim|ext_twox_128>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-135>>
 
-    <with|par-left|2tab|F.1.10.2.<space|2spc><with|font-family|tt|language|verbatim|ext_submit_transaction>
+    <with|par-left|2tab|F.1.16.4.<space|2spc><with|font-family|tt|language|verbatim|ext_ed25519_verify>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-136>>
 
-    <with|par-left|2tab|F.1.10.3.<space|2spc><with|font-family|tt|language|verbatim|ext_network_state>
+    <with|par-left|2tab|F.1.16.5.<space|2spc><with|font-family|tt|language|verbatim|ext_sr25519_verify>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-137>>
 
-    <with|par-left|2tab|F.1.10.4.<space|2spc><with|font-family|tt|language|verbatim|ext_timestamp>
+    <with|par-left|2tab|F.1.16.6.<space|2spc>To be Specced
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-138>>
 
-    <with|par-left|2tab|F.1.10.5.<space|2spc><with|font-family|tt|language|verbatim|ext_sleep_until>
-    <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+    <with|par-left|1tab|F.1.17.<space|2spc>Offchain Worker
+    \ <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-139>>
 
-    <with|par-left|2tab|F.1.10.6.<space|2spc><with|font-family|tt|language|verbatim|ext_random_seed>
+    <with|par-left|2tab|F.1.17.1.<space|2spc><with|font-family|tt|language|verbatim|ext_is_validator>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-140>>
 
-    <with|par-left|2tab|F.1.10.7.<space|2spc><with|font-family|tt|language|verbatim|ext_local_storage_set>
+    <with|par-left|2tab|F.1.17.2.<space|2spc><with|font-family|tt|language|verbatim|ext_submit_transaction>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-141>>
 
-    <with|par-left|2tab|F.1.10.8.<space|2spc><with|font-family|tt|language|verbatim|ext_local_storage_compare_and_set>
+    <with|par-left|2tab|F.1.17.3.<space|2spc><with|font-family|tt|language|verbatim|ext_network_state>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-142>>
 
-    <with|par-left|2tab|F.1.10.9.<space|2spc><with|font-family|tt|language|verbatim|ext_local_storage_get>
+    <with|par-left|2tab|F.1.17.4.<space|2spc><with|font-family|tt|language|verbatim|ext_timestamp>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-143>>
 
-    <with|par-left|2tab|F.1.10.10.<space|2spc><with|font-family|tt|language|verbatim|ext_http_request_start>
+    <with|par-left|2tab|F.1.17.5.<space|2spc><with|font-family|tt|language|verbatim|ext_sleep_until>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-144>>
 
-    <with|par-left|2tab|F.1.10.11.<space|2spc><with|font-family|tt|language|verbatim|ext_http_request_add_header>
+    <with|par-left|2tab|F.1.17.6.<space|2spc><with|font-family|tt|language|verbatim|ext_random_seed>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-145>>
 
-    <with|par-left|2tab|F.1.10.12.<space|2spc><with|font-family|tt|language|verbatim|ext_http_request_write_body>
+    <with|par-left|2tab|F.1.17.7.<space|2spc><with|font-family|tt|language|verbatim|ext_local_storage_set>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-146>>
 
-    <with|par-left|2tab|F.1.10.13.<space|2spc><with|font-family|tt|language|verbatim|ext_http_response_wait>
+    <with|par-left|2tab|F.1.17.8.<space|2spc><with|font-family|tt|language|verbatim|ext_local_storage_compare_and_set>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-147>>
 
-    <with|par-left|2tab|F.1.10.14.<space|2spc><with|font-family|tt|language|verbatim|ext_http_response_headers>
+    <with|par-left|2tab|F.1.17.9.<space|2spc><with|font-family|tt|language|verbatim|ext_local_storage_get>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-148>>
 
-    <with|par-left|2tab|F.1.10.15.<space|2spc><with|font-family|tt|language|verbatim|ext_http_response_read_body>
+    <with|par-left|2tab|F.1.17.10.<space|2spc><with|font-family|tt|language|verbatim|ext_http_request_start>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-149>>
 
-    <with|par-left|1tab|F.1.11.<space|2spc>Sandboxing
+    <with|par-left|2tab|F.1.17.11.<space|2spc><with|font-family|tt|language|verbatim|ext_http_request_add_header>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-150>>
 
-    <with|par-left|2tab|F.1.11.1.<space|2spc>To be Specced
+    <with|par-left|2tab|F.1.17.12.<space|2spc><with|font-family|tt|language|verbatim|ext_http_request_write_body>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-151>>
 
-    <with|par-left|1tab|F.1.12.<space|2spc>Auxillary Debugging API
+    <with|par-left|2tab|F.1.17.13.<space|2spc><with|font-family|tt|language|verbatim|ext_http_response_wait>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-152>>
 
-    <with|par-left|2tab|F.1.12.1.<space|2spc><with|font-family|tt|language|verbatim|ext_print_hex>
+    <with|par-left|2tab|F.1.17.14.<space|2spc><with|font-family|tt|language|verbatim|ext_http_response_headers>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-153>>
 
-    <with|par-left|2tab|F.1.12.2.<space|2spc><with|font-family|tt|language|verbatim|ext_print_utf8>
+    <with|par-left|2tab|F.1.17.15.<space|2spc><with|font-family|tt|language|verbatim|ext_http_response_read_body>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-154>>
 
-    <with|par-left|1tab|F.1.13.<space|2spc>Misc
+    <with|par-left|1tab|F.1.18.<space|2spc>Sandboxing
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-155>>
 
-    <with|par-left|2tab|F.1.13.1.<space|2spc>To be Specced
+    <with|par-left|2tab|F.1.18.1.<space|2spc>To be Specced
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-156>>
 
-    <with|par-left|1tab|F.1.14.<space|2spc>Block Production
+    <with|par-left|1tab|F.1.19.<space|2spc>Auxillary Debugging API
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <no-break><pageref|auto-157>>
 
+    <with|par-left|2tab|F.1.19.1.<space|2spc><with|font-family|tt|language|verbatim|ext_print_hex>
+    <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+    <no-break><pageref|auto-158>>
+
+    <with|par-left|2tab|F.1.19.2.<space|2spc><with|font-family|tt|language|verbatim|ext_print_utf8>
+    <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+    <no-break><pageref|auto-159>>
+
+    <with|par-left|1tab|F.1.20.<space|2spc>Misc
+    <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+    <no-break><pageref|auto-160>>
+
+    <with|par-left|2tab|F.1.20.1.<space|2spc>To be Specced
+    <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+    <no-break><pageref|auto-161>>
+
+    <with|par-left|1tab|F.1.21.<space|2spc>Block Production
+    <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+    <no-break><pageref|auto-162>>
+
     F.2.<space|2spc>Validation <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-    <no-break><pageref|auto-158>
+    <no-break><pageref|auto-163>
 
     <vspace*|1fn><with|font-series|bold|math-font-series|bold|font-shape|small-caps|Appendix
     G.<space|2spc>Runtime Entries> <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-    <pageref|auto-159><vspace|0.5fn>
+    <pageref|auto-164><vspace|0.5fn>
 
     G.1.<space|2spc>List of Runtime Entries
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-    <no-break><pageref|auto-160>
+    <no-break><pageref|auto-165>
 
     G.2.<space|2spc>Argument Specification
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-    <no-break><pageref|auto-162>
+    <no-break><pageref|auto-167>
 
     <with|par-left|1tab|G.2.1.<space|2spc><with|font-family|tt|language|verbatim|Core_version>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-    <no-break><pageref|auto-163>>
+    <no-break><pageref|auto-168>>
 
     <with|par-left|1tab|G.2.2.<space|2spc><with|font-family|tt|language|verbatim|Core_execute_block>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-    <no-break><pageref|auto-165>>
+    <no-break><pageref|auto-170>>
 
     <with|par-left|1tab|G.2.3.<space|2spc><with|font-family|tt|language|verbatim|Core_initialise_block>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-    <no-break><pageref|auto-166>>
+    <no-break><pageref|auto-171>>
 
     <with|par-left|1tab|G.2.4.<space|2spc><with|font-family|tt|language|verbatim|hash_and_length>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-    <no-break><pageref|auto-167>>
+    <no-break><pageref|auto-172>>
 
     <with|par-left|1tab|G.2.5.<space|2spc><with|font-family|tt|language|verbatim|BabeApi_epoch>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-    <no-break><pageref|auto-168>>
+    <no-break><pageref|auto-173>>
 
     <with|par-left|1tab|G.2.6.<space|2spc><with|font-family|tt|language|verbatim|Grandpa_authorities>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-    <no-break><pageref|auto-169>>
+    <no-break><pageref|auto-174>>
 
     <with|par-left|1tab|G.2.7.<space|2spc><with|font-family|tt|language|verbatim|TaggedTransactionQueue_validate_transaction>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-    <no-break><pageref|auto-170>>
+    <no-break><pageref|auto-175>>
 
     <vspace*|1fn><with|font-series|bold|math-font-series|bold|font-shape|small-caps|Glossary>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-    <pageref|auto-173><vspace|0.5fn>
+    <pageref|auto-178><vspace|0.5fn>
 
     <vspace*|1fn><with|font-series|bold|math-font-series|bold|font-shape|small-caps|Bibliography>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-    <pageref|auto-174><vspace|0.5fn>
+    <pageref|auto-179><vspace|0.5fn>
 
     <vspace*|1fn><with|font-series|bold|math-font-series|bold|font-shape|small-caps|Index>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-    <pageref|auto-175><vspace|0.5fn>
+    <pageref|auto-180><vspace|0.5fn>
   </table-of-contents>
 
   <chapter|Background>
@@ -5774,11 +5794,11 @@
   </bibliography>
 
   <\the-index|idx>
-    <index+1|Transaction Message|<pageref|auto-47>\U<pageref|auto-50>>
+    <index-1|Transaction Message|<pageref|auto-47>\U<pageref|auto-50>>
 
-    <index+1|transaction pool|<pageref|auto-48>>
+    <index-1|transaction pool|<pageref|auto-48>>
 
-    <index+1|transaction queue|<pageref|auto-49>>
+    <index-1|transaction queue|<pageref|auto-49>>
   </the-index>
 </body>
 

--- a/runtime-environment-spec/polkadot_re_spec.tm
+++ b/runtime-environment-spec/polkadot_re_spec.tm
@@ -4396,22 +4396,31 @@
     <item><verbatim|value_len>: the length of the value buffer in bytes.
   </itemize>
 
-  <subsection|To Be Specced>
+  <subsection|<verbatim|ext_storage_changes_root>>
+
+  Todo
+
+  \;
+
+  <strong|Prototype:>
+
+  <\verbatim>
+    (func $ext_storage_changes_root
+
+    \ \ (param $parent_hash_data i32) (param $parent_hash_len i32) (result
+    i32))
+  </verbatim>
+
+  \;
+
+  <strong|Arguments>:
 
   <\itemize>
-    <item><verbatim|>
+    <item><verbatim|parent_hash_data>: todo.
 
-    <item><verbatim|>
+    <item><verbatim|parent_hash_len>: todo.
 
-    <item><verbatim|>
-
-    <item><verbatim|>
-
-    <item><verbatim|>
-
-    <item><verbatim|>
-
-    <item><verbatim|ext_storage_changes_root>
+    <item><verbatim|result>: todo.
   </itemize>
 
   <subsection|Memory>
@@ -5925,6 +5934,7 @@
     <associate|auto-18|<tuple|1.13|9>>
     <associate|auto-180|<tuple|G.3|?>>
     <associate|auto-181|<tuple|Tec19|?>>
+    <associate|auto-182|<tuple|Tec19|?>>
     <associate|auto-19|<tuple|1.13|9>>
     <associate|auto-2|<tuple|1.1|7>>
     <associate|auto-20|<tuple|1.13|9>>

--- a/runtime-environment-spec/polkadot_re_spec.tm
+++ b/runtime-environment-spec/polkadot_re_spec.tm
@@ -4158,8 +4158,8 @@
 
   <subsection|<verbatim|ext_clear_child_storage>>
 
-  Given a byte array, this function removes all child storage entries whose
-  key is specified in the array.
+  Given a byte array, this function removes the child storage entry whose key
+  is specified in the array.
 
   \;
 
@@ -4331,6 +4331,33 @@
     entry does not exist under the specified key.
   </itemize>
 
+  <subsection|<verbatim|ext_kill_child_storage>>
+
+  Given a byte array, this function removes all entries of the child storage
+  whose child storage key is specified in the array.
+
+  \;
+
+  <strong|Prototype:>
+
+  <\verbatim>
+    \ \ \ \ (func $ext_kill_child_storage
+
+    \ \ \ \ \ \ (param $storage_key_data i32) (param $storage_key_len i32))
+  </verbatim>
+
+  \;
+
+  <strong|Arguments>:
+
+  <\itemize>
+    <item><verbatim|storage_key_data>: a memory address pointing at the
+    buffer of the byte array containing the child storage key.
+
+    <item><verbatim|storage_key_len>: the length of the child storage key
+    byte array in number of bytes.
+  </itemize>
+
   <subsection|To Be Specced>
 
   <\itemize>
@@ -4342,7 +4369,7 @@
 
     <item><verbatim|>
 
-    <item><verbatim|ext_kill_child_storage>
+    <item><verbatim|>
 
     <item><verbatim|ext_set_child_storage>
 
@@ -5800,63 +5827,63 @@
     <associate|auto-125|<tuple|F.1.10|56>>
     <associate|auto-126|<tuple|F.1.11|57>>
     <associate|auto-127|<tuple|F.1.12|57>>
-    <associate|auto-128|<tuple|F.1.12.1|57>>
-    <associate|auto-129|<tuple|F.1.12.2|57>>
+    <associate|auto-128|<tuple|F.1.13|57>>
+    <associate|auto-129|<tuple|F.1.13.1|57>>
     <associate|auto-13|<tuple|1.9|9>>
-    <associate|auto-130|<tuple|F.1.12.3|57>>
-    <associate|auto-131|<tuple|F.1.13|58>>
-    <associate|auto-132|<tuple|F.1.13.1|58>>
-    <associate|auto-133|<tuple|F.1.13.2|59>>
-    <associate|auto-134|<tuple|F.1.13.3|59>>
-    <associate|auto-135|<tuple|F.1.13.4|59>>
-    <associate|auto-136|<tuple|F.1.13.5|60>>
-    <associate|auto-137|<tuple|F.1.13.6|60>>
-    <associate|auto-138|<tuple|F.1.14|60>>
-    <associate|auto-139|<tuple|F.1.14.1|61>>
+    <associate|auto-130|<tuple|F.1.13.2|57>>
+    <associate|auto-131|<tuple|F.1.13.3|58>>
+    <associate|auto-132|<tuple|F.1.14|58>>
+    <associate|auto-133|<tuple|F.1.14.1|59>>
+    <associate|auto-134|<tuple|F.1.14.2|59>>
+    <associate|auto-135|<tuple|F.1.14.3|59>>
+    <associate|auto-136|<tuple|F.1.14.4|60>>
+    <associate|auto-137|<tuple|F.1.14.5|60>>
+    <associate|auto-138|<tuple|F.1.14.6|60>>
+    <associate|auto-139|<tuple|F.1.15|61>>
     <associate|auto-14|<tuple|1.2.1|9>>
-    <associate|auto-140|<tuple|F.1.14.2|61>>
-    <associate|auto-141|<tuple|F.1.14.3|61>>
-    <associate|auto-142|<tuple|F.1.14.4|62>>
-    <associate|auto-143|<tuple|F.1.14.5|62>>
-    <associate|auto-144|<tuple|F.1.14.6|62>>
-    <associate|auto-145|<tuple|F.1.14.7|63>>
-    <associate|auto-146|<tuple|F.1.14.8|63>>
-    <associate|auto-147|<tuple|F.1.14.9|64>>
-    <associate|auto-148|<tuple|F.1.14.10|64>>
-    <associate|auto-149|<tuple|F.1.14.11|65>>
+    <associate|auto-140|<tuple|F.1.15.1|61>>
+    <associate|auto-141|<tuple|F.1.15.2|61>>
+    <associate|auto-142|<tuple|F.1.15.3|62>>
+    <associate|auto-143|<tuple|F.1.15.4|62>>
+    <associate|auto-144|<tuple|F.1.15.5|62>>
+    <associate|auto-145|<tuple|F.1.15.6|63>>
+    <associate|auto-146|<tuple|F.1.15.7|63>>
+    <associate|auto-147|<tuple|F.1.15.8|64>>
+    <associate|auto-148|<tuple|F.1.15.9|64>>
+    <associate|auto-149|<tuple|F.1.15.10|65>>
     <associate|auto-15|<tuple|1.11|9>>
-    <associate|auto-150|<tuple|F.1.14.12|65>>
-    <associate|auto-151|<tuple|F.1.14.13|65>>
-    <associate|auto-152|<tuple|F.1.14.14|65>>
-    <associate|auto-153|<tuple|F.1.14.15|65>>
-    <associate|auto-154|<tuple|F.1.15|66>>
-    <associate|auto-155|<tuple|F.1.15.1|66>>
-    <associate|auto-156|<tuple|F.1.16|66>>
-    <associate|auto-157|<tuple|F.1.16.1|66>>
-    <associate|auto-158|<tuple|F.1.16.2|66>>
-    <associate|auto-159|<tuple|F.1.17|67>>
+    <associate|auto-150|<tuple|F.1.15.11|65>>
+    <associate|auto-151|<tuple|F.1.15.12|65>>
+    <associate|auto-152|<tuple|F.1.15.13|65>>
+    <associate|auto-153|<tuple|F.1.15.14|65>>
+    <associate|auto-154|<tuple|F.1.15.15|66>>
+    <associate|auto-155|<tuple|F.1.16|66>>
+    <associate|auto-156|<tuple|F.1.16.1|66>>
+    <associate|auto-157|<tuple|F.1.17|66>>
+    <associate|auto-158|<tuple|F.1.17.1|66>>
+    <associate|auto-159|<tuple|F.1.17.2|67>>
     <associate|auto-16|<tuple|1.12|9>>
-    <associate|auto-160|<tuple|F.1.17.1|67>>
-    <associate|auto-161|<tuple|F.1.18|67>>
-    <associate|auto-162|<tuple|F.2|68>>
-    <associate|auto-163|<tuple|G|68>>
-    <associate|auto-164|<tuple|G.1|68>>
+    <associate|auto-160|<tuple|F.1.18|67>>
+    <associate|auto-161|<tuple|F.1.18.1|67>>
+    <associate|auto-162|<tuple|F.1.19|68>>
+    <associate|auto-163|<tuple|F.2|68>>
+    <associate|auto-164|<tuple|G|68>>
     <associate|auto-165|<tuple|G.1|68>>
-    <associate|auto-166|<tuple|G.2|68>>
-    <associate|auto-167|<tuple|G.2.1|68>>
-    <associate|auto-168|<tuple|G.1|69>>
-    <associate|auto-169|<tuple|G.2.2|69>>
+    <associate|auto-166|<tuple|G.1|68>>
+    <associate|auto-167|<tuple|G.2|68>>
+    <associate|auto-168|<tuple|G.2.1|69>>
+    <associate|auto-169|<tuple|G.1|69>>
     <associate|auto-17|<tuple|1.12|9>>
-    <associate|auto-170|<tuple|G.2.3|69>>
-    <associate|auto-171|<tuple|G.2.4|70>>
-    <associate|auto-172|<tuple|G.2.5|70>>
-    <associate|auto-173|<tuple|G.2.6|71>>
-    <associate|auto-174|<tuple|G.2.7|73>>
-    <associate|auto-175|<tuple|G.2|75>>
-    <associate|auto-176|<tuple|G.3|?>>
+    <associate|auto-170|<tuple|G.2.2|69>>
+    <associate|auto-171|<tuple|G.2.3|70>>
+    <associate|auto-172|<tuple|G.2.4|70>>
+    <associate|auto-173|<tuple|G.2.5|71>>
+    <associate|auto-174|<tuple|G.2.6|73>>
+    <associate|auto-175|<tuple|G.2.7|75>>
+    <associate|auto-176|<tuple|G.2|?>>
     <associate|auto-177|<tuple|G.3|?>>
     <associate|auto-178|<tuple|G.3|?>>
-    <associate|auto-179|<tuple|Tec19|?>>
+    <associate|auto-179|<tuple|G.3|?>>
     <associate|auto-18|<tuple|1.13|9>>
     <associate|auto-180|<tuple|Tec19|?>>
     <associate|auto-19|<tuple|1.13|9>>

--- a/runtime-environment-spec/polkadot_re_spec.tm
+++ b/runtime-environment-spec/polkadot_re_spec.tm
@@ -4396,33 +4396,6 @@
     <item><verbatim|value_len>: the length of the value buffer in bytes.
   </itemize>
 
-  <subsection|<verbatim|ext_storage_changes_root>>
-
-  Todo
-
-  \;
-
-  <strong|Prototype:>
-
-  <\verbatim>
-    (func $ext_storage_changes_root
-
-    \ \ (param $parent_hash_data i32) (param $parent_hash_len i32) (result
-    i32))
-  </verbatim>
-
-  \;
-
-  <strong|Arguments>:
-
-  <\itemize>
-    <item><verbatim|parent_hash_data>: todo.
-
-    <item><verbatim|parent_hash_len>: todo.
-
-    <item><verbatim|result>: todo.
-  </itemize>
-
   <subsection|Memory>
 
   <subsubsection|<verbatim|ext_malloc>>
@@ -5875,66 +5848,65 @@
     <associate|auto-126|<tuple|F.1.11|57>>
     <associate|auto-127|<tuple|F.1.12|57>>
     <associate|auto-128|<tuple|F.1.13|57>>
-    <associate|auto-129|<tuple|F.1.14|57>>
+    <associate|auto-129|<tuple|F.1.13.1|57>>
     <associate|auto-13|<tuple|1.9|9>>
-    <associate|auto-130|<tuple|F.1.14.1|57>>
-    <associate|auto-131|<tuple|F.1.14.2|58>>
-    <associate|auto-132|<tuple|F.1.14.3|58>>
-    <associate|auto-133|<tuple|F.1.15|59>>
-    <associate|auto-134|<tuple|F.1.15.1|59>>
-    <associate|auto-135|<tuple|F.1.15.2|59>>
-    <associate|auto-136|<tuple|F.1.15.3|60>>
-    <associate|auto-137|<tuple|F.1.15.4|60>>
-    <associate|auto-138|<tuple|F.1.15.5|60>>
-    <associate|auto-139|<tuple|F.1.15.6|61>>
+    <associate|auto-130|<tuple|F.1.13.2|57>>
+    <associate|auto-131|<tuple|F.1.13.3|58>>
+    <associate|auto-132|<tuple|F.1.14|58>>
+    <associate|auto-133|<tuple|F.1.14.1|59>>
+    <associate|auto-134|<tuple|F.1.14.2|59>>
+    <associate|auto-135|<tuple|F.1.14.3|59>>
+    <associate|auto-136|<tuple|F.1.14.4|60>>
+    <associate|auto-137|<tuple|F.1.14.5|60>>
+    <associate|auto-138|<tuple|F.1.14.6|60>>
+    <associate|auto-139|<tuple|F.1.15|61>>
     <associate|auto-14|<tuple|1.2.1|9>>
-    <associate|auto-140|<tuple|F.1.16|61>>
-    <associate|auto-141|<tuple|F.1.16.1|61>>
-    <associate|auto-142|<tuple|F.1.16.2|62>>
-    <associate|auto-143|<tuple|F.1.16.3|62>>
-    <associate|auto-144|<tuple|F.1.16.4|62>>
-    <associate|auto-145|<tuple|F.1.16.5|63>>
-    <associate|auto-146|<tuple|F.1.16.6|63>>
-    <associate|auto-147|<tuple|F.1.16.7|64>>
-    <associate|auto-148|<tuple|F.1.16.8|64>>
-    <associate|auto-149|<tuple|F.1.16.9|65>>
+    <associate|auto-140|<tuple|F.1.15.1|61>>
+    <associate|auto-141|<tuple|F.1.15.2|61>>
+    <associate|auto-142|<tuple|F.1.15.3|62>>
+    <associate|auto-143|<tuple|F.1.15.4|62>>
+    <associate|auto-144|<tuple|F.1.15.5|62>>
+    <associate|auto-145|<tuple|F.1.15.6|63>>
+    <associate|auto-146|<tuple|F.1.15.7|63>>
+    <associate|auto-147|<tuple|F.1.15.8|64>>
+    <associate|auto-148|<tuple|F.1.15.9|64>>
+    <associate|auto-149|<tuple|F.1.15.10|65>>
     <associate|auto-15|<tuple|1.11|9>>
-    <associate|auto-150|<tuple|F.1.16.10|65>>
-    <associate|auto-151|<tuple|F.1.16.11|65>>
-    <associate|auto-152|<tuple|F.1.16.12|65>>
-    <associate|auto-153|<tuple|F.1.16.13|65>>
-    <associate|auto-154|<tuple|F.1.16.14|66>>
-    <associate|auto-155|<tuple|F.1.16.15|66>>
-    <associate|auto-156|<tuple|F.1.17|66>>
-    <associate|auto-157|<tuple|F.1.17.1|66>>
-    <associate|auto-158|<tuple|F.1.18|66>>
-    <associate|auto-159|<tuple|F.1.18.1|67>>
+    <associate|auto-150|<tuple|F.1.15.11|65>>
+    <associate|auto-151|<tuple|F.1.15.12|65>>
+    <associate|auto-152|<tuple|F.1.15.13|65>>
+    <associate|auto-153|<tuple|F.1.15.14|65>>
+    <associate|auto-154|<tuple|F.1.15.15|66>>
+    <associate|auto-155|<tuple|F.1.16|66>>
+    <associate|auto-156|<tuple|F.1.16.1|66>>
+    <associate|auto-157|<tuple|F.1.17|66>>
+    <associate|auto-158|<tuple|F.1.17.1|66>>
+    <associate|auto-159|<tuple|F.1.17.2|67>>
     <associate|auto-16|<tuple|1.12|9>>
-    <associate|auto-160|<tuple|F.1.18.2|67>>
-    <associate|auto-161|<tuple|F.1.19|67>>
-    <associate|auto-162|<tuple|F.1.19.1|68>>
-    <associate|auto-163|<tuple|F.1.20|68>>
-    <associate|auto-164|<tuple|F.2|68>>
-    <associate|auto-165|<tuple|G|68>>
+    <associate|auto-160|<tuple|F.1.18|67>>
+    <associate|auto-161|<tuple|F.1.18.1|67>>
+    <associate|auto-162|<tuple|F.1.19|68>>
+    <associate|auto-163|<tuple|F.2|68>>
+    <associate|auto-164|<tuple|G|68>>
+    <associate|auto-165|<tuple|G.1|68>>
     <associate|auto-166|<tuple|G.1|68>>
-    <associate|auto-167|<tuple|G.1|68>>
-    <associate|auto-168|<tuple|G.2|69>>
-    <associate|auto-169|<tuple|G.2.1|69>>
+    <associate|auto-167|<tuple|G.2|68>>
+    <associate|auto-168|<tuple|G.2.1|69>>
+    <associate|auto-169|<tuple|G.1|69>>
     <associate|auto-17|<tuple|1.12|9>>
-    <associate|auto-170|<tuple|G.1|69>>
-    <associate|auto-171|<tuple|G.2.2|70>>
-    <associate|auto-172|<tuple|G.2.3|70>>
-    <associate|auto-173|<tuple|G.2.4|71>>
-    <associate|auto-174|<tuple|G.2.5|73>>
-    <associate|auto-175|<tuple|G.2.6|75>>
-    <associate|auto-176|<tuple|G.2.7|?>>
-    <associate|auto-177|<tuple|G.2|?>>
+    <associate|auto-170|<tuple|G.2.2|69>>
+    <associate|auto-171|<tuple|G.2.3|70>>
+    <associate|auto-172|<tuple|G.2.4|70>>
+    <associate|auto-173|<tuple|G.2.5|71>>
+    <associate|auto-174|<tuple|G.2.6|73>>
+    <associate|auto-175|<tuple|G.2.7|75>>
+    <associate|auto-176|<tuple|G.2|?>>
+    <associate|auto-177|<tuple|G.3|?>>
     <associate|auto-178|<tuple|G.3|?>>
     <associate|auto-179|<tuple|G.3|?>>
     <associate|auto-18|<tuple|1.13|9>>
-    <associate|auto-180|<tuple|G.3|?>>
+    <associate|auto-180|<tuple|Tec19|?>>
     <associate|auto-181|<tuple|Tec19|?>>
-    <associate|auto-182|<tuple|Tec19|?>>
     <associate|auto-19|<tuple|1.13|9>>
     <associate|auto-2|<tuple|1.1|7>>
     <associate|auto-20|<tuple|1.13|9>>
@@ -6182,7 +6154,7 @@
     </associate>
     <\associate|figure>
       <tuple|normal|<surround|<hidden-binding|<tuple>|G.1>||Snippet to export
-      entries into tho Wasm runtime module.>|<pageref|auto-161>>
+      entries into tho Wasm runtime module.>|<pageref|auto-167>>
     </associate>
     <\associate|gly>
       <tuple|normal|<with|font-series|<quote|bold>|math-font-series|<quote|bold>|<with|mode|<quote|math>|P<rsub|n>>>|a
@@ -6324,16 +6296,16 @@
       <tuple|normal|<surround|<hidden-binding|<tuple>|G.1>||Detail of the
       version data type returns from runtime
       <with|font-family|<quote|tt>|language|<quote|verbatim>|version>
-      function.>|<pageref|auto-164>>
+      function.>|<pageref|auto-170>>
 
       <tuple|normal|<surround|<hidden-binding|<tuple>|G.2>||Type variation
-      for the return value of <with|font-family|<quote|tt>|language|<quote|verbatim>|TaggedTransactionQueue_transaction_validity>.>|<pageref|auto-171>>
+      for the return value of <with|font-family|<quote|tt>|language|<quote|verbatim>|TaggedTransactionQueue_transaction_validity>.>|<pageref|auto-177>>
 
       <tuple|normal|<\surround|<hidden-binding|<tuple>|G.3>|>
         The quintuple provided by <with|font-family|<quote|tt>|language|<quote|verbatim>|TaggedTransactionQueue_transaction_validity>
 
         in the case the transaction is judged to be valid.
-      </surround>|<pageref|auto-172>>
+      </surround>|<pageref|auto-178>>
     </associate>
     <\associate|toc>
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|font-shape|<quote|small-caps>|1.<space|2spc>Background>
@@ -6672,204 +6644,228 @@
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-121>>
 
-      <with|par-left|<quote|1tab>|F.1.7.<space|2spc>To Be Specced
+      <with|par-left|<quote|1tab>|F.1.7.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_clear_child_storage>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-122>>
 
-      <with|par-left|<quote|1tab>|F.1.8.<space|2spc>Memory
+      <with|par-left|<quote|1tab>|F.1.8.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_exists_child_storage>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-123>>
 
-      <with|par-left|<quote|2tab>|F.1.8.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_malloc>
+      <with|par-left|<quote|1tab>|F.1.9.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_get_allocated_child_storage>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-124>>
 
-      <with|par-left|<quote|2tab>|F.1.8.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_free>
+      <with|par-left|<quote|1tab>|F.1.10.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_get_child_storage_into>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-125>>
 
-      <with|par-left|<quote|2tab>|F.1.8.3.<space|2spc>Input/Output
+      <with|par-left|<quote|1tab>|F.1.11.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_kill_child_storage>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-126>>
 
-      <with|par-left|<quote|1tab>|F.1.9.<space|2spc>Cryptograhpic Auxiliary
-      Functions <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <with|par-left|<quote|1tab>|F.1.12.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_set_child_storage>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-127>>
 
-      <with|par-left|<quote|2tab>|F.1.9.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_blake2_256>
+      <with|par-left|<quote|1tab>|F.1.13.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_storage_changes_root>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-128>>
 
-      <with|par-left|<quote|2tab>|F.1.9.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_keccak_256>
+      <with|par-left|<quote|1tab>|F.1.14.<space|2spc>Memory
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-129>>
 
-      <with|par-left|<quote|2tab>|F.1.9.3.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_twox_128>
+      <with|par-left|<quote|2tab>|F.1.14.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_malloc>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-130>>
 
-      <with|par-left|<quote|2tab>|F.1.9.4.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_ed25519_verify>
+      <with|par-left|<quote|2tab>|F.1.14.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_free>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-131>>
 
-      <with|par-left|<quote|2tab>|F.1.9.5.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_sr25519_verify>
+      <with|par-left|<quote|2tab>|F.1.14.3.<space|2spc>Input/Output
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-132>>
 
-      <with|par-left|<quote|2tab>|F.1.9.6.<space|2spc>To be Specced
-      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <with|par-left|<quote|1tab>|F.1.15.<space|2spc>Cryptograhpic Auxiliary
+      Functions <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-133>>
 
-      <with|par-left|<quote|1tab>|F.1.10.<space|2spc>Offchain Worker
-      \ <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <with|par-left|<quote|2tab>|F.1.15.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_blake2_256>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-134>>
 
-      <with|par-left|<quote|2tab>|F.1.10.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_is_validator>
+      <with|par-left|<quote|2tab>|F.1.15.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_keccak_256>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-135>>
 
-      <with|par-left|<quote|2tab>|F.1.10.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_submit_transaction>
+      <with|par-left|<quote|2tab>|F.1.15.3.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_twox_128>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-136>>
 
-      <with|par-left|<quote|2tab>|F.1.10.3.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_network_state>
+      <with|par-left|<quote|2tab>|F.1.15.4.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_ed25519_verify>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-137>>
 
-      <with|par-left|<quote|2tab>|F.1.10.4.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_timestamp>
+      <with|par-left|<quote|2tab>|F.1.15.5.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_sr25519_verify>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-138>>
 
-      <with|par-left|<quote|2tab>|F.1.10.5.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_sleep_until>
+      <with|par-left|<quote|2tab>|F.1.15.6.<space|2spc>To be Specced
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-139>>
 
-      <with|par-left|<quote|2tab>|F.1.10.6.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_random_seed>
-      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <with|par-left|<quote|1tab>|F.1.16.<space|2spc>Offchain Worker
+      \ <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-140>>
 
-      <with|par-left|<quote|2tab>|F.1.10.7.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_local_storage_set>
+      <with|par-left|<quote|2tab>|F.1.16.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_is_validator>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-141>>
 
-      <with|par-left|<quote|2tab>|F.1.10.8.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_local_storage_compare_and_set>
+      <with|par-left|<quote|2tab>|F.1.16.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_submit_transaction>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-142>>
 
-      <with|par-left|<quote|2tab>|F.1.10.9.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_local_storage_get>
+      <with|par-left|<quote|2tab>|F.1.16.3.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_network_state>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-143>>
 
-      <with|par-left|<quote|2tab>|F.1.10.10.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_request_start>
+      <with|par-left|<quote|2tab>|F.1.16.4.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_timestamp>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-144>>
 
-      <with|par-left|<quote|2tab>|F.1.10.11.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_request_add_header>
+      <with|par-left|<quote|2tab>|F.1.16.5.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_sleep_until>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-145>>
 
-      <with|par-left|<quote|2tab>|F.1.10.12.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_request_write_body>
+      <with|par-left|<quote|2tab>|F.1.16.6.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_random_seed>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-146>>
 
-      <with|par-left|<quote|2tab>|F.1.10.13.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_response_wait>
+      <with|par-left|<quote|2tab>|F.1.16.7.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_local_storage_set>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-147>>
 
-      <with|par-left|<quote|2tab>|F.1.10.14.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_response_headers>
+      <with|par-left|<quote|2tab>|F.1.16.8.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_local_storage_compare_and_set>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-148>>
 
-      <with|par-left|<quote|2tab>|F.1.10.15.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_response_read_body>
+      <with|par-left|<quote|2tab>|F.1.16.9.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_local_storage_get>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-149>>
 
-      <with|par-left|<quote|1tab>|F.1.11.<space|2spc>Sandboxing
+      <with|par-left|<quote|2tab>|F.1.16.10.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_request_start>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-150>>
 
-      <with|par-left|<quote|2tab>|F.1.11.1.<space|2spc>To be Specced
+      <with|par-left|<quote|2tab>|F.1.16.11.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_request_add_header>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-151>>
 
-      <with|par-left|<quote|1tab>|F.1.12.<space|2spc>Auxillary Debugging API
+      <with|par-left|<quote|2tab>|F.1.16.12.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_request_write_body>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-152>>
 
-      <with|par-left|<quote|2tab>|F.1.12.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_print_hex>
+      <with|par-left|<quote|2tab>|F.1.16.13.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_response_wait>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-153>>
 
-      <with|par-left|<quote|2tab>|F.1.12.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_print_utf8>
+      <with|par-left|<quote|2tab>|F.1.16.14.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_response_headers>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-154>>
 
-      <with|par-left|<quote|1tab>|F.1.13.<space|2spc>Misc
+      <with|par-left|<quote|2tab>|F.1.16.15.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_response_read_body>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-155>>
 
-      <with|par-left|<quote|2tab>|F.1.13.1.<space|2spc>To be Specced
+      <with|par-left|<quote|1tab>|F.1.17.<space|2spc>Sandboxing
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-156>>
 
-      <with|par-left|<quote|1tab>|F.1.14.<space|2spc>Block Production
+      <with|par-left|<quote|2tab>|F.1.17.1.<space|2spc>To be Specced
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-157>>
 
-      F.2.<space|2spc>Validation <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-158>
-
-      <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|font-shape|<quote|small-caps>|Appendix
-      G.<space|2spc>Runtime Entries> <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <pageref|auto-159><vspace|0.5fn>
-
-      G.1.<space|2spc>List of Runtime Entries
+      <with|par-left|<quote|1tab>|F.1.18.<space|2spc>Auxillary Debugging API
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-160>
+      <no-break><pageref|auto-158>>
 
-      G.2.<space|2spc>Argument Specification
+      <with|par-left|<quote|2tab>|F.1.18.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_print_hex>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-162>
+      <no-break><pageref|auto-159>>
 
-      <with|par-left|<quote|1tab>|G.2.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|Core_version>
+      <with|par-left|<quote|2tab>|F.1.18.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_print_utf8>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-160>>
+
+      <with|par-left|<quote|1tab>|F.1.19.<space|2spc>Misc
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-161>>
+
+      <with|par-left|<quote|2tab>|F.1.19.1.<space|2spc>To be Specced
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-162>>
+
+      <with|par-left|<quote|1tab>|F.1.20.<space|2spc>Block Production
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-163>>
 
-      <with|par-left|<quote|1tab>|G.2.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|Core_execute_block>
-      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-165>>
+      F.2.<space|2spc>Validation <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-164>
 
-      <with|par-left|<quote|1tab>|G.2.3.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|Core_initialise_block>
-      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-166>>
+      <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|font-shape|<quote|small-caps>|Appendix
+      G.<space|2spc>Runtime Entries> <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <pageref|auto-165><vspace|0.5fn>
 
-      <with|par-left|<quote|1tab>|G.2.4.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|hash_and_length>
+      G.1.<space|2spc>List of Runtime Entries
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-167>>
+      <no-break><pageref|auto-166>
 
-      <with|par-left|<quote|1tab>|G.2.5.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|BabeApi_epoch>
+      G.2.<space|2spc>Argument Specification
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-168>>
+      <no-break><pageref|auto-168>
 
-      <with|par-left|<quote|1tab>|G.2.6.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|Grandpa_authorities>
+      <with|par-left|<quote|1tab>|G.2.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|Core_version>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-169>>
 
+      <with|par-left|<quote|1tab>|G.2.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|Core_execute_block>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-171>>
+
+      <with|par-left|<quote|1tab>|G.2.3.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|Core_initialise_block>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-172>>
+
+      <with|par-left|<quote|1tab>|G.2.4.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|hash_and_length>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-173>>
+
+      <with|par-left|<quote|1tab>|G.2.5.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|BabeApi_epoch>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-174>>
+
+      <with|par-left|<quote|1tab>|G.2.6.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|Grandpa_authorities>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-175>>
+
       <with|par-left|<quote|1tab>|G.2.7.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|TaggedTransactionQueue_validate_transaction>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-170>>
+      <no-break><pageref|auto-176>>
 
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|font-shape|<quote|small-caps>|Glossary>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <pageref|auto-173><vspace|0.5fn>
+      <pageref|auto-179><vspace|0.5fn>
 
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|font-shape|<quote|small-caps>|Bibliography>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <pageref|auto-174><vspace|0.5fn>
+      <pageref|auto-180><vspace|0.5fn>
 
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|font-shape|<quote|small-caps>|Index>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <pageref|auto-175><vspace|0.5fn>
+      <pageref|auto-181><vspace|0.5fn>
     </associate>
   </collection>
 </auxiliary>

--- a/runtime-environment-spec/polkadot_re_spec.tm
+++ b/runtime-environment-spec/polkadot_re_spec.tm
@@ -4133,8 +4133,8 @@
   <strong|Arguments>:
 
   <\itemize>
-    <item><verbatim|key_data>: a memory address pointing at the buffer
-    containing the byte array containing the key value.
+    <item><verbatim|key_data>: a memory address pointing at the buffer of the
+    byte array containing the key value.
 
     <item><verbatim|key_len>: the length of the byte array in number of
     bytes.
@@ -4156,10 +4156,45 @@
     entry does not exist under the specified key.
   </itemize>
 
+  <subsection|<verbatim|ext_clear_child_storage>>
+
+  Given a byte array, this function removes all child storage entries whose
+  key is specified in the array.
+
+  \;
+
+  <strong|Prototype:>
+
+  <\verbatim>
+    \ \ \ \ (func $ext_clear_child_storage
+
+    \ \ \ \ \ \ (param $storage_key_data i32) (param $storage_key_len i32)
+
+    \ \ \ \ \ \ (param $key_data i32) (param $key_len i32))
+  </verbatim>
+
+  \;
+
+  <strong|Arguments>:
+
+  <\itemize>
+    <item><verbatim|storage_key_data>: a memory address pointing at the
+    buffer of the byte array containing the child storage key.
+
+    <item><verbatim|storage_key_len>: the length of the child storage key
+    byte array in number of bytes.
+
+    <item><verbatim|key_data>: a memory address pointing at the buffer of the
+    byte array containing the key value.
+
+    <item><verbatim|key_len>: the length of the key byte array in number of
+    bytes.
+  </itemize>
+
   <subsection|To Be Specced>
 
   <\itemize>
-    <item><verbatim|ext_clear_child_storage>
+    <item><verbatim|>
 
     <item><verbatim|ext_exists_child_storage>
 
@@ -5621,63 +5656,64 @@
     <associate|auto-121|<tuple|F.1.6|55>>
     <associate|auto-122|<tuple|F.1.7|56>>
     <associate|auto-123|<tuple|F.1.8|56>>
-    <associate|auto-124|<tuple|F.1.8.1|56>>
-    <associate|auto-125|<tuple|F.1.8.2|56>>
-    <associate|auto-126|<tuple|F.1.8.3|57>>
-    <associate|auto-127|<tuple|F.1.9|57>>
-    <associate|auto-128|<tuple|F.1.9.1|57>>
-    <associate|auto-129|<tuple|F.1.9.2|57>>
+    <associate|auto-124|<tuple|F.1.9|56>>
+    <associate|auto-125|<tuple|F.1.9.1|56>>
+    <associate|auto-126|<tuple|F.1.9.2|57>>
+    <associate|auto-127|<tuple|F.1.9.3|57>>
+    <associate|auto-128|<tuple|F.1.10|57>>
+    <associate|auto-129|<tuple|F.1.10.1|57>>
     <associate|auto-13|<tuple|1.9|9>>
-    <associate|auto-130|<tuple|F.1.9.3|57>>
-    <associate|auto-131|<tuple|F.1.9.4|58>>
-    <associate|auto-132|<tuple|F.1.9.5|58>>
-    <associate|auto-133|<tuple|F.1.9.6|59>>
-    <associate|auto-134|<tuple|F.1.10|59>>
-    <associate|auto-135|<tuple|F.1.10.1|59>>
-    <associate|auto-136|<tuple|F.1.10.2|60>>
-    <associate|auto-137|<tuple|F.1.10.3|60>>
-    <associate|auto-138|<tuple|F.1.10.4|60>>
-    <associate|auto-139|<tuple|F.1.10.5|61>>
+    <associate|auto-130|<tuple|F.1.10.2|57>>
+    <associate|auto-131|<tuple|F.1.10.3|58>>
+    <associate|auto-132|<tuple|F.1.10.4|58>>
+    <associate|auto-133|<tuple|F.1.10.5|59>>
+    <associate|auto-134|<tuple|F.1.10.6|59>>
+    <associate|auto-135|<tuple|F.1.11|59>>
+    <associate|auto-136|<tuple|F.1.11.1|60>>
+    <associate|auto-137|<tuple|F.1.11.2|60>>
+    <associate|auto-138|<tuple|F.1.11.3|60>>
+    <associate|auto-139|<tuple|F.1.11.4|61>>
     <associate|auto-14|<tuple|1.2.1|9>>
-    <associate|auto-140|<tuple|F.1.10.6|61>>
-    <associate|auto-141|<tuple|F.1.10.7|61>>
-    <associate|auto-142|<tuple|F.1.10.8|62>>
-    <associate|auto-143|<tuple|F.1.10.9|62>>
-    <associate|auto-144|<tuple|F.1.10.10|62>>
-    <associate|auto-145|<tuple|F.1.10.11|63>>
-    <associate|auto-146|<tuple|F.1.10.12|63>>
-    <associate|auto-147|<tuple|F.1.10.13|64>>
-    <associate|auto-148|<tuple|F.1.10.14|64>>
-    <associate|auto-149|<tuple|F.1.10.15|65>>
+    <associate|auto-140|<tuple|F.1.11.5|61>>
+    <associate|auto-141|<tuple|F.1.11.6|61>>
+    <associate|auto-142|<tuple|F.1.11.7|62>>
+    <associate|auto-143|<tuple|F.1.11.8|62>>
+    <associate|auto-144|<tuple|F.1.11.9|62>>
+    <associate|auto-145|<tuple|F.1.11.10|63>>
+    <associate|auto-146|<tuple|F.1.11.11|63>>
+    <associate|auto-147|<tuple|F.1.11.12|64>>
+    <associate|auto-148|<tuple|F.1.11.13|64>>
+    <associate|auto-149|<tuple|F.1.11.14|65>>
     <associate|auto-15|<tuple|1.11|9>>
-    <associate|auto-150|<tuple|F.1.11|65>>
-    <associate|auto-151|<tuple|F.1.11.1|65>>
-    <associate|auto-152|<tuple|F.1.12|65>>
-    <associate|auto-153|<tuple|F.1.12.1|65>>
-    <associate|auto-154|<tuple|F.1.12.2|66>>
-    <associate|auto-155|<tuple|F.1.13|66>>
-    <associate|auto-156|<tuple|F.1.13.1|66>>
-    <associate|auto-157|<tuple|F.1.14|66>>
-    <associate|auto-158|<tuple|F.2|66>>
-    <associate|auto-159|<tuple|G|67>>
+    <associate|auto-150|<tuple|F.1.11.15|65>>
+    <associate|auto-151|<tuple|F.1.12|65>>
+    <associate|auto-152|<tuple|F.1.12.1|65>>
+    <associate|auto-153|<tuple|F.1.13|65>>
+    <associate|auto-154|<tuple|F.1.13.1|66>>
+    <associate|auto-155|<tuple|F.1.13.2|66>>
+    <associate|auto-156|<tuple|F.1.14|66>>
+    <associate|auto-157|<tuple|F.1.14.1|66>>
+    <associate|auto-158|<tuple|F.1.15|66>>
+    <associate|auto-159|<tuple|F.2|67>>
     <associate|auto-16|<tuple|1.12|9>>
-    <associate|auto-160|<tuple|G.1|67>>
+    <associate|auto-160|<tuple|G|67>>
     <associate|auto-161|<tuple|G.1|67>>
-    <associate|auto-162|<tuple|G.2|68>>
-    <associate|auto-163|<tuple|G.2.1|68>>
-    <associate|auto-164|<tuple|G.1|68>>
-    <associate|auto-165|<tuple|G.2.2|68>>
-    <associate|auto-166|<tuple|G.2.3|68>>
-    <associate|auto-167|<tuple|G.2.4|68>>
-    <associate|auto-168|<tuple|G.2.5|69>>
-    <associate|auto-169|<tuple|G.2.6|69>>
+    <associate|auto-162|<tuple|G.1|68>>
+    <associate|auto-163|<tuple|G.2|68>>
+    <associate|auto-164|<tuple|G.2.1|68>>
+    <associate|auto-165|<tuple|G.1|68>>
+    <associate|auto-166|<tuple|G.2.2|68>>
+    <associate|auto-167|<tuple|G.2.3|68>>
+    <associate|auto-168|<tuple|G.2.4|69>>
+    <associate|auto-169|<tuple|G.2.5|69>>
     <associate|auto-17|<tuple|1.12|9>>
-    <associate|auto-170|<tuple|G.2.7|69>>
-    <associate|auto-171|<tuple|G.2|70>>
-    <associate|auto-172|<tuple|G.3|70>>
+    <associate|auto-170|<tuple|G.2.6|69>>
+    <associate|auto-171|<tuple|G.2.7|70>>
+    <associate|auto-172|<tuple|G.2|70>>
     <associate|auto-173|<tuple|G.3|71>>
     <associate|auto-174|<tuple|G.3|73>>
-    <associate|auto-175|<tuple|Tec19|75>>
+    <associate|auto-175|<tuple|G.3|75>>
+    <associate|auto-176|<tuple|Tec19|?>>
     <associate|auto-18|<tuple|1.13|9>>
     <associate|auto-19|<tuple|1.13|9>>
     <associate|auto-2|<tuple|1.1|7>>
@@ -5865,11 +5901,11 @@
     <associate|sect-msg-consensus|<tuple|E.1.6|52>>
     <associate|sect-msg-status|<tuple|E.1.1|49>>
     <associate|sect-msg-transactions|<tuple|E.1.5|51>>
-    <associate|sect-network-interactions|<tuple|Tec19|25>>
+    <associate|sect-network-interactions|<tuple|4|25>>
     <associate|sect-network-messages|<tuple|E|49>>
     <associate|sect-predef-storage-keys|<tuple|D|47>>
     <associate|sect-randomness|<tuple|A.3|39>>
-    <associate|sect-re-api|<tuple|Tec19|53>>
+    <associate|sect-re-api|<tuple|F|53>>
     <associate|sect-rte-babeapi-epoch|<tuple|G.2.5|69>>
     <associate|sect-rte-grandpa-auth|<tuple|G.2.6|69>>
     <associate|sect-rte-hash-and-length|<tuple|G.2.4|68>>

--- a/runtime-environment-spec/polkadot_re_spec.tm
+++ b/runtime-environment-spec/polkadot_re_spec.tm
@@ -5906,7 +5906,6 @@
     <associate|auto-179|<tuple|G.3|?>>
     <associate|auto-18|<tuple|1.13|9>>
     <associate|auto-180|<tuple|Tec19|?>>
-    <associate|auto-181|<tuple|Tec19|?>>
     <associate|auto-19|<tuple|1.13|9>>
     <associate|auto-2|<tuple|1.1|7>>
     <associate|auto-20|<tuple|1.13|9>>
@@ -6154,7 +6153,7 @@
     </associate>
     <\associate|figure>
       <tuple|normal|<surround|<hidden-binding|<tuple>|G.1>||Snippet to export
-      entries into tho Wasm runtime module.>|<pageref|auto-167>>
+      entries into tho Wasm runtime module.>|<pageref|auto-166>>
     </associate>
     <\associate|gly>
       <tuple|normal|<with|font-series|<quote|bold>|math-font-series|<quote|bold>|<with|mode|<quote|math>|P<rsub|n>>>|a
@@ -6296,16 +6295,16 @@
       <tuple|normal|<surround|<hidden-binding|<tuple>|G.1>||Detail of the
       version data type returns from runtime
       <with|font-family|<quote|tt>|language|<quote|verbatim>|version>
-      function.>|<pageref|auto-170>>
+      function.>|<pageref|auto-169>>
 
       <tuple|normal|<surround|<hidden-binding|<tuple>|G.2>||Type variation
-      for the return value of <with|font-family|<quote|tt>|language|<quote|verbatim>|TaggedTransactionQueue_transaction_validity>.>|<pageref|auto-177>>
+      for the return value of <with|font-family|<quote|tt>|language|<quote|verbatim>|TaggedTransactionQueue_transaction_validity>.>|<pageref|auto-176>>
 
       <tuple|normal|<\surround|<hidden-binding|<tuple>|G.3>|>
         The quintuple provided by <with|font-family|<quote|tt>|language|<quote|verbatim>|TaggedTransactionQueue_transaction_validity>
 
         in the case the transaction is judged to be valid.
-      </surround>|<pageref|auto-178>>
+      </surround>|<pageref|auto-177>>
     </associate>
     <\associate|toc>
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|font-shape|<quote|small-caps>|1.<space|2spc>Background>
@@ -6620,252 +6619,248 @@
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-115>>
 
-      <with|par-left|<quote|2tab>|F.1.2.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_blake2_256_enumerated_trie_root>
+      <with|par-left|<quote|1tab>|F.1.3.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_blake2_256_enumerated_trie_root>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-116>>
 
-      <with|par-left|<quote|1tab>|F.1.3.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_clear_prefix>
+      <with|par-left|<quote|1tab>|F.1.4.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_clear_prefix>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-117>>
 
-      <with|par-left|<quote|1tab>|F.1.4.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_clear_storage>
+      <with|par-left|<quote|1tab>|F.1.5.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_clear_storage>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-118>>
 
-      <with|par-left|<quote|2tab>|F.1.4.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_exists_storage>
+      <with|par-left|<quote|1tab>|F.1.6.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_exists_storage>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-119>>
 
-      <with|par-left|<quote|1tab>|F.1.5.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_get_allocated_storage>
+      <with|par-left|<quote|1tab>|F.1.7.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_get_allocated_storage>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-120>>
 
-      <with|par-left|<quote|1tab>|F.1.6.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_get_storage_into>
+      <with|par-left|<quote|1tab>|F.1.8.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_get_storage_into>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-121>>
 
-      <with|par-left|<quote|1tab>|F.1.7.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_clear_child_storage>
+      <with|par-left|<quote|1tab>|F.1.9.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_clear_child_storage>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-122>>
 
-      <with|par-left|<quote|1tab>|F.1.8.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_exists_child_storage>
+      <with|par-left|<quote|1tab>|F.1.10.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_exists_child_storage>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-123>>
 
-      <with|par-left|<quote|1tab>|F.1.9.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_get_allocated_child_storage>
+      <with|par-left|<quote|1tab>|F.1.11.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_get_allocated_child_storage>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-124>>
 
-      <with|par-left|<quote|1tab>|F.1.10.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_get_child_storage_into>
+      <with|par-left|<quote|1tab>|F.1.12.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_get_child_storage_into>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-125>>
 
-      <with|par-left|<quote|1tab>|F.1.11.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_kill_child_storage>
+      <with|par-left|<quote|1tab>|F.1.13.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_kill_child_storage>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-126>>
 
-      <with|par-left|<quote|1tab>|F.1.12.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_set_child_storage>
+      <with|par-left|<quote|1tab>|F.1.14.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_set_child_storage>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-127>>
 
-      <with|par-left|<quote|1tab>|F.1.13.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_storage_changes_root>
+      <with|par-left|<quote|1tab>|F.1.15.<space|2spc>Memory
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-128>>
 
-      <with|par-left|<quote|1tab>|F.1.14.<space|2spc>Memory
+      <with|par-left|<quote|2tab>|F.1.15.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_malloc>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-129>>
 
-      <with|par-left|<quote|2tab>|F.1.14.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_malloc>
+      <with|par-left|<quote|2tab>|F.1.15.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_free>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-130>>
 
-      <with|par-left|<quote|2tab>|F.1.14.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_free>
+      <with|par-left|<quote|2tab>|F.1.15.3.<space|2spc>Input/Output
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-131>>
 
-      <with|par-left|<quote|2tab>|F.1.14.3.<space|2spc>Input/Output
-      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <with|par-left|<quote|1tab>|F.1.16.<space|2spc>Cryptograhpic Auxiliary
+      Functions <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-132>>
 
-      <with|par-left|<quote|1tab>|F.1.15.<space|2spc>Cryptograhpic Auxiliary
-      Functions <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <with|par-left|<quote|2tab>|F.1.16.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_blake2_256>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-133>>
 
-      <with|par-left|<quote|2tab>|F.1.15.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_blake2_256>
+      <with|par-left|<quote|2tab>|F.1.16.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_keccak_256>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-134>>
 
-      <with|par-left|<quote|2tab>|F.1.15.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_keccak_256>
+      <with|par-left|<quote|2tab>|F.1.16.3.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_twox_128>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-135>>
 
-      <with|par-left|<quote|2tab>|F.1.15.3.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_twox_128>
+      <with|par-left|<quote|2tab>|F.1.16.4.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_ed25519_verify>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-136>>
 
-      <with|par-left|<quote|2tab>|F.1.15.4.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_ed25519_verify>
+      <with|par-left|<quote|2tab>|F.1.16.5.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_sr25519_verify>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-137>>
 
-      <with|par-left|<quote|2tab>|F.1.15.5.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_sr25519_verify>
+      <with|par-left|<quote|2tab>|F.1.16.6.<space|2spc>To be Specced
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-138>>
 
-      <with|par-left|<quote|2tab>|F.1.15.6.<space|2spc>To be Specced
-      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <with|par-left|<quote|1tab>|F.1.17.<space|2spc>Offchain Worker
+      \ <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-139>>
 
-      <with|par-left|<quote|1tab>|F.1.16.<space|2spc>Offchain Worker
-      \ <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <with|par-left|<quote|2tab>|F.1.17.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_is_validator>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-140>>
 
-      <with|par-left|<quote|2tab>|F.1.16.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_is_validator>
+      <with|par-left|<quote|2tab>|F.1.17.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_submit_transaction>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-141>>
 
-      <with|par-left|<quote|2tab>|F.1.16.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_submit_transaction>
+      <with|par-left|<quote|2tab>|F.1.17.3.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_network_state>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-142>>
 
-      <with|par-left|<quote|2tab>|F.1.16.3.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_network_state>
+      <with|par-left|<quote|2tab>|F.1.17.4.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_timestamp>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-143>>
 
-      <with|par-left|<quote|2tab>|F.1.16.4.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_timestamp>
+      <with|par-left|<quote|2tab>|F.1.17.5.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_sleep_until>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-144>>
 
-      <with|par-left|<quote|2tab>|F.1.16.5.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_sleep_until>
+      <with|par-left|<quote|2tab>|F.1.17.6.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_random_seed>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-145>>
 
-      <with|par-left|<quote|2tab>|F.1.16.6.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_random_seed>
+      <with|par-left|<quote|2tab>|F.1.17.7.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_local_storage_set>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-146>>
 
-      <with|par-left|<quote|2tab>|F.1.16.7.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_local_storage_set>
+      <with|par-left|<quote|2tab>|F.1.17.8.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_local_storage_compare_and_set>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-147>>
 
-      <with|par-left|<quote|2tab>|F.1.16.8.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_local_storage_compare_and_set>
+      <with|par-left|<quote|2tab>|F.1.17.9.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_local_storage_get>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-148>>
 
-      <with|par-left|<quote|2tab>|F.1.16.9.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_local_storage_get>
+      <with|par-left|<quote|2tab>|F.1.17.10.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_request_start>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-149>>
 
-      <with|par-left|<quote|2tab>|F.1.16.10.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_request_start>
+      <with|par-left|<quote|2tab>|F.1.17.11.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_request_add_header>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-150>>
 
-      <with|par-left|<quote|2tab>|F.1.16.11.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_request_add_header>
+      <with|par-left|<quote|2tab>|F.1.17.12.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_request_write_body>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-151>>
 
-      <with|par-left|<quote|2tab>|F.1.16.12.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_request_write_body>
+      <with|par-left|<quote|2tab>|F.1.17.13.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_response_wait>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-152>>
 
-      <with|par-left|<quote|2tab>|F.1.16.13.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_response_wait>
+      <with|par-left|<quote|2tab>|F.1.17.14.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_response_headers>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-153>>
 
-      <with|par-left|<quote|2tab>|F.1.16.14.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_response_headers>
+      <with|par-left|<quote|2tab>|F.1.17.15.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_response_read_body>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-154>>
 
-      <with|par-left|<quote|2tab>|F.1.16.15.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_http_response_read_body>
+      <with|par-left|<quote|1tab>|F.1.18.<space|2spc>Sandboxing
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-155>>
 
-      <with|par-left|<quote|1tab>|F.1.17.<space|2spc>Sandboxing
+      <with|par-left|<quote|2tab>|F.1.18.1.<space|2spc>To be Specced
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-156>>
 
-      <with|par-left|<quote|2tab>|F.1.17.1.<space|2spc>To be Specced
+      <with|par-left|<quote|1tab>|F.1.19.<space|2spc>Auxillary Debugging API
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-157>>
 
-      <with|par-left|<quote|1tab>|F.1.18.<space|2spc>Auxillary Debugging API
+      <with|par-left|<quote|2tab>|F.1.19.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_print_hex>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-158>>
 
-      <with|par-left|<quote|2tab>|F.1.18.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_print_hex>
+      <with|par-left|<quote|2tab>|F.1.19.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_print_utf8>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-159>>
 
-      <with|par-left|<quote|2tab>|F.1.18.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ext_print_utf8>
+      <with|par-left|<quote|1tab>|F.1.20.<space|2spc>Misc
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-160>>
 
-      <with|par-left|<quote|1tab>|F.1.19.<space|2spc>Misc
+      <with|par-left|<quote|2tab>|F.1.20.1.<space|2spc>To be Specced
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-161>>
 
-      <with|par-left|<quote|2tab>|F.1.19.1.<space|2spc>To be Specced
+      <with|par-left|<quote|1tab>|F.1.21.<space|2spc>Block Production
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-162>>
 
-      <with|par-left|<quote|1tab>|F.1.20.<space|2spc>Block Production
-      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-163>>
-
       F.2.<space|2spc>Validation <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-164>
+      <no-break><pageref|auto-163>
 
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|font-shape|<quote|small-caps>|Appendix
       G.<space|2spc>Runtime Entries> <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <pageref|auto-165><vspace|0.5fn>
+      <pageref|auto-164><vspace|0.5fn>
 
       G.1.<space|2spc>List of Runtime Entries
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-166>
+      <no-break><pageref|auto-165>
 
       G.2.<space|2spc>Argument Specification
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-168>
+      <no-break><pageref|auto-167>
 
       <with|par-left|<quote|1tab>|G.2.1.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|Core_version>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-169>>
+      <no-break><pageref|auto-168>>
 
       <with|par-left|<quote|1tab>|G.2.2.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|Core_execute_block>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-171>>
+      <no-break><pageref|auto-170>>
 
       <with|par-left|<quote|1tab>|G.2.3.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|Core_initialise_block>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-172>>
+      <no-break><pageref|auto-171>>
 
       <with|par-left|<quote|1tab>|G.2.4.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|hash_and_length>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-173>>
+      <no-break><pageref|auto-172>>
 
       <with|par-left|<quote|1tab>|G.2.5.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|BabeApi_epoch>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-174>>
+      <no-break><pageref|auto-173>>
 
       <with|par-left|<quote|1tab>|G.2.6.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|Grandpa_authorities>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-175>>
+      <no-break><pageref|auto-174>>
 
       <with|par-left|<quote|1tab>|G.2.7.<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|TaggedTransactionQueue_validate_transaction>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-176>>
+      <no-break><pageref|auto-175>>
 
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|font-shape|<quote|small-caps>|Glossary>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <pageref|auto-179><vspace|0.5fn>
+      <pageref|auto-178><vspace|0.5fn>
 
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|font-shape|<quote|small-caps>|Bibliography>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <pageref|auto-180><vspace|0.5fn>
+      <pageref|auto-179><vspace|0.5fn>
 
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|font-shape|<quote|small-caps>|Index>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <pageref|auto-181><vspace|0.5fn>
+      <pageref|auto-180><vspace|0.5fn>
     </associate>
   </collection>
 </auxiliary>

--- a/runtime-environment-spec/polkadot_re_spec.tm
+++ b/runtime-environment-spec/polkadot_re_spec.tm
@@ -3915,7 +3915,7 @@
     <item><verbatim|value>: a pointer indicating the buffer containing the
     value to be stored under the key.
 
-    <item><verbatim|value_len>: \ the length of the value buffer in bytes.
+    <item><verbatim|value_len>: the length of the value buffer in bytes.
   </itemize>
 
   <subsection|<verbatim|ext_storage_root>>
@@ -4358,6 +4358,44 @@
     byte array in number of bytes.
   </itemize>
 
+  <subsection|<verbatim|ext_set_child_storage>>
+
+  Sets the value of a specific key in the child state storage.
+
+  \;
+
+  <strong|Prototype:>
+
+  <\verbatim>
+    (func $ext_set_child_storage
+
+    \ \ (param $storage_key_data i32) (param $storage_key_len i32) (param
+    $key_data i32)
+
+    \ \ (param $key_len i32) (param $value_data i32) (param $value_len i32))
+  </verbatim>
+
+  \;
+
+  <strong|Arguments>:
+
+  <\itemize>
+    <item><verbatim|storage_key_data>: a memory address pointing at the
+    buffer of the byte array containing the child storage key.
+
+    <item><verbatim|storage_key_len>: the length of the child storage key
+    byte array in number of bytes.
+
+    <item><verbatim|key>: a pointer indicating the buffer containing the key.
+
+    <item><verbatim|key_len>: the key length in bytes.
+
+    <item><verbatim|value>: a pointer indicating the buffer containing the
+    value to be stored under the key.
+
+    <item><verbatim|value_len>: the length of the value buffer in bytes.
+  </itemize>
+
   <subsection|To Be Specced>
 
   <\itemize>
@@ -4371,7 +4409,7 @@
 
     <item><verbatim|>
 
-    <item><verbatim|ext_set_child_storage>
+    <item><verbatim|>
 
     <item><verbatim|ext_storage_changes_root>
   </itemize>
@@ -5828,64 +5866,65 @@
     <associate|auto-126|<tuple|F.1.11|57>>
     <associate|auto-127|<tuple|F.1.12|57>>
     <associate|auto-128|<tuple|F.1.13|57>>
-    <associate|auto-129|<tuple|F.1.13.1|57>>
+    <associate|auto-129|<tuple|F.1.14|57>>
     <associate|auto-13|<tuple|1.9|9>>
-    <associate|auto-130|<tuple|F.1.13.2|57>>
-    <associate|auto-131|<tuple|F.1.13.3|58>>
-    <associate|auto-132|<tuple|F.1.14|58>>
-    <associate|auto-133|<tuple|F.1.14.1|59>>
-    <associate|auto-134|<tuple|F.1.14.2|59>>
-    <associate|auto-135|<tuple|F.1.14.3|59>>
-    <associate|auto-136|<tuple|F.1.14.4|60>>
-    <associate|auto-137|<tuple|F.1.14.5|60>>
-    <associate|auto-138|<tuple|F.1.14.6|60>>
-    <associate|auto-139|<tuple|F.1.15|61>>
+    <associate|auto-130|<tuple|F.1.14.1|57>>
+    <associate|auto-131|<tuple|F.1.14.2|58>>
+    <associate|auto-132|<tuple|F.1.14.3|58>>
+    <associate|auto-133|<tuple|F.1.15|59>>
+    <associate|auto-134|<tuple|F.1.15.1|59>>
+    <associate|auto-135|<tuple|F.1.15.2|59>>
+    <associate|auto-136|<tuple|F.1.15.3|60>>
+    <associate|auto-137|<tuple|F.1.15.4|60>>
+    <associate|auto-138|<tuple|F.1.15.5|60>>
+    <associate|auto-139|<tuple|F.1.15.6|61>>
     <associate|auto-14|<tuple|1.2.1|9>>
-    <associate|auto-140|<tuple|F.1.15.1|61>>
-    <associate|auto-141|<tuple|F.1.15.2|61>>
-    <associate|auto-142|<tuple|F.1.15.3|62>>
-    <associate|auto-143|<tuple|F.1.15.4|62>>
-    <associate|auto-144|<tuple|F.1.15.5|62>>
-    <associate|auto-145|<tuple|F.1.15.6|63>>
-    <associate|auto-146|<tuple|F.1.15.7|63>>
-    <associate|auto-147|<tuple|F.1.15.8|64>>
-    <associate|auto-148|<tuple|F.1.15.9|64>>
-    <associate|auto-149|<tuple|F.1.15.10|65>>
+    <associate|auto-140|<tuple|F.1.16|61>>
+    <associate|auto-141|<tuple|F.1.16.1|61>>
+    <associate|auto-142|<tuple|F.1.16.2|62>>
+    <associate|auto-143|<tuple|F.1.16.3|62>>
+    <associate|auto-144|<tuple|F.1.16.4|62>>
+    <associate|auto-145|<tuple|F.1.16.5|63>>
+    <associate|auto-146|<tuple|F.1.16.6|63>>
+    <associate|auto-147|<tuple|F.1.16.7|64>>
+    <associate|auto-148|<tuple|F.1.16.8|64>>
+    <associate|auto-149|<tuple|F.1.16.9|65>>
     <associate|auto-15|<tuple|1.11|9>>
-    <associate|auto-150|<tuple|F.1.15.11|65>>
-    <associate|auto-151|<tuple|F.1.15.12|65>>
-    <associate|auto-152|<tuple|F.1.15.13|65>>
-    <associate|auto-153|<tuple|F.1.15.14|65>>
-    <associate|auto-154|<tuple|F.1.15.15|66>>
-    <associate|auto-155|<tuple|F.1.16|66>>
-    <associate|auto-156|<tuple|F.1.16.1|66>>
-    <associate|auto-157|<tuple|F.1.17|66>>
-    <associate|auto-158|<tuple|F.1.17.1|66>>
-    <associate|auto-159|<tuple|F.1.17.2|67>>
+    <associate|auto-150|<tuple|F.1.16.10|65>>
+    <associate|auto-151|<tuple|F.1.16.11|65>>
+    <associate|auto-152|<tuple|F.1.16.12|65>>
+    <associate|auto-153|<tuple|F.1.16.13|65>>
+    <associate|auto-154|<tuple|F.1.16.14|66>>
+    <associate|auto-155|<tuple|F.1.16.15|66>>
+    <associate|auto-156|<tuple|F.1.17|66>>
+    <associate|auto-157|<tuple|F.1.17.1|66>>
+    <associate|auto-158|<tuple|F.1.18|66>>
+    <associate|auto-159|<tuple|F.1.18.1|67>>
     <associate|auto-16|<tuple|1.12|9>>
-    <associate|auto-160|<tuple|F.1.18|67>>
-    <associate|auto-161|<tuple|F.1.18.1|67>>
-    <associate|auto-162|<tuple|F.1.19|68>>
-    <associate|auto-163|<tuple|F.2|68>>
-    <associate|auto-164|<tuple|G|68>>
-    <associate|auto-165|<tuple|G.1|68>>
+    <associate|auto-160|<tuple|F.1.18.2|67>>
+    <associate|auto-161|<tuple|F.1.19|67>>
+    <associate|auto-162|<tuple|F.1.19.1|68>>
+    <associate|auto-163|<tuple|F.1.20|68>>
+    <associate|auto-164|<tuple|F.2|68>>
+    <associate|auto-165|<tuple|G|68>>
     <associate|auto-166|<tuple|G.1|68>>
-    <associate|auto-167|<tuple|G.2|68>>
-    <associate|auto-168|<tuple|G.2.1|69>>
-    <associate|auto-169|<tuple|G.1|69>>
+    <associate|auto-167|<tuple|G.1|68>>
+    <associate|auto-168|<tuple|G.2|69>>
+    <associate|auto-169|<tuple|G.2.1|69>>
     <associate|auto-17|<tuple|1.12|9>>
-    <associate|auto-170|<tuple|G.2.2|69>>
-    <associate|auto-171|<tuple|G.2.3|70>>
-    <associate|auto-172|<tuple|G.2.4|70>>
-    <associate|auto-173|<tuple|G.2.5|71>>
-    <associate|auto-174|<tuple|G.2.6|73>>
-    <associate|auto-175|<tuple|G.2.7|75>>
-    <associate|auto-176|<tuple|G.2|?>>
-    <associate|auto-177|<tuple|G.3|?>>
+    <associate|auto-170|<tuple|G.1|69>>
+    <associate|auto-171|<tuple|G.2.2|70>>
+    <associate|auto-172|<tuple|G.2.3|70>>
+    <associate|auto-173|<tuple|G.2.4|71>>
+    <associate|auto-174|<tuple|G.2.5|73>>
+    <associate|auto-175|<tuple|G.2.6|75>>
+    <associate|auto-176|<tuple|G.2.7|?>>
+    <associate|auto-177|<tuple|G.2|?>>
     <associate|auto-178|<tuple|G.3|?>>
     <associate|auto-179|<tuple|G.3|?>>
     <associate|auto-18|<tuple|1.13|9>>
-    <associate|auto-180|<tuple|Tec19|?>>
+    <associate|auto-180|<tuple|G.3|?>>
+    <associate|auto-181|<tuple|Tec19|?>>
     <associate|auto-19|<tuple|1.13|9>>
     <associate|auto-2|<tuple|1.1|7>>
     <associate|auto-20|<tuple|1.13|9>>

--- a/runtime-environment-spec/polkadot_re_spec.tm
+++ b/runtime-environment-spec/polkadot_re_spec.tm
@@ -4233,9 +4233,9 @@
   <subsection|<verbatim|ext_get_allocated_child_storage>>
 
   Given a byte array, this function allocates a large enough buffer in the
-  memory and retrieves the value stored under the key that is specified in
-  the array. Then, it stores in in the allocated buffer if the entry exists
-  in the child storage.
+  memory and retrieves the child value stored under the key that is specified
+  in the array. Then, it stores in in the allocated buffer if the entry
+  exists in the child storage.
 
   \;
 
@@ -4275,6 +4275,62 @@
     entry exist; otherwise it is equal to 0.
   </itemize>
 
+  <subsection|<verbatim|ext_get_child_storage_into>>
+
+  Given a byte array, this function retrieves the child value stored under
+  the key specified in the array and stores a specified chunk of it in the
+  provided buffer, if the entry exists in the storage.
+
+  \;
+
+  <strong|Prototype:>
+
+  <\verbatim>
+    \ \ \ \ (func $ext_get_child_storage_into
+
+    \ \ \ \ \ \ (param $storage_key_data i32) (param $storage_key_len i32)
+
+    \ \ \ \ \ \ (param $key_data i32) (param $key_len i32) (param $value_data
+    i32)
+
+    \ \ \ \ \ \ (param $value_len i32) (param $value_offset i32) (result
+    i32))
+  </verbatim>
+
+  \;
+
+  <strong|Arguments>:
+
+  <\itemize>
+    <item><verbatim|storage_key_data>: a memory address pointing at the
+    buffer of the byte array containing the child storage key.
+
+    <item><verbatim|storage_key_len>: the length of the child storage key
+    byte array in number of bytes.
+
+    <item><verbatim|key_data>: a memory address pointing at the buffer of the
+    byte array containing the key value.
+
+    <item><verbatim|key_len>: the length of the byte array in number of
+    bytes.
+
+    <item><verbatim|value_data>: a pointer to the buffer in which the
+    function stores the chunk of the value it retrieves.
+
+    <item><verbatim|value_len>: the (maximum) length of the chunk in bytes
+    the function will read of the value and will store in the
+    <verbatim|value_data> buffer.
+
+    <item><verbatim|value_offset>: the offset of the chunk where the function
+    should start storing the value in the provided buffer, i.e. the number of
+    bytes the functions should skip from the retrieved value before storing
+    the data in the <verbatim|value_data> in number of bytes.
+
+    <item><verbatim|result>: The number of bytes the function writes in
+    <verbatim|value_data> if the value exists or <math|2<rsup|32>-1> if the
+    entry does not exist under the specified key.
+  </itemize>
+
   <subsection|To Be Specced>
 
   <\itemize>
@@ -4284,7 +4340,7 @@
 
     <item><verbatim|>
 
-    <item><verbatim|ext_get_child_storage_into>
+    <item><verbatim|>
 
     <item><verbatim|ext_kill_child_storage>
 
@@ -5743,64 +5799,66 @@
     <associate|auto-124|<tuple|F.1.9|56>>
     <associate|auto-125|<tuple|F.1.10|56>>
     <associate|auto-126|<tuple|F.1.11|57>>
-    <associate|auto-127|<tuple|F.1.11.1|57>>
-    <associate|auto-128|<tuple|F.1.11.2|57>>
-    <associate|auto-129|<tuple|F.1.11.3|57>>
+    <associate|auto-127|<tuple|F.1.12|57>>
+    <associate|auto-128|<tuple|F.1.12.1|57>>
+    <associate|auto-129|<tuple|F.1.12.2|57>>
     <associate|auto-13|<tuple|1.9|9>>
-    <associate|auto-130|<tuple|F.1.12|57>>
-    <associate|auto-131|<tuple|F.1.12.1|58>>
-    <associate|auto-132|<tuple|F.1.12.2|58>>
-    <associate|auto-133|<tuple|F.1.12.3|59>>
-    <associate|auto-134|<tuple|F.1.12.4|59>>
-    <associate|auto-135|<tuple|F.1.12.5|59>>
-    <associate|auto-136|<tuple|F.1.12.6|60>>
-    <associate|auto-137|<tuple|F.1.13|60>>
-    <associate|auto-138|<tuple|F.1.13.1|60>>
-    <associate|auto-139|<tuple|F.1.13.2|61>>
+    <associate|auto-130|<tuple|F.1.12.3|57>>
+    <associate|auto-131|<tuple|F.1.13|58>>
+    <associate|auto-132|<tuple|F.1.13.1|58>>
+    <associate|auto-133|<tuple|F.1.13.2|59>>
+    <associate|auto-134|<tuple|F.1.13.3|59>>
+    <associate|auto-135|<tuple|F.1.13.4|59>>
+    <associate|auto-136|<tuple|F.1.13.5|60>>
+    <associate|auto-137|<tuple|F.1.13.6|60>>
+    <associate|auto-138|<tuple|F.1.14|60>>
+    <associate|auto-139|<tuple|F.1.14.1|61>>
     <associate|auto-14|<tuple|1.2.1|9>>
-    <associate|auto-140|<tuple|F.1.13.3|61>>
-    <associate|auto-141|<tuple|F.1.13.4|61>>
-    <associate|auto-142|<tuple|F.1.13.5|62>>
-    <associate|auto-143|<tuple|F.1.13.6|62>>
-    <associate|auto-144|<tuple|F.1.13.7|62>>
-    <associate|auto-145|<tuple|F.1.13.8|63>>
-    <associate|auto-146|<tuple|F.1.13.9|63>>
-    <associate|auto-147|<tuple|F.1.13.10|64>>
-    <associate|auto-148|<tuple|F.1.13.11|64>>
-    <associate|auto-149|<tuple|F.1.13.12|65>>
+    <associate|auto-140|<tuple|F.1.14.2|61>>
+    <associate|auto-141|<tuple|F.1.14.3|61>>
+    <associate|auto-142|<tuple|F.1.14.4|62>>
+    <associate|auto-143|<tuple|F.1.14.5|62>>
+    <associate|auto-144|<tuple|F.1.14.6|62>>
+    <associate|auto-145|<tuple|F.1.14.7|63>>
+    <associate|auto-146|<tuple|F.1.14.8|63>>
+    <associate|auto-147|<tuple|F.1.14.9|64>>
+    <associate|auto-148|<tuple|F.1.14.10|64>>
+    <associate|auto-149|<tuple|F.1.14.11|65>>
     <associate|auto-15|<tuple|1.11|9>>
-    <associate|auto-150|<tuple|F.1.13.13|65>>
-    <associate|auto-151|<tuple|F.1.13.14|65>>
-    <associate|auto-152|<tuple|F.1.13.15|65>>
-    <associate|auto-153|<tuple|F.1.14|65>>
-    <associate|auto-154|<tuple|F.1.14.1|66>>
-    <associate|auto-155|<tuple|F.1.15|66>>
-    <associate|auto-156|<tuple|F.1.15.1|66>>
-    <associate|auto-157|<tuple|F.1.15.2|66>>
-    <associate|auto-158|<tuple|F.1.16|66>>
-    <associate|auto-159|<tuple|F.1.16.1|67>>
+    <associate|auto-150|<tuple|F.1.14.12|65>>
+    <associate|auto-151|<tuple|F.1.14.13|65>>
+    <associate|auto-152|<tuple|F.1.14.14|65>>
+    <associate|auto-153|<tuple|F.1.14.15|65>>
+    <associate|auto-154|<tuple|F.1.15|66>>
+    <associate|auto-155|<tuple|F.1.15.1|66>>
+    <associate|auto-156|<tuple|F.1.16|66>>
+    <associate|auto-157|<tuple|F.1.16.1|66>>
+    <associate|auto-158|<tuple|F.1.16.2|66>>
+    <associate|auto-159|<tuple|F.1.17|67>>
     <associate|auto-16|<tuple|1.12|9>>
-    <associate|auto-160|<tuple|F.1.17|67>>
-    <associate|auto-161|<tuple|F.2|67>>
-    <associate|auto-162|<tuple|G|68>>
-    <associate|auto-163|<tuple|G.1|68>>
+    <associate|auto-160|<tuple|F.1.17.1|67>>
+    <associate|auto-161|<tuple|F.1.18|67>>
+    <associate|auto-162|<tuple|F.2|68>>
+    <associate|auto-163|<tuple|G|68>>
     <associate|auto-164|<tuple|G.1|68>>
-    <associate|auto-165|<tuple|G.2|68>>
-    <associate|auto-166|<tuple|G.2.1|68>>
-    <associate|auto-167|<tuple|G.1|68>>
-    <associate|auto-168|<tuple|G.2.2|69>>
-    <associate|auto-169|<tuple|G.2.3|69>>
+    <associate|auto-165|<tuple|G.1|68>>
+    <associate|auto-166|<tuple|G.2|68>>
+    <associate|auto-167|<tuple|G.2.1|68>>
+    <associate|auto-168|<tuple|G.1|69>>
+    <associate|auto-169|<tuple|G.2.2|69>>
     <associate|auto-17|<tuple|1.12|9>>
-    <associate|auto-170|<tuple|G.2.4|69>>
-    <associate|auto-171|<tuple|G.2.5|70>>
-    <associate|auto-172|<tuple|G.2.6|70>>
-    <associate|auto-173|<tuple|G.2.7|71>>
-    <associate|auto-174|<tuple|G.2|73>>
-    <associate|auto-175|<tuple|G.3|75>>
+    <associate|auto-170|<tuple|G.2.3|69>>
+    <associate|auto-171|<tuple|G.2.4|70>>
+    <associate|auto-172|<tuple|G.2.5|70>>
+    <associate|auto-173|<tuple|G.2.6|71>>
+    <associate|auto-174|<tuple|G.2.7|73>>
+    <associate|auto-175|<tuple|G.2|75>>
     <associate|auto-176|<tuple|G.3|?>>
     <associate|auto-177|<tuple|G.3|?>>
-    <associate|auto-178|<tuple|Tec19|?>>
+    <associate|auto-178|<tuple|G.3|?>>
+    <associate|auto-179|<tuple|Tec19|?>>
     <associate|auto-18|<tuple|1.13|9>>
+    <associate|auto-180|<tuple|Tec19|?>>
     <associate|auto-19|<tuple|1.13|9>>
     <associate|auto-2|<tuple|1.1|7>>
     <associate|auto-20|<tuple|1.13|9>>

--- a/runtime-environment-spec/polkadot_re_spec.tm
+++ b/runtime-environment-spec/polkadot_re_spec.tm
@@ -3942,7 +3942,7 @@
     concludes.
   </itemize>
 
-  <subsubsection|<verbatim|ext_blake2_256_enumerated_trie_root>>
+  <subsection|<verbatim|ext_blake2_256_enumerated_trie_root>>
 
   Given an array of byte arrays, it arranges them in a Merkle trie, defined
   in<verbatim|<em|<strong|>>> Section <reference|sect-merkl-proof>, where the
@@ -4035,9 +4035,9 @@
     bytes.
   </itemize>
 
-  <\subsubsection>
+  <\subsection>
     <verbatim|ext_exists_storage>
-  </subsubsection>
+  </subsection>
 
   Given a byte array, this function checks if the storage entry corresponding
   to the key specified in the array exists.
@@ -5834,58 +5834,58 @@
     <associate|auto-113|<tuple|F.1|53>>
     <associate|auto-114|<tuple|F.1.1|53>>
     <associate|auto-115|<tuple|F.1.2|53>>
-    <associate|auto-116|<tuple|F.1.2.1|54>>
-    <associate|auto-117|<tuple|F.1.3|54>>
-    <associate|auto-118|<tuple|F.1.4|54>>
-    <associate|auto-119|<tuple|F.1.4.1|54>>
+    <associate|auto-116|<tuple|F.1.3|54>>
+    <associate|auto-117|<tuple|F.1.4|54>>
+    <associate|auto-118|<tuple|F.1.5|54>>
+    <associate|auto-119|<tuple|F.1.6|54>>
     <associate|auto-12|<tuple|1.9|9>>
-    <associate|auto-120|<tuple|F.1.5|55>>
-    <associate|auto-121|<tuple|F.1.6|55>>
-    <associate|auto-122|<tuple|F.1.7|56>>
-    <associate|auto-123|<tuple|F.1.8|56>>
-    <associate|auto-124|<tuple|F.1.9|56>>
-    <associate|auto-125|<tuple|F.1.10|56>>
-    <associate|auto-126|<tuple|F.1.11|57>>
-    <associate|auto-127|<tuple|F.1.12|57>>
-    <associate|auto-128|<tuple|F.1.13|57>>
-    <associate|auto-129|<tuple|F.1.13.1|57>>
+    <associate|auto-120|<tuple|F.1.7|55>>
+    <associate|auto-121|<tuple|F.1.8|55>>
+    <associate|auto-122|<tuple|F.1.9|56>>
+    <associate|auto-123|<tuple|F.1.10|56>>
+    <associate|auto-124|<tuple|F.1.11|56>>
+    <associate|auto-125|<tuple|F.1.12|56>>
+    <associate|auto-126|<tuple|F.1.13|57>>
+    <associate|auto-127|<tuple|F.1.14|57>>
+    <associate|auto-128|<tuple|F.1.15|57>>
+    <associate|auto-129|<tuple|F.1.15.1|57>>
     <associate|auto-13|<tuple|1.9|9>>
-    <associate|auto-130|<tuple|F.1.13.2|57>>
-    <associate|auto-131|<tuple|F.1.13.3|58>>
-    <associate|auto-132|<tuple|F.1.14|58>>
-    <associate|auto-133|<tuple|F.1.14.1|59>>
-    <associate|auto-134|<tuple|F.1.14.2|59>>
-    <associate|auto-135|<tuple|F.1.14.3|59>>
-    <associate|auto-136|<tuple|F.1.14.4|60>>
-    <associate|auto-137|<tuple|F.1.14.5|60>>
-    <associate|auto-138|<tuple|F.1.14.6|60>>
-    <associate|auto-139|<tuple|F.1.15|61>>
+    <associate|auto-130|<tuple|F.1.15.2|57>>
+    <associate|auto-131|<tuple|F.1.15.3|58>>
+    <associate|auto-132|<tuple|F.1.16|58>>
+    <associate|auto-133|<tuple|F.1.16.1|59>>
+    <associate|auto-134|<tuple|F.1.16.2|59>>
+    <associate|auto-135|<tuple|F.1.16.3|59>>
+    <associate|auto-136|<tuple|F.1.16.4|60>>
+    <associate|auto-137|<tuple|F.1.16.5|60>>
+    <associate|auto-138|<tuple|F.1.16.6|60>>
+    <associate|auto-139|<tuple|F.1.17|61>>
     <associate|auto-14|<tuple|1.2.1|9>>
-    <associate|auto-140|<tuple|F.1.15.1|61>>
-    <associate|auto-141|<tuple|F.1.15.2|61>>
-    <associate|auto-142|<tuple|F.1.15.3|62>>
-    <associate|auto-143|<tuple|F.1.15.4|62>>
-    <associate|auto-144|<tuple|F.1.15.5|62>>
-    <associate|auto-145|<tuple|F.1.15.6|63>>
-    <associate|auto-146|<tuple|F.1.15.7|63>>
-    <associate|auto-147|<tuple|F.1.15.8|64>>
-    <associate|auto-148|<tuple|F.1.15.9|64>>
-    <associate|auto-149|<tuple|F.1.15.10|65>>
+    <associate|auto-140|<tuple|F.1.17.1|61>>
+    <associate|auto-141|<tuple|F.1.17.2|61>>
+    <associate|auto-142|<tuple|F.1.17.3|62>>
+    <associate|auto-143|<tuple|F.1.17.4|62>>
+    <associate|auto-144|<tuple|F.1.17.5|62>>
+    <associate|auto-145|<tuple|F.1.17.6|63>>
+    <associate|auto-146|<tuple|F.1.17.7|63>>
+    <associate|auto-147|<tuple|F.1.17.8|64>>
+    <associate|auto-148|<tuple|F.1.17.9|64>>
+    <associate|auto-149|<tuple|F.1.17.10|65>>
     <associate|auto-15|<tuple|1.11|9>>
-    <associate|auto-150|<tuple|F.1.15.11|65>>
-    <associate|auto-151|<tuple|F.1.15.12|65>>
-    <associate|auto-152|<tuple|F.1.15.13|65>>
-    <associate|auto-153|<tuple|F.1.15.14|65>>
-    <associate|auto-154|<tuple|F.1.15.15|66>>
-    <associate|auto-155|<tuple|F.1.16|66>>
-    <associate|auto-156|<tuple|F.1.16.1|66>>
-    <associate|auto-157|<tuple|F.1.17|66>>
-    <associate|auto-158|<tuple|F.1.17.1|66>>
-    <associate|auto-159|<tuple|F.1.17.2|67>>
+    <associate|auto-150|<tuple|F.1.17.11|65>>
+    <associate|auto-151|<tuple|F.1.17.12|65>>
+    <associate|auto-152|<tuple|F.1.17.13|65>>
+    <associate|auto-153|<tuple|F.1.17.14|65>>
+    <associate|auto-154|<tuple|F.1.17.15|66>>
+    <associate|auto-155|<tuple|F.1.18|66>>
+    <associate|auto-156|<tuple|F.1.18.1|66>>
+    <associate|auto-157|<tuple|F.1.19|66>>
+    <associate|auto-158|<tuple|F.1.19.1|66>>
+    <associate|auto-159|<tuple|F.1.19.2|67>>
     <associate|auto-16|<tuple|1.12|9>>
-    <associate|auto-160|<tuple|F.1.18|67>>
-    <associate|auto-161|<tuple|F.1.18.1|67>>
-    <associate|auto-162|<tuple|F.1.19|68>>
+    <associate|auto-160|<tuple|F.1.20|67>>
+    <associate|auto-161|<tuple|F.1.20.1|67>>
+    <associate|auto-162|<tuple|F.1.21|68>>
     <associate|auto-163|<tuple|F.2|68>>
     <associate|auto-164|<tuple|G|68>>
     <associate|auto-165|<tuple|G.1|68>>


### PR DESCRIPTION
Replacement for #77. Rebased this branch (edit: turns out you can rebase active PRs by force-pushing. I will do that in the future).

**Original description:**
This PR specs the following APIs:

    ext_clear_child_storage
    ext_get_allocated_child_storage
    ext_kill_child_storage
    ext_storage_changes_root
    ext_exists_child_storage
    ext_get_child_storage_into
    ext_set_child_storage

@drskalman I've adapted the sentences from the current non-child storage APIs, but I'm going to rephrase those to make them "basic and easy". I'll update this branch or create a new PR if you decide to merge.

Feedback welcome.