### PR TITLE
Correct digest item types in spec

### DIFF
--- a/runtime-environment-spec/polkadot_re_spec.tm
+++ b/runtime-environment-spec/polkadot_re_spec.tm
@@ -1891,9 +1891,9 @@
         <\center>
           <tabular*|<tformat|<cwith|1|-1|1|1|cell-halign|r>|<cwith|1|-1|3|3|cell-halign|l>|<cwith|1|-1|1|-1|cell-valign|c>|<cwith|1|-1|1|-1|cell-tborder|0ln>|<cwith|1|-1|1|-1|cell-bborder|0ln>|<cwith|1|-1|1|-1|cell-lborder|1ln>|<cwith|1|-1|1|-1|cell-rborder|1ln>|<cwith|5|5|1|-1|cell-bborder|1ln>|<cwith|1|-1|1|1|cell-lborder|1ln>|<cwith|1|1|1|-1|cell-tborder|1ln>|<cwith|1|1|1|-1|cell-bborder|1ln>|<cwith|2|2|1|-1|cell-tborder|1ln>|<cwith|1|1|1|1|cell-lborder|1ln>|<cwith|1|1|1|3|cell-halign|l>|<cwith|1|5|2|2|cell-halign|l>|<cwith|1|5|2|2|cell-valign|c>|<cwith|1|5|2|2|cell-tborder|0ln>|<cwith|1|5|2|2|cell-bborder|0ln>|<cwith|1|5|2|2|cell-lborder|1ln>|<cwith|1|5|2|2|cell-rborder|1ln>|<cwith|5|5|2|2|cell-bborder|1ln>|<cwith|1|5|2|2|cell-rborder|1ln>|<cwith|1|1|2|2|cell-tborder|1ln>|<cwith|1|1|2|2|cell-bborder|1ln>|<cwith|2|2|2|2|cell-tborder|1ln>|<cwith|1|1|2|2|cell-rborder|1ln>|<table|<row|<cell|Type
           Id>|<cell|Type name>|<cell|sub-components
-          >>|<row|<cell|<math|0>>|<cell|Changes trie
-          root>|<cell|<math|\<bbb-B\><rsub|32>>>>|<row|<cell|1>|<cell|Pre-Runtime>|<cell|<math|E<rsub|id>,\<bbb-B\>>>>|<row|<cell|2>|<cell|Consensus
-          Message>|<cell|<math|E<rsub|id>,\<bbb-B\>>>>|<row|<cell|4>|<cell|Seal
+          >>|<row|<cell|<math|2>>|<cell|Changes trie
+          root>|<cell|<math|\<bbb-B\><rsub|32>>>>|<row|<cell|6>|<cell|Pre-Runtime>|<cell|<math|E<rsub|id>,\<bbb-B\>>>>|<row|<cell|4>|<cell|Consensus
+          Message>|<cell|<math|E<rsub|id>,\<bbb-B\>>>>|<row|<cell|5>|<cell|Seal
           >|<cell|<math|E<rsub|id>,\<bbb-B\>>>>>>>
         </center>
 


### PR DESCRIPTION
**Printscreen**
![image](https://user-images.githubusercontent.com/42901763/72606301-a5b31300-391e-11ea-980a-3b8641390ea9.png)

`DigestItem` does not use the default SCALE encoding process where the Enum items get indexed from 0 to `n`, but a custom one:

```rust
pub enum DigestItemType {
	ChangesTrieRoot = 2,
	PreRuntime = 6,
	Consensus = 4,
	Seal = 5,
	Other = 0,
}
```

```rust
impl<'a, Hash: Encode> Encode for DigestItemRef<'a, Hash> {
	fn encode(&self) -> Vec<u8> {
		let mut v = Vec::new();
		match *self {
			DigestItemRef::ChangesTrieRoot(changes_trie_root) => {
				DigestItemType::ChangesTrieRoot.encode_to(&mut v);
				changes_trie_root.encode_to(&mut v);
			},
			DigestItemRef::Consensus(val, data) => {
				DigestItemType::Consensus.encode_to(&mut v);
				(val, data).encode_to(&mut v);
			},
// . . .
```
```rust
impl<Hash: Decode> Decode for DigestItem<Hash> {
	#[allow(deprecated)]
	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
		let item_type: DigestItemType = Decode::decode(input)?;
		match item_type {
			DigestItemType::ChangesTrieRoot => Ok(DigestItem::ChangesTrieRoot(
				Decode::decode(input)?,
			)),
			DigestItemType::PreRuntime => {
				let vals: (ConsensusEngineId, Vec<u8>) = Decode::decode(input)?;
				Ok(DigestItem::PreRuntime(vals.0, vals.1))
			},
// ...
```
