### PR TITLE
Rename "Runtime Environment" to "Host".

### DIFF
--- a/runtime-environment-spec/polkadot_re_spec.tm
+++ b/runtime-environment-spec/polkadot_re_spec.tm
@@ -1,4 +1,4 @@
-<TeXmacs|1.99.11>
+<TeXmacs|1.99.12>
 
 <style|<tuple|tmbook|std-latex|algorithmacs-style|old-dots>>
 
@@ -8814,11 +8814,11 @@
   </bibliography>
 
   <\the-index|idx>
-    <index-1|Transaction Message|<pageref|auto-47>\U<pageref|auto-50>>
+    <index+1|Transaction Message|<pageref|auto-47>\U<pageref|auto-50>>
 
-    <index-1|transaction pool|<pageref|auto-48>>
+    <index+1|transaction pool|<pageref|auto-48>>
 
-    <index-1|transaction queue|<pageref|auto-49>>
+    <index+1|transaction queue|<pageref|auto-49>>
   </the-index>
 </body>
 
@@ -9323,10 +9323,10 @@
     <associate|sect-msg-consensus|<tuple|D.1.6|58>>
     <associate|sect-msg-status|<tuple|D.1.1|55>>
     <associate|sect-msg-transactions|<tuple|D.1.5|57>>
-    <associate|sect-network-interactions|<tuple|Tec19|29>>
+    <associate|sect-network-interactions|<tuple|4|29>>
     <associate|sect-network-messages|<tuple|D|55>>
     <associate|sect-randomness|<tuple|A.3|47>>
-    <associate|sect-re-api|<tuple|Tec19|83>>
+    <associate|sect-re-api|<tuple|F|83>>
     <associate|sect-rte-babeapi-epoch|<tuple|G.2.5|101>>
     <associate|sect-rte-grandpa-auth|<tuple|G.2.6|102>>
     <associate|sect-rte-hash-and-length|<tuple|G.2.4|101>>

--- a/runtime-environment-spec/polkadot_re_spec.tm
+++ b/runtime-environment-spec/polkadot_re_spec.tm
@@ -1155,7 +1155,7 @@
   into two parts, the <em|Runtime> and the <em|Host>. The Runtime comprises
   most of the state transition logic for the Polkadot protocol and is
   designed and expected to be upgradable as part of the state transition
-  process. The Runtime environment consists of parts of the
+  process. The Polkadot Host consists of parts of the
   protocol,<space|1em>shared mostly among peer-to-peer decentralized
   cryptographically-secured transaction systems, i.e. blockchains whose
   consensus system is based on the proof-of-stake. The Polkadot Host is
@@ -2045,7 +2045,7 @@
   The Polkadot Host provides a Wasm Virtual Machine (VM) to run the Runtime.
   The Wasm VM exposes the Polkadot Host API to the Runtime, which, on its
   turn, executes a call to the Runtime entries stored in the Wasm module.
-  This part of the Runtime environment is referred to as the
+  This part of the Polkadot Host is referred to as the
   <em|<strong|Executor>.>
 
   Definition <reference|nota-call-into-runtime> introduces the notation for
@@ -8839,26 +8839,26 @@
 
 <\references>
   <\collection>
-    <associate|alg-join-leave-grandpa|<tuple|5.8|45>>
-    <associate|algo-aggregate-key|<tuple|2.1|19>>
-    <associate|algo-attempt-to\Ufinalize|<tuple|5.11|46>>
-    <associate|algo-block-production|<tuple|5.3|39>>
-    <associate|algo-block-production-lottery|<tuple|5.1|38>>
-    <associate|algo-build-block|<tuple|5.7|41>>
-    <associate|algo-epoch-randomness|<tuple|5.4|40>>
-    <associate|algo-grandpa-best-candidate|<tuple|5.10|46>>
-    <associate|algo-grandpa-round|<tuple|5.9|45>>
-    <associate|algo-import-and-validate-block|<tuple|3.4|29>>
-    <associate|algo-maintain-transaction-pool|<tuple|3.3|26>>
-    <associate|algo-pk-length|<tuple|2.2|20>>
-    <associate|algo-runtime-interaction|<tuple|3.1|23>>
-    <associate|algo-slot-time|<tuple|5.2|38>>
-    <associate|algo-validate-transactions|<tuple|3.2|26>>
-    <associate|algo-verify-authorship-right|<tuple|5.5|40>>
-    <associate|algo-verify-slot-winner|<tuple|5.6|41>>
+    <associate|alg-join-leave-grandpa|<tuple|5.8|43>>
+    <associate|algo-aggregate-key|<tuple|2.1|17>>
+    <associate|algo-attempt-to\Ufinalize|<tuple|5.11|44>>
+    <associate|algo-block-production|<tuple|5.3|37>>
+    <associate|algo-block-production-lottery|<tuple|5.1|36>>
+    <associate|algo-build-block|<tuple|5.7|39>>
+    <associate|algo-epoch-randomness|<tuple|5.4|38>>
+    <associate|algo-grandpa-best-candidate|<tuple|5.10|44>>
+    <associate|algo-grandpa-round|<tuple|5.9|43>>
+    <associate|algo-import-and-validate-block|<tuple|3.4|27>>
+    <associate|algo-maintain-transaction-pool|<tuple|3.3|24>>
+    <associate|algo-pk-length|<tuple|2.2|18>>
+    <associate|algo-runtime-interaction|<tuple|3.1|21>>
+    <associate|algo-slot-time|<tuple|5.2|36>>
+    <associate|algo-validate-transactions|<tuple|3.2|24>>
+    <associate|algo-verify-authorship-right|<tuple|5.5|38>>
+    <associate|algo-verify-slot-winner|<tuple|5.6|39>>
     <associate|appendix-e|<tuple|E|59>>
-    <associate|auto-1|<tuple|1|13>>
-    <associate|auto-10|<tuple|1.9|15>>
+    <associate|auto-1|<tuple|1|11>>
+    <associate|auto-10|<tuple|1.9|13>>
     <associate|auto-100|<tuple|A.5.3|48>>
     <associate|auto-101|<tuple|A.5.4|48>>
     <associate|auto-102|<tuple|A.5.5|48>>
@@ -8869,7 +8869,7 @@
     <associate|auto-107|<tuple|C|53>>
     <associate|auto-108|<tuple|C.1|53>>
     <associate|auto-109|<tuple|D|55>>
-    <associate|auto-11|<tuple|1.9|15>>
+    <associate|auto-11|<tuple|1.9|13>>
     <associate|auto-110|<tuple|D.1|55>>
     <associate|auto-111|<tuple|D.1|55>>
     <associate|auto-112|<tuple|D.1.1|55>>
@@ -8880,7 +8880,7 @@
     <associate|auto-117|<tuple|D.1.4|57>>
     <associate|auto-118|<tuple|D.1.5|57>>
     <associate|auto-119|<tuple|D.1.6|58>>
-    <associate|auto-12|<tuple|1.9|15>>
+    <associate|auto-12|<tuple|1.9|13>>
     <associate|auto-120|<tuple|E|59>>
     <associate|auto-121|<tuple|E.1|59>>
     <associate|auto-122|<tuple|E.1.1|59>>
@@ -8891,7 +8891,7 @@
     <associate|auto-127|<tuple|E.1.3.1|60>>
     <associate|auto-128|<tuple|E.1.4|60>>
     <associate|auto-129|<tuple|E.1.4.1|60>>
-    <associate|auto-13|<tuple|1.9|15>>
+    <associate|auto-13|<tuple|1.9|13>>
     <associate|auto-130|<tuple|E.1.5|60>>
     <associate|auto-131|<tuple|E.1.5.1|60>>
     <associate|auto-132|<tuple|E.1.6|61>>
@@ -8902,7 +8902,7 @@
     <associate|auto-137|<tuple|E.1.8.1|61>>
     <associate|auto-138|<tuple|E.1.9|61>>
     <associate|auto-139|<tuple|E.1.9.1|61>>
-    <associate|auto-14|<tuple|1.2.1|15>>
+    <associate|auto-14|<tuple|1.2.1|13>>
     <associate|auto-140|<tuple|E.2|62>>
     <associate|auto-141|<tuple|E.2.1|62>>
     <associate|auto-142|<tuple|E.2.1.1|62>>
@@ -8913,7 +8913,7 @@
     <associate|auto-147|<tuple|E.2.4|63>>
     <associate|auto-148|<tuple|E.2.4.1|63>>
     <associate|auto-149|<tuple|E.2.5|64>>
-    <associate|auto-15|<tuple|1.11|15>>
+    <associate|auto-15|<tuple|1.11|13>>
     <associate|auto-150|<tuple|E.2.5.1|64>>
     <associate|auto-151|<tuple|E.2.6|64>>
     <associate|auto-152|<tuple|E.2.6.1|64>>
@@ -8924,7 +8924,7 @@
     <associate|auto-157|<tuple|E.2.9|65>>
     <associate|auto-158|<tuple|E.2.9.1|65>>
     <associate|auto-159|<tuple|E.3|66>>
-    <associate|auto-16|<tuple|1.12|15>>
+    <associate|auto-16|<tuple|1.12|13>>
     <associate|auto-160|<tuple|E.1|66>>
     <associate|auto-161|<tuple|E.2|66>>
     <associate|auto-162|<tuple|E.3.1|66>>
@@ -8935,7 +8935,7 @@
     <associate|auto-167|<tuple|E.3.3.1|67>>
     <associate|auto-168|<tuple|E.3.4|67>>
     <associate|auto-169|<tuple|E.3.4.1|67>>
-    <associate|auto-17|<tuple|1.12|15>>
+    <associate|auto-17|<tuple|1.12|13>>
     <associate|auto-170|<tuple|E.3.5|68>>
     <associate|auto-171|<tuple|E.3.5.1|68>>
     <associate|auto-172|<tuple|E.3.6|68>>
@@ -8946,7 +8946,7 @@
     <associate|auto-177|<tuple|E.3.8.1|69>>
     <associate|auto-178|<tuple|E.3.9|69>>
     <associate|auto-179|<tuple|E.3.9.1|69>>
-    <associate|auto-18|<tuple|1.13|15>>
+    <associate|auto-18|<tuple|1.13|13>>
     <associate|auto-180|<tuple|E.3.10|69>>
     <associate|auto-181|<tuple|E.3.10.1|70>>
     <associate|auto-182|<tuple|E.4|70>>
@@ -8957,7 +8957,7 @@
     <associate|auto-187|<tuple|E.4.3|70>>
     <associate|auto-188|<tuple|E.4.3.1|71>>
     <associate|auto-189|<tuple|E.4.4|71>>
-    <associate|auto-19|<tuple|1.13|15>>
+    <associate|auto-19|<tuple|1.13|13>>
     <associate|auto-190|<tuple|E.4.4.1|71>>
     <associate|auto-191|<tuple|E.4.5|71>>
     <associate|auto-192|<tuple|E.4.5.1|71>>
@@ -8968,8 +8968,8 @@
     <associate|auto-197|<tuple|E.5|72>>
     <associate|auto-198|<tuple|E.3|73>>
     <associate|auto-199|<tuple|E.5.1|73>>
-    <associate|auto-2|<tuple|1.1|13>>
-    <associate|auto-20|<tuple|1.13|15>>
+    <associate|auto-2|<tuple|1.1|11>>
+    <associate|auto-20|<tuple|1.13|13>>
     <associate|auto-200|<tuple|E.5.1.1|73>>
     <associate|auto-201|<tuple|E.5.2|73>>
     <associate|auto-202|<tuple|E.5.2.1|73>>
@@ -8980,7 +8980,7 @@
     <associate|auto-207|<tuple|E.5.5|74>>
     <associate|auto-208|<tuple|E.5.5.1|74>>
     <associate|auto-209|<tuple|E.5.6|74>>
-    <associate|auto-21|<tuple|1.13|15>>
+    <associate|auto-21|<tuple|1.13|13>>
     <associate|auto-210|<tuple|E.5.6.1|74>>
     <associate|auto-211|<tuple|E.5.7|74>>
     <associate|auto-212|<tuple|E.5.7.1|74>>
@@ -8991,7 +8991,7 @@
     <associate|auto-217|<tuple|E.5.10|75>>
     <associate|auto-218|<tuple|E.5.10.1|75>>
     <associate|auto-219|<tuple|E.5.11|76>>
-    <associate|auto-22|<tuple|1.13|15>>
+    <associate|auto-22|<tuple|1.13|13>>
     <associate|auto-220|<tuple|E.5.11.1|76>>
     <associate|auto-221|<tuple|E.5.12|76>>
     <associate|auto-222|<tuple|E.5.12.1|76>>
@@ -9002,7 +9002,7 @@
     <associate|auto-227|<tuple|E.5.15|77>>
     <associate|auto-228|<tuple|E.5.15.1|77>>
     <associate|auto-229|<tuple|E.6|78>>
-    <associate|auto-23|<tuple|1.13|15>>
+    <associate|auto-23|<tuple|1.13|13>>
     <associate|auto-230|<tuple|E.6.1|78>>
     <associate|auto-231|<tuple|E.6.1.1|78>>
     <associate|auto-232|<tuple|E.6.2|78>>
@@ -9013,7 +9013,7 @@
     <associate|auto-237|<tuple|E.7.2|79>>
     <associate|auto-238|<tuple|E.7.2.1|79>>
     <associate|auto-239|<tuple|E.7.3|79>>
-    <associate|auto-24|<tuple|1.13|15>>
+    <associate|auto-24|<tuple|1.13|13>>
     <associate|auto-240|<tuple|E.7.3.1|79>>
     <associate|auto-241|<tuple|E.7.4|79>>
     <associate|auto-242|<tuple|E.7.4.1|79>>
@@ -9024,7 +9024,7 @@
     <associate|auto-247|<tuple|E.8.1.1|80>>
     <associate|auto-248|<tuple|E.8.2|80>>
     <associate|auto-249|<tuple|E.8.2.1|80>>
-    <associate|auto-25|<tuple|1.14|15>>
+    <associate|auto-25|<tuple|1.14|13>>
     <associate|auto-250|<tuple|E.9|80>>
     <associate|auto-251|<tuple|E.4|81>>
     <associate|auto-252|<tuple|E.9.1|81>>
@@ -9035,7 +9035,7 @@
     <associate|auto-257|<tuple|F.1.2|83>>
     <associate|auto-258|<tuple|F.1.3|84>>
     <associate|auto-259|<tuple|F.1.4|84>>
-    <associate|auto-26|<tuple|1.15|15>>
+    <associate|auto-26|<tuple|1.15|13>>
     <associate|auto-260|<tuple|F.1.5|84>>
     <associate|auto-261|<tuple|F.1.6|84>>
     <associate|auto-262|<tuple|F.1.7|85>>
@@ -9046,7 +9046,7 @@
     <associate|auto-267|<tuple|F.1.12|87>>
     <associate|auto-268|<tuple|F.1.13|87>>
     <associate|auto-269|<tuple|F.1.14|88>>
-    <associate|auto-27|<tuple|1.15|15>>
+    <associate|auto-27|<tuple|1.15|13>>
     <associate|auto-270|<tuple|F.1.15|88>>
     <associate|auto-271|<tuple|F.1.15.1|88>>
     <associate|auto-272|<tuple|F.1.15.2|89>>
@@ -9057,7 +9057,7 @@
     <associate|auto-277|<tuple|F.1.16.3|90>>
     <associate|auto-278|<tuple|F.1.16.4|90>>
     <associate|auto-279|<tuple|F.1.16.5|91>>
-    <associate|auto-28|<tuple|2|17>>
+    <associate|auto-28|<tuple|2|15>>
     <associate|auto-280|<tuple|F.1.16.6|91>>
     <associate|auto-281|<tuple|F.1.17|91>>
     <associate|auto-282|<tuple|F.1.17.1|92>>
@@ -9068,7 +9068,7 @@
     <associate|auto-287|<tuple|F.1.17.6|93>>
     <associate|auto-288|<tuple|F.1.17.7|93>>
     <associate|auto-289|<tuple|F.1.17.8|94>>
-    <associate|auto-29|<tuple|2.1|17>>
+    <associate|auto-29|<tuple|2.1|15>>
     <associate|auto-290|<tuple|F.1.17.9|94>>
     <associate|auto-291|<tuple|F.1.17.10|95>>
     <associate|auto-292|<tuple|F.1.17.11|95>>
@@ -9079,8 +9079,8 @@
     <associate|auto-297|<tuple|F.1.18|97>>
     <associate|auto-298|<tuple|F.1.18.1|97>>
     <associate|auto-299|<tuple|F.1.19|98>>
-    <associate|auto-3|<tuple|1.2|13>>
-    <associate|auto-30|<tuple|2.1.1|17>>
+    <associate|auto-3|<tuple|1.2|11>>
+    <associate|auto-30|<tuple|2.1.1|15>>
     <associate|auto-300|<tuple|F.1.19.1|98>>
     <associate|auto-301|<tuple|F.1.19.2|98>>
     <associate|auto-302|<tuple|F.1.20|98>>
@@ -9091,7 +9091,7 @@
     <associate|auto-307|<tuple|G.1|99>>
     <associate|auto-308|<tuple|G.1|99>>
     <associate|auto-309|<tuple|G.2|100>>
-    <associate|auto-31|<tuple|2.1|17>>
+    <associate|auto-31|<tuple|2.1|15>>
     <associate|auto-310|<tuple|G.2.1|100>>
     <associate|auto-311|<tuple|G.1|100>>
     <associate|auto-312|<tuple|G.2.2|100>>
@@ -9102,7 +9102,7 @@
     <associate|auto-317|<tuple|G.2.6|102>>
     <associate|auto-318|<tuple|G.2.7|102>>
     <associate|auto-319|<tuple|G.3|102>>
-    <associate|auto-32|<tuple|2.1.2|17>>
+    <associate|auto-32|<tuple|2.1.2|15>>
     <associate|auto-320|<tuple|G.4|102>>
     <associate|auto-321|<tuple|G.5|103>>
     <associate|auto-322|<tuple|G.6|103>>
@@ -9113,70 +9113,70 @@
     <associate|auto-327|<tuple|G.2.10|104>>
     <associate|auto-328|<tuple|G.2.10|105>>
     <associate|auto-329|<tuple|G.2.10|107>>
-    <associate|auto-33|<tuple|2.1.3|18>>
+    <associate|auto-33|<tuple|2.1.3|16>>
     <associate|auto-330|<tuple|Tec19|109>>
-    <associate|auto-34|<tuple|2.1.4|20>>
-    <associate|auto-35|<tuple|3|23>>
-    <associate|auto-36|<tuple|3.1|23>>
-    <associate|auto-37|<tuple|3.1.1|23>>
-    <associate|auto-38|<tuple|3.1.2|24>>
-    <associate|auto-39|<tuple|3.1.2.1|24>>
-    <associate|auto-4|<tuple|1.2|14>>
-    <associate|auto-40|<tuple|3.1.2.2|24>>
-    <associate|auto-41|<tuple|3.1.2.3|25>>
-    <associate|auto-42|<tuple|3.2|25>>
-    <associate|auto-43|<tuple|3.2.1|25>>
-    <associate|auto-44|<tuple|3.2.2|25>>
-    <associate|auto-45|<tuple|3.2.2.1|25>>
-    <associate|auto-46|<tuple|3.2.3|25>>
-    <associate|auto-47|<tuple|3.2.3|25>>
-    <associate|auto-48|<tuple|3.2.3|25>>
-    <associate|auto-49|<tuple|3.2.3|25>>
-    <associate|auto-5|<tuple|1.4|14>>
-    <associate|auto-50|<tuple|<with|mode|<quote|math>|<rigid|->>|26>>
-    <associate|auto-51|<tuple|3.2.3.1|27>>
-    <associate|auto-52|<tuple|3.1|27>>
-    <associate|auto-53|<tuple|3.3|27>>
-    <associate|auto-54|<tuple|3.3.1|27>>
-    <associate|auto-55|<tuple|3.3.1.1|27>>
-    <associate|auto-56|<tuple|3.2|28>>
-    <associate|auto-57|<tuple|3.3.1.2|28>>
-    <associate|auto-58|<tuple|3.3.1.3|29>>
-    <associate|auto-59|<tuple|3.3.2|29>>
-    <associate|auto-6|<tuple|1.7|14>>
-    <associate|auto-60|<tuple|3.3.3|29>>
-    <associate|auto-61|<tuple|3.3.4|30>>
-    <associate|auto-62|<tuple|4|31>>
-    <associate|auto-63|<tuple|4.1|31>>
-    <associate|auto-64|<tuple|4.2|31>>
-    <associate|auto-65|<tuple|4.3|32>>
-    <associate|auto-66|<tuple|4.3.1|32>>
-    <associate|auto-67|<tuple|4.3.2|32>>
-    <associate|auto-68|<tuple|4.4|33>>
-    <associate|auto-69|<tuple|4.4.1|33>>
-    <associate|auto-7|<tuple|1.7|14>>
-    <associate|auto-70|<tuple|4.4.2|33>>
-    <associate|auto-71|<tuple|5|35>>
-    <associate|auto-72|<tuple|5.1|35>>
-    <associate|auto-73|<tuple|5.1.1|35>>
-    <associate|auto-74|<tuple|5.1.2|35>>
-    <associate|auto-75|<tuple|5.1|36>>
-    <associate|auto-76|<tuple|5.2|37>>
-    <associate|auto-77|<tuple|5.2.1|37>>
-    <associate|auto-78|<tuple|5.2.2|37>>
-    <associate|auto-79|<tuple|5.2.3|38>>
-    <associate|auto-8|<tuple|1.7|14>>
-    <associate|auto-80|<tuple|5.2.4|39>>
-    <associate|auto-81|<tuple|5.2.5|40>>
-    <associate|auto-82|<tuple|5.2.6|40>>
-    <associate|auto-83|<tuple|5.2.7|41>>
-    <associate|auto-84|<tuple|5.3|42>>
-    <associate|auto-85|<tuple|5.3.1|42>>
-    <associate|auto-86|<tuple|5.3.2|44>>
-    <associate|auto-87|<tuple|5.3.3|45>>
-    <associate|auto-88|<tuple|5.3.4|45>>
-    <associate|auto-89|<tuple|5.4|46>>
-    <associate|auto-9|<tuple|1.9|15>>
+    <associate|auto-34|<tuple|2.1.4|18>>
+    <associate|auto-35|<tuple|3|21>>
+    <associate|auto-36|<tuple|3.1|21>>
+    <associate|auto-37|<tuple|3.1.1|21>>
+    <associate|auto-38|<tuple|3.1.2|22>>
+    <associate|auto-39|<tuple|3.1.2.1|22>>
+    <associate|auto-4|<tuple|1.2|12>>
+    <associate|auto-40|<tuple|3.1.2.2|22>>
+    <associate|auto-41|<tuple|3.1.2.3|23>>
+    <associate|auto-42|<tuple|3.2|23>>
+    <associate|auto-43|<tuple|3.2.1|23>>
+    <associate|auto-44|<tuple|3.2.2|23>>
+    <associate|auto-45|<tuple|3.2.2.1|23>>
+    <associate|auto-46|<tuple|3.2.3|23>>
+    <associate|auto-47|<tuple|3.2.3|23>>
+    <associate|auto-48|<tuple|3.2.3|23>>
+    <associate|auto-49|<tuple|3.2.3|23>>
+    <associate|auto-5|<tuple|1.4|12>>
+    <associate|auto-50|<tuple|<with|mode|<quote|math>|<rigid|->>|24>>
+    <associate|auto-51|<tuple|3.2.3.1|24>>
+    <associate|auto-52|<tuple|3.1|25>>
+    <associate|auto-53|<tuple|3.3|25>>
+    <associate|auto-54|<tuple|3.3.1|25>>
+    <associate|auto-55|<tuple|3.3.1.1|25>>
+    <associate|auto-56|<tuple|3.2|26>>
+    <associate|auto-57|<tuple|3.3.1.2|26>>
+    <associate|auto-58|<tuple|3.3.1.3|26>>
+    <associate|auto-59|<tuple|3.3.2|27>>
+    <associate|auto-6|<tuple|1.7|12>>
+    <associate|auto-60|<tuple|3.3.3|27>>
+    <associate|auto-61|<tuple|3.3.4|27>>
+    <associate|auto-62|<tuple|4|29>>
+    <associate|auto-63|<tuple|4.1|29>>
+    <associate|auto-64|<tuple|4.2|29>>
+    <associate|auto-65|<tuple|4.3|30>>
+    <associate|auto-66|<tuple|4.3.1|30>>
+    <associate|auto-67|<tuple|4.3.2|30>>
+    <associate|auto-68|<tuple|4.4|31>>
+    <associate|auto-69|<tuple|4.4.1|31>>
+    <associate|auto-7|<tuple|1.7|12>>
+    <associate|auto-70|<tuple|4.4.2|31>>
+    <associate|auto-71|<tuple|5|33>>
+    <associate|auto-72|<tuple|5.1|33>>
+    <associate|auto-73|<tuple|5.1.1|33>>
+    <associate|auto-74|<tuple|5.1.2|33>>
+    <associate|auto-75|<tuple|5.1|34>>
+    <associate|auto-76|<tuple|5.2|35>>
+    <associate|auto-77|<tuple|5.2.1|35>>
+    <associate|auto-78|<tuple|5.2.2|35>>
+    <associate|auto-79|<tuple|5.2.3|36>>
+    <associate|auto-8|<tuple|1.7|12>>
+    <associate|auto-80|<tuple|5.2.4|37>>
+    <associate|auto-81|<tuple|5.2.5|38>>
+    <associate|auto-82|<tuple|5.2.6|38>>
+    <associate|auto-83|<tuple|5.2.7|39>>
+    <associate|auto-84|<tuple|5.3|40>>
+    <associate|auto-85|<tuple|5.3.1|40>>
+    <associate|auto-86|<tuple|5.3.2|42>>
+    <associate|auto-87|<tuple|5.3.3|43>>
+    <associate|auto-88|<tuple|5.3.4|43>>
+    <associate|auto-89|<tuple|5.4|44>>
+    <associate|auto-9|<tuple|1.9|13>>
     <associate|auto-90|<tuple|A|47>>
     <associate|auto-91|<tuple|A.1|47>>
     <associate|auto-92|<tuple|A.2|47>>
@@ -9199,65 +9199,65 @@
     <associate|bib-stewart_grandpa:_2019|<tuple|Ste19|107>>
     <associate|bib-w3f_research_group_blind_2019|<tuple|Gro19|107>>
     <associate|bib-web3.0_technologies_foundation_polkadot_2020|<tuple|Fou20|107>>
-    <associate|block|<tuple|3.3.1.1|27>>
-    <associate|chap-consensu|<tuple|5|35>>
-    <associate|chap-state-spec|<tuple|2|17>>
-    <associate|chap-state-transit|<tuple|3|23>>
+    <associate|block|<tuple|3.3.1.1|25>>
+    <associate|chap-consensu|<tuple|5|33>>
+    <associate|chap-state-spec|<tuple|2|15>>
+    <associate|chap-state-transit|<tuple|3|21>>
     <associate|defn-account-key|<tuple|A.1|47>>
-    <associate|defn-authority-list|<tuple|5.1|35>>
-    <associate|defn-babe-header|<tuple|5.12|39>>
-    <associate|defn-babe-seal|<tuple|5.13|39>>
-    <associate|defn-bit-rep|<tuple|1.6|14>>
-    <associate|defn-block-body|<tuple|3.9|29>>
+    <associate|defn-authority-list|<tuple|5.1|33>>
+    <associate|defn-babe-header|<tuple|5.12|37>>
+    <associate|defn-babe-seal|<tuple|5.13|37>>
+    <associate|defn-bit-rep|<tuple|1.6|12>>
+    <associate|defn-block-body|<tuple|3.9|26>>
     <associate|defn-block-data|<tuple|D.2|57>>
-    <associate|defn-block-header|<tuple|3.6|27>>
-    <associate|defn-block-header-hash|<tuple|3.8|28>>
-    <associate|defn-block-signature|<tuple|5.13|39>>
-    <associate|defn-block-time|<tuple|5.10|38>>
-    <associate|defn-block-tree|<tuple|1.11|15>>
-    <associate|defn-chain-subchain|<tuple|1.13|15>>
+    <associate|defn-block-header|<tuple|3.6|25>>
+    <associate|defn-block-header-hash|<tuple|3.8|26>>
+    <associate|defn-block-signature|<tuple|5.13|37>>
+    <associate|defn-block-time|<tuple|5.10|36>>
+    <associate|defn-block-tree|<tuple|1.11|13>>
+    <associate|defn-chain-subchain|<tuple|1.13|13>>
     <associate|defn-child-storage-definition|<tuple|E.4|62>>
     <associate|defn-child-storage-type|<tuple|E.3|62>>
     <associate|defn-child-type|<tuple|E.5|62>>
-    <associate|defn-children-bitmap|<tuple|2.10|21>>
-    <associate|defn-consensus-message-digest|<tuple|5.2|35>>
+    <associate|defn-children-bitmap|<tuple|2.10|19>>
+    <associate|defn-consensus-message-digest|<tuple|5.2|33>>
     <associate|defn-controller-key|<tuple|A.3|48>>
-    <associate|defn-digest|<tuple|3.7|28>>
+    <associate|defn-digest|<tuple|3.7|26>>
     <associate|defn-ecdsa-verify-error|<tuple|E.7|66>>
-    <associate|defn-epoch-slot|<tuple|5.5|37>>
-    <associate|defn-epoch-subchain|<tuple|5.7|37>>
-    <associate|defn-finalized-block|<tuple|5.27|46>>
+    <associate|defn-epoch-slot|<tuple|5.5|35>>
+    <associate|defn-epoch-subchain|<tuple|5.7|35>>
+    <associate|defn-finalized-block|<tuple|5.27|44>>
     <associate|defn-genesis-header|<tuple|C.1|53>>
-    <associate|defn-grandpa-completable|<tuple|5.23|44>>
-    <associate|defn-grandpa-justification|<tuple|5.25|44>>
+    <associate|defn-grandpa-completable|<tuple|5.23|42>>
+    <associate|defn-grandpa-justification|<tuple|5.25|42>>
     <associate|defn-hex-encoding|<tuple|B.12|51>>
     <associate|defn-http-error|<tuple|E.11|72>>
     <associate|defn-http-return-value|<tuple|F.3|92>>
     <associate|defn-http-status-codes|<tuple|E.10|72>>
-    <associate|defn-index-function|<tuple|2.7|19>>
-    <associate|defn-inherent-data|<tuple|3.5|27>>
+    <associate|defn-index-function|<tuple|2.7|17>>
+    <associate|defn-inherent-data|<tuple|3.5|25>>
     <associate|defn-invalid-transaction|<tuple|G.3|103>>
     <associate|defn-key-type-id|<tuple|E.6|66>>
-    <associate|defn-little-endian|<tuple|1.7|14>>
+    <associate|defn-little-endian|<tuple|1.7|12>>
     <associate|defn-local-storage|<tuple|E.9|72>>
     <associate|defn-logging-log-level|<tuple|E.12|80>>
-    <associate|defn-longest-chain|<tuple|1.14|15>>
-    <associate|defn-merkle-value|<tuple|2.12|21>>
-    <associate|defn-node-header|<tuple|2.9|19>>
-    <associate|defn-node-key|<tuple|2.6|19>>
-    <associate|defn-node-subvalue|<tuple|2.11|21>>
-    <associate|defn-node-value|<tuple|2.8|19>>
-    <associate|defn-nodetype|<tuple|2.4|18>>
+    <associate|defn-longest-chain|<tuple|1.14|13>>
+    <associate|defn-merkle-value|<tuple|2.12|19>>
+    <associate|defn-node-header|<tuple|2.9|17>>
+    <associate|defn-node-key|<tuple|2.6|17>>
+    <associate|defn-node-subvalue|<tuple|2.11|19>>
+    <associate|defn-node-value|<tuple|2.8|17>>
+    <associate|defn-nodetype|<tuple|2.4|16>>
     <associate|defn-offchain-local-storage|<tuple|F.2|91>>
     <associate|defn-offchain-persistent-storage|<tuple|F.1|91>>
     <associate|defn-option-type|<tuple|B.4|49>>
-    <associate|defn-path-graph|<tuple|1.2|14>>
+    <associate|defn-path-graph|<tuple|1.2|12>>
     <associate|defn-persistent-storage|<tuple|E.8|72>>
-    <associate|defn-pruned-tree|<tuple|1.12|15>>
-    <associate|defn-radix-tree|<tuple|1.3|14>>
+    <associate|defn-pruned-tree|<tuple|1.12|13>>
+    <associate|defn-radix-tree|<tuple|1.3|12>>
     <associate|defn-result-type|<tuple|B.5|50>>
     <associate|defn-rt-core-version|<tuple|G.2.1|100>>
-    <associate|defn-runtime|<tuple|<with|mode|<quote|math>|\<bullet\>>|13>>
+    <associate|defn-runtime|<tuple|<with|mode|<quote|math>|\<bullet\>>|12>>
     <associate|defn-runtime-pointer|<tuple|E.2|59>>
     <associate|defn-sc-len-encoding|<tuple|B.11|51>>
     <associate|defn-scale-byte-array|<tuple|B.1|49>>
@@ -9267,55 +9267,55 @@
     <associate|defn-scale-tuple|<tuple|B.2|49>>
     <associate|defn-scale-variable-type|<tuple|B.6|50>>
     <associate|defn-session-key|<tuple|A.4|48>>
-    <associate|defn-set-state-at|<tuple|3.10|30>>
-    <associate|defn-slot-offset|<tuple|5.11|38>>
+    <associate|defn-set-state-at|<tuple|3.10|28>>
+    <associate|defn-slot-offset|<tuple|5.11|36>>
     <associate|defn-stash-key|<tuple|A.2|47>>
-    <associate|defn-state-machine|<tuple|1.1|13>>
-    <associate|defn-stored-value|<tuple|2.1|17>>
-    <associate|defn-transaction-queue|<tuple|3.4|26>>
+    <associate|defn-state-machine|<tuple|1.1|11>>
+    <associate|defn-stored-value|<tuple|2.1|15>>
+    <associate|defn-transaction-queue|<tuple|3.4|23>>
     <associate|defn-transaction-validity-error|<tuple|G.2|102>>
-    <associate|defn-unix-time|<tuple|1.10|15>>
+    <associate|defn-unix-time|<tuple|1.10|13>>
     <associate|defn-unknown-transaction|<tuple|G.4|103>>
     <associate|defn-valid-transaction|<tuple|G.1|102>>
     <associate|defn-varrying-data-type|<tuple|B.3|49>>
-    <associate|defn-vote|<tuple|5.16|43>>
-    <associate|defn-winning-threshold|<tuple|5.8|37>>
-    <associate|key-encode-in-trie|<tuple|2.1|18>>
-    <associate|network-protocol|<tuple|4|31>>
-    <associate|nota-call-into-runtime|<tuple|3.2|24>>
+    <associate|defn-vote|<tuple|5.16|41>>
+    <associate|defn-winning-threshold|<tuple|5.8|35>>
+    <associate|key-encode-in-trie|<tuple|2.1|16>>
+    <associate|network-protocol|<tuple|4|29>>
+    <associate|nota-call-into-runtime|<tuple|3.2|22>>
     <associate|nota-re-api-at-state|<tuple|E.1|59>>
-    <associate|nota-runtime-code-at-state|<tuple|3.1|24>>
-    <associate|note-slot|<tuple|5.6|37>>
-    <associate|sect-authority-set|<tuple|5.1.1|35>>
-    <associate|sect-babe|<tuple|5.2|37>>
+    <associate|nota-runtime-code-at-state|<tuple|3.1|22>>
+    <associate|note-slot|<tuple|5.6|35>>
+    <associate|sect-authority-set|<tuple|5.1.1|33>>
+    <associate|sect-babe|<tuple|5.2|35>>
     <associate|sect-blake2|<tuple|A.2|47>>
-    <associate|sect-block-body|<tuple|3.3.1.3|29>>
-    <associate|sect-block-building|<tuple|5.2.7|41>>
-    <associate|sect-block-finalization|<tuple|5.4|46>>
-    <associate|sect-block-format|<tuple|3.3.1|27>>
-    <associate|sect-block-production|<tuple|5.2|37>>
-    <associate|sect-block-submission|<tuple|3.3.2|29>>
-    <associate|sect-block-validation|<tuple|3.3.3|29>>
+    <associate|sect-block-body|<tuple|3.3.1.3|26>>
+    <associate|sect-block-building|<tuple|5.2.7|39>>
+    <associate|sect-block-finalization|<tuple|5.4|44>>
+    <associate|sect-block-format|<tuple|3.3.1|25>>
+    <associate|sect-block-production|<tuple|5.2|35>>
+    <associate|sect-block-submission|<tuple|3.3.2|27>>
+    <associate|sect-block-validation|<tuple|3.3.3|27>>
     <associate|sect-certifying-keys|<tuple|A.5.5|48>>
-    <associate|sect-consensus-message-digest|<tuple|5.1.2|35>>
+    <associate|sect-consensus-message-digest|<tuple|5.1.2|33>>
     <associate|sect-controller-settings|<tuple|A.5.4|48>>
     <associate|sect-creating-controller-key|<tuple|A.5.2|48>>
     <associate|sect-cryptographic-keys|<tuple|A.5|47>>
-    <associate|sect-defn-conv|<tuple|1.2|13>>
+    <associate|sect-defn-conv|<tuple|1.2|11>>
     <associate|sect-designating-proxy|<tuple|A.5.3|48>>
     <associate|sect-encoding|<tuple|B|49>>
-    <associate|sect-entries-into-runtime|<tuple|3.1|23>>
-    <associate|sect-epoch-randomness|<tuple|5.2.5|40>>
-    <associate|sect-extrinsics|<tuple|3.2|25>>
-    <associate|sect-finality|<tuple|5.3|42>>
+    <associate|sect-entries-into-runtime|<tuple|3.1|21>>
+    <associate|sect-epoch-randomness|<tuple|5.2.5|38>>
+    <associate|sect-extrinsics|<tuple|3.2|23>>
+    <associate|sect-finality|<tuple|5.3|40>>
     <associate|sect-genesis-block|<tuple|C|53>>
     <associate|sect-hash-functions|<tuple|A.1|47>>
     <associate|sect-int-encoding|<tuple|B.1.1|50>>
-    <associate|sect-justified-block-header|<tuple|3.3.1.2|28>>
+    <associate|sect-justified-block-header|<tuple|3.3.1.2|26>>
     <associate|sect-list-of-runtime-entries|<tuple|G.1|99>>
-    <associate|sect-loading-runtime-code|<tuple|3.1.1|23>>
-    <associate|sect-managing-multiple-states|<tuple|3.3.4|30>>
-    <associate|sect-merkl-proof|<tuple|2.1.4|20>>
+    <associate|sect-loading-runtime-code|<tuple|3.1.1|21>>
+    <associate|sect-managing-multiple-states|<tuple|3.3.4|27>>
+    <associate|sect-merkl-proof|<tuple|2.1.4|18>>
     <associate|sect-message-detail|<tuple|D.1|55>>
     <associate|sect-msg-block-announce|<tuple|D.1.4|57>>
     <associate|sect-msg-block-request|<tuple|D.1.2|56>>
@@ -9323,35 +9323,35 @@
     <associate|sect-msg-consensus|<tuple|D.1.6|58>>
     <associate|sect-msg-status|<tuple|D.1.1|55>>
     <associate|sect-msg-transactions|<tuple|D.1.5|57>>
-    <associate|sect-network-interactions|<tuple|4|31>>
+    <associate|sect-network-interactions|<tuple|Tec19|29>>
     <associate|sect-network-messages|<tuple|D|55>>
     <associate|sect-randomness|<tuple|A.3|47>>
-    <associate|sect-re-api|<tuple|F|83>>
+    <associate|sect-re-api|<tuple|Tec19|83>>
     <associate|sect-rte-babeapi-epoch|<tuple|G.2.5|101>>
     <associate|sect-rte-grandpa-auth|<tuple|G.2.6|102>>
     <associate|sect-rte-hash-and-length|<tuple|G.2.4|101>>
     <associate|sect-rte-validate-transaction|<tuple|G.2.7|102>>
     <associate|sect-runtime-entries|<tuple|G|99>>
-    <associate|sect-runtime-return-value|<tuple|3.1.2.3|25>>
-    <associate|sect-runtime-send-args-to-runtime-enteries|<tuple|3.1.2.2|24>>
+    <associate|sect-runtime-return-value|<tuple|3.1.2.3|23>>
+    <associate|sect-runtime-send-args-to-runtime-enteries|<tuple|3.1.2.2|22>>
     <associate|sect-scale-codec|<tuple|B.1|49>>
     <associate|sect-set-storage|<tuple|F.1.1|83>>
     <associate|sect-staking-funds|<tuple|A.5.1|48>>
-    <associate|sect-state-replication|<tuple|3.3|27>>
-    <associate|sect-state-storage|<tuple|2.1|17>>
-    <associate|sect-state-storage-trie-structure|<tuple|2.1.3|18>>
-    <associate|sect-verifying-authorship|<tuple|5.2.6|40>>
+    <associate|sect-state-replication|<tuple|3.3|25>>
+    <associate|sect-state-storage|<tuple|2.1|15>>
+    <associate|sect-state-storage-trie-structure|<tuple|2.1.3|16>>
+    <associate|sect-verifying-authorship|<tuple|5.2.6|38>>
     <associate|sect-vrf|<tuple|A.4|47>>
-    <associate|sect_polkadot_communication_substream|<tuple|4.4.2|33>>
-    <associate|sect_transport_protocol|<tuple|4.3|32>>
-    <associate|slot-time-cal-tail|<tuple|5.9|38>>
+    <associate|sect_polkadot_communication_substream|<tuple|4.4.2|31>>
+    <associate|sect_transport_protocol|<tuple|4.3|30>>
+    <associate|slot-time-cal-tail|<tuple|5.9|36>>
     <associate|snippet-runtime-enteries|<tuple|G.1|99>>
     <associate|tabl-account-key-schemes|<tuple|A.1|47>>
     <associate|tabl-block-attributes|<tuple|D.3|56>>
-    <associate|tabl-consensus-messages|<tuple|5.1|36>>
-    <associate|tabl-digest-items|<tuple|3.2|28>>
+    <associate|tabl-consensus-messages|<tuple|5.1|34>>
+    <associate|tabl-digest-items|<tuple|3.2|26>>
     <associate|tabl-genesis-header|<tuple|C.1|53>>
-    <associate|tabl-inherent-data|<tuple|3.1|27>>
+    <associate|tabl-inherent-data|<tuple|3.1|25>>
     <associate|tabl-message-types|<tuple|D.1|55>>
     <associate|tabl-node-role|<tuple|D.2|56>>
     <associate|tabl-session-keys|<tuple|A.2|48>>

--- a/runtime-environment-spec/polkadot_re_spec.tm
+++ b/runtime-environment-spec/polkadot_re_spec.tm
@@ -354,8 +354,7 @@
     <no-break><pageref|auto-119>>
 
     <vspace*|1fn><with|font-series|bold|math-font-series|bold|font-shape|small-caps|Appendix
-    E.<space|2spc>Runtime Environment API>
-    <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+    E.<space|2spc>Polkadot Host API> <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <pageref|auto-120><vspace|0.5fn>
 
     E.1.<space|2spc>Storage <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
@@ -866,7 +865,7 @@
     <no-break><pageref|auto-253>>
 
     <vspace*|1fn><with|font-series|bold|math-font-series|bold|font-shape|small-caps|Appendix
-    F.<space|2spc>Legacy Runtime Environment API>
+    F.<space|2spc>Legacy Polkadot Host API>
     <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
     <pageref|auto-254><vspace|0.5fn>
 
@@ -8815,11 +8814,11 @@
   </bibliography>
 
   <\the-index|idx>
-    <index+1|Transaction Message|<pageref|auto-47>\U<pageref|auto-50>>
+    <index-1|Transaction Message|<pageref|auto-47>\U<pageref|auto-50>>
 
-    <index+1|transaction pool|<pageref|auto-48>>
+    <index-1|transaction pool|<pageref|auto-48>>
 
-    <index+1|transaction queue|<pageref|auto-49>>
+    <index-1|transaction queue|<pageref|auto-49>>
   </the-index>
 </body>
 
@@ -9917,8 +9916,7 @@
       <no-break><pageref|auto-119>>
 
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|font-shape|<quote|small-caps>|Appendix
-      E.<space|2spc>Runtime Environment API>
-      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      E.<space|2spc>Polkadot Host API> <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <pageref|auto-120><vspace|0.5fn>
 
       E.1.<space|2spc>Storage <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
@@ -10429,7 +10427,7 @@
       <no-break><pageref|auto-253>>
 
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|font-shape|<quote|small-caps>|Appendix
-      F.<space|2spc>Legacy Runtime Environment API>
+      F.<space|2spc>Legacy Polkadot Host API>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <pageref|auto-254><vspace|0.5fn>
 

--- a/runtime-environment-spec/polkadot_re_spec.tm
+++ b/runtime-environment-spec/polkadot_re_spec.tm
@@ -1,4 +1,4 @@
-<TeXmacs|1.99.12>
+<TeXmacs|1.99.11>
 
 <style|<tuple|tmbook|std-latex|algorithmacs-style|old-dots>>
 
@@ -35,7 +35,7 @@
     \;
   </hide-preamble>
 
-  <doc-data|<doc-title|Polkadot Runtime Environment<next-line><with|font-size|1.41|Protocol
+  <doc-data|<doc-title|Polkadot Host<next-line><with|font-size|1.41|Protocol
   Specification>>|<doc-date|<date|>>>
 
   <\table-of-contents|toc>
@@ -1944,10 +1944,9 @@
   <em|extrinsics>. In Polkadot, the execution logic of the state-transition
   function is encapsulated in Runtime as defined in Definition
   <reference|defn-state-machine>. Runtime is presented as a Wasm blob in
-  order to be easily upgradable. Nonetheless, the Polkadot Runtime
-  Environment needs to be in constant interaction with Runtime. The detail of
-  such interaction is further described in Section
-  <reference|sect-entries-into-runtime>.
+  order to be easily upgradable. Nonetheless, the Polkadot Host needs to be
+  in constant interaction with Runtime. The detail of such interaction is
+  further described in Section <reference|sect-entries-into-runtime>.
 
   In Section <reference|sect-extrinsics>, we specify the procedure of the
   process where the extrinsics are submitted, pre-processed and validated by
@@ -4187,10 +4186,10 @@
     </big-table>
   </definition>
 
-  Session keys must be accessible by certain Runtime Environment APIs defined
-  in Appendix <reference|sect-re-api>. Session keys are <em|not> meant to
-  control the majority of the users' funds and should only be used for their
-  intended purpose. <todo|key managing fund need to be defined>
+  Session keys must be accessible by certain Host APIs defined in Appendix
+  <reference|sect-re-api>. Session keys are <em|not> meant to control the
+  majority of the users' funds and should only be used for their intended
+  purpose. <todo|key managing fund need to be defined>
 
   <subsection|Holding and staking funds><label|sect-staking-funds>
 
@@ -4773,13 +4772,13 @@
 
   \;
 
-  <appendix|Runtime Environment API><label|appendix-e>
+  <appendix|Host API><label|appendix-e>
 
-  The Runtime Environment API is a set of functions that Polkadot RE exposes
-  to Runtime to access external functions needed for various reasons, such as
-  the Storage of the content, access and manipulation, memory allocation, and
-  also efficiency. The encoding of each data type is specified or referenced
-  in this section. If the encoding is not mentioned, then the default Wasm
+  The Host API is a set of functions that Polkadot RE exposes to Runtime to
+  access external functions needed for various reasons, such as the Storage
+  of the content, access and manipulation, memory allocation, and also
+  efficiency. The encoding of each data type is specified or referenced in
+  this section. If the encoding is not mentioned, then the default Wasm
   encoding is used, such as little-endian byte ordering for integers.
 
   <\notation>
@@ -4795,7 +4794,7 @@
     integers in which the least significant one indicates the pointer to the
     memory buffer. The most significant one provides the size of the buffer.
     This pointer is the primary way to exchange data of arbitrary sizes
-    between the Runtime and the Runtime Environment.
+    between the Runtime and the Host.
   </definition>
 
   \ The functions are specified in each subsequent subsection for each
@@ -6718,14 +6717,14 @@
     <reference|defn-runtime-pointer> indicating the log message.
   </itemize>
 
-  <appendix|Legacy Runtime Environment API<label|sect-re-api>>
+  <appendix|Legacy Host API<label|sect-re-api>>
 
   \;
 
-  The Legacy Runtime Environments APIs were exceeded and replaces by the
-  current API as described in Appendix <reference|appendix-e>. Those legacy
-  functions are only required for executing Runtimes prior the official
-  Polkadot Runtime, such as the Kusama test network.
+  The Legacy Host APIs were exceeded and replaces by the current API as
+  described in Appendix <reference|appendix-e>. Those legacy functions are
+  only required for executing Runtimes prior the official Polkadot Runtime,
+  such as the Kusama test network.
 
   \;
 

--- a/runtime-environment-spec/polkadot_re_spec.tm
+++ b/runtime-environment-spec/polkadot_re_spec.tm
@@ -35,7 +35,7 @@
     \;
   </hide-preamble>
 
-  <doc-data|<doc-title|Polkadot Host<next-line><with|font-size|1.41|Protocol
+  <doc-data|<doc-title|The Polkadot Host<next-line><with|font-size|1.41|Protocol
   Specification>>|<doc-date|<date|>>>
 
   <\table-of-contents|toc>
@@ -1148,31 +1148,36 @@
   The Polkadot relay chain protocol, henceforward called <em|Polkadot
   protocol>, can itself be considered as a replicated state machine on its
   own. As such, the protocol can be specified by identifying the state
-  machine and the replication strategy.\ 
+  machine and the replication strategy.
+
+  \;
 
   From a more technical point of view, the Polkadot protocol has been divided
-  into two parts, the <em|Runtime> and the <em|Runtime environment> (RE). The
-  Runtime comprises most of the state transition logic for the Polkadot
-  protocol and is designed and expected to be upgradable as part of the state
-  transition process. The Runtime environment consists of parts of the
+  into two parts, the <em|Runtime> and the <em|Host>. The Runtime comprises
+  most of the state transition logic for the Polkadot protocol and is
+  designed and expected to be upgradable as part of the state transition
+  process. The Runtime environment consists of parts of the
   protocol,<space|1em>shared mostly among peer-to-peer decentralized
   cryptographically-secured transaction systems, i.e. blockchains whose
-  consensus system is based on the proof-of-stake. The RE is planned to be
-  stable and static for the lifetime duration of the Polkadot protocol.
+  consensus system is based on the proof-of-stake. The Polkadot Host is
+  planned to be stable and static for the lifetime duration of the Polkadot
+  protocol.
 
-  With the current document, we aim to specify the RE part of the Polkadot
-  protocol as a replicated state machine. After defining the basic terms in
-  Chapter 1, we proceed to specify the representation of a valid state of the
-  Protocol in Chapter <reference|chap-state-spec>. In Chapter
+  \;
+
+  With the current document, we aim to specify the Polkadot Host part of the
+  Polkadot protocol as a replicated state machine. After defining the basic
+  terms in Chapter 1, we proceed to specify the representation of a valid
+  state of the Protocol in Chapter <reference|chap-state-spec>. In Chapter
   <reference|chap-state-transit>, we identify the protocol states, by
   explaining the Polkadot state transition and discussing the detail based on
-  which Polkadot RE interacts with the state transition function, i.e.
+  which the Polkadot Host interacts with the state transition function, i.e.
   Runtime. Following, we specify the input messages triggering the state
   transition and the system behaviour. In Chapter <reference|chap-consensu>,
   we specify the consensus protocol, which is responsible for keeping all the
   replica in the same state. Finally, the initial state of the machine is
   identified and discussed in Appendix <reference|sect-genesis-block>. A
-  Polkadot RE implementation which conforms with this part of the
+  Polkadot Host implementation which conforms with this part of the
   specification should successfully be able to sync its states with the
   Polkadot network.
 
@@ -1470,7 +1475,7 @@
 
   <section|State Storage and Storage Trie><label|sect-state-storage>
 
-  For storing the state of the system, Polkadot RE implements a hash table
+  For storing the state of the system, Polkadot Host implements a hash table
   storage where the keys are used to access each data entry. There is no
   assumption either on the size of the key nor on the size of the data stored
   under them, besides the fact that they are byte arrays with specific upper
@@ -1479,11 +1484,11 @@
 
   <subsection|Accessing System Storage >
 
-  Polkadot RE implements various functions to facilitate access to the system
-  storage for the Runtime. See Section <reference|sect-entries-into-runtime>
-  for a an explaination of those functions. Here we formalize the access to
-  the storage when it is being directly accessed by Polkadot RE (in contrast
-  to Polkadot runtime).
+  The Polkadot Host implements various functions to facilitate access to the
+  system storage for the Runtime. See Section
+  <reference|sect-entries-into-runtime> for a an explaination of those
+  functions. Here we formalize the access to the storage when it is being
+  directly accessed by the Polkadot Host (in contrast to Polkadot runtime).
 
   <\definition>
     <label|defn-stored-value>The <glossary-explain|StoredValue|the function
@@ -1519,10 +1524,10 @@
 
   The Trie is used to compute the <em|state root>, <math|H<rsub|r>>, (see
   Definition <reference|defn-block-header>), whose purpose is to authenticate
-  the validity of the state database. Thus, Polkadot RE follows a rigorous
-  encoding algorithm to compute the values stored in the trie nodes to ensure
-  that the computed Merkle hash, <math|H<rsub|r>>, matches across the
-  Polkadot RE implementations.
+  the validity of the state database. Thus, the Polkadot Host follows a
+  rigorous encoding algorithm to compute the values stored in the trie nodes
+  to ensure that the computed Merkle hash, <math|H<rsub|r>>, matches across
+  the Polkadot Host implementations.
 
   The Trie is a <em|radix-16> tree as defined in Definition
   <reference|defn-radix-tree>. Each key value identifies a unique node in the
@@ -1963,8 +1968,8 @@
 
   Runtime as defined in Definition <reference|defn-runtime> is the code
   implementing the logic of the chain. This code is decoupled from the
-  Polkadot RE to make the Runtime easily upgradable without the need to
-  upgrade the Polkadot RE itself. The general procedure to interact with
+  Polkadot Host to make the Runtime easily upgradable without the need to
+  upgrade the Polkadot Host itself. The general procedure to interact with
   Runtime is described in Algorithm <reference|algo-runtime-interaction>.
 
   <\algorithm>
@@ -1992,7 +1997,7 @@
     </algorithmic>
   </algorithm>
 
-  In this section, we describe the details upon which the Polkadot RE is
+  In this section, we describe the details upon which the Polkadot Host is
   interacting with the Runtime. In particular, <name|Set-State-At> and
   <name|Call-Runtime-Entry> procedures called in Algorithm
   <reference|algo-runtime-interaction> are explained in Notation
@@ -2000,13 +2005,13 @@
   <reference|defn-set-state-at> respectively. <math|R<rsub|B>> is the Runtime
   code loaded from <math|\<cal-S\><rsub|B>>, as described in Notation
   <reference|nota-runtime-code-at-state>, and
-  <math|\<cal-R\>\<cal-E\><rsub|B>> is the Polkadot RE API, as described in
+  <math|\<cal-R\>\<cal-E\><rsub|B>> is the Polkadot Host API, as described in
   Notation <reference|nota-re-api-at-state>.
 
   <subsection|Loading the Runtime Code \ \ ><label|sect-loading-runtime-code>
 
-  Polkadot RE expects to receive the code for the Runtime of the chain as a
-  compiled WebAssembly (Wasm) Blob. The current runtime is stored in the
+  The Polkadot Host expects to receive the code for the Runtime of the chain
+  as a compiled WebAssembly (Wasm) Blob. The current runtime is stored in the
   state database under the key represented as a byte array:
 
   <\equation*>
@@ -2014,8 +2019,8 @@
   </equation*>
 
   which is the byte array of ASCII representation of string \P:code\Q (see
-  Section <reference|sect-genesis-block>). For any call to the Runtime,
-  Polkadot RE makes sure that it has the Runtime corresponding to the state
+  Section <reference|sect-genesis-block>). For any call to the Runtime, the
+  Polkadot Host makes sure that it has the Runtime corresponding to the state
   in which the entry has been called. This is, in part, because the calls to
   Runtime have potentially the ability to change the Runtime code and hence
   Runtime code is state sensitive. Accordingly, we introduce the following
@@ -2029,7 +2034,8 @@
 
   The initial runtime code of the chain is embedded as an extrinsics into the
   chain initialization JSON file (representing the genesis state) and is
-  submitted to Polkadot RE (see Section <reference|sect-genesis-block>).
+  submitted to the Polkadot Host (see Section
+  <reference|sect-genesis-block>).
 
   Subsequent calls to the runtime have the ability to, in turn, call the
   storage API (see Section <reference|sect-re-api>) to insert a new Wasm blob
@@ -2037,14 +2043,15 @@
 
   <subsection|Code Executor>
 
-  Polkadot RE provides a Wasm Virtual Machine (VM) to run the Runtime. The
-  Wasm VM exposes the Polkadot RE API to the Runtime, which, on its turn,
-  executes a call to the Runtime entries stored in the Wasm module. This part
-  of the Runtime environment is referred to as the <em|<strong|Executor>.>
+  The Polkadot Host provides a Wasm Virtual Machine (VM) to run the Runtime.
+  The Wasm VM exposes the Polkadot Host API to the Runtime, which, on its
+  turn, executes a call to the Runtime entries stored in the Wasm module.
+  This part of the Runtime environment is referred to as the
+  <em|<strong|Executor>.>
 
   Definition <reference|nota-call-into-runtime> introduces the notation for
-  calling the runtime entry which is used whenever an algorithm of Polkadot
-  RE needs to access the runtime.
+  calling the runtime entry which is used whenever an algorithm of the
+  Polkadot Host needs to access the runtime.
 
   <\notation>
     <label|nota-call-into-runtime> By
@@ -2065,16 +2072,16 @@
 
   <subsubsection|Access to Runtime API>
 
-  When Polkadot RE calls a Runtime entry it should make sure Runtime has
-  access to the all Polkadot Runtime API functions described in Appendix
+  When the Polkadot Host calls a Runtime entry it should make sure Runtime
+  has access to the all Polkadot Runtime API functions described in Appendix
   <reference|sect-runtime-entries>. This can be done for example by loading
   another Wasm module alongside the runtime which imports these functions
-  from Polkadot RE as host functions.
+  from the Polkadot Host as host functions.
 
   <subsubsection|Sending Arguments to Runtime
   ><label|sect-runtime-send-args-to-runtime-enteries>
 
-  In general, all data exchanged between Polkadot RE and the Runtime is
+  In general, all data exchanged between the Polkadot Host and the Runtime is
   encoded using SCALE codec described in Section
   <reference|sect-scale-codec>. As a Wasm function, all runtime entries have
   the following identical signatures:
@@ -2126,14 +2133,14 @@
     either of the key types described in section
     <reference|sect-cryptographic-keys> and broadcasted between the nodes.
     <strong|Inherents extrinsics> are unsigned extrinsics which are generated
-    by Polkadot RE and only included in the blocks produced by the node
+    by Polkadot Host and only included in the blocks produced by the node
     itself. They are broadcasted as part of the produced blocks rather than
     being gossiped as individual extrinsics.
   </definition>
 
-  Polkadot RE does not specify or limit the internals of each extrinsics and
-  those are dealt with by the Runtime. From Polkadot RE point of view, each
-  extrinsics is simply a SCALE-encoded blob (see Section
+  The Polkadot Host does not specify or limit the internals of each
+  extrinsics and those are dealt with by the Runtime. From the Polkadot Host
+  point of view, each extrinsics is simply a SCALE-encoded blob (see Section
   <reference|sect-scale-codec>).
 
   <subsection|Transactions>
@@ -2143,12 +2150,13 @@
   Transaction submission is made by sending a <em|Transactions> network
   message. The structure of this message is specified in Section
   <reference|sect-msg-transactions>. Upon receiving a Transactions message,
-  Polkadot RE decodes and decouples the transactions and calls
+  the Polkadot Host decodes and decouples the transactions and calls
   <verbatim|validate_trasaction> Runtime entry, defined in Section
   <reference|sect-rte-validate-transaction>, to check the validity of each
   received transaction. If <verbatim|validate_transaction> considers the
-  submitted transaction as a valid one, Polkadot RE makes the transaction
-  available for the consensus engine for inclusion in future blocks.
+  submitted transaction as a valid one, the Polkadot Host makes the
+  transaction available for the consensus engine for inclusion in future
+  blocks.
 
   <subsection|Transaction Queue>
 
@@ -2156,12 +2164,13 @@
   messages<em|<index|Transaction Message>>. This is because the transactions
   are submitted to the node through the <em|transactions> network message
   specified in Section <reference|sect-msg-transactions>. Upon receiving a
-  transactions message, Polkadot RE separates the submitted transactions in
-  the transactions message into individual transactions and passes them to
-  the Runtime by executing Algorithm <reference|algo-validate-transactions>
-  to validate and store them for inclusion into future blocks. To that aim,
-  Polkodot RE should keep a <em|transaction pool<index|transaction pool>> and
-  a <em|transaction queue><index|transaction queue> defined as follows:
+  transactions message, the Polkadot Host separates the submitted
+  transactions in the transactions message into individual transactions and
+  passes them to the Runtime by executing Algorithm
+  <reference|algo-validate-transactions> to validate and store them for
+  inclusion into future blocks. To that aim, the Polkadot Host should keep a
+  <em|transaction pool<index|transaction pool>> and a <em|transaction
+  queue><index|transaction queue> defined as follows:
 
   <\definition>
     <label|defn-transaction-queue>The <strong|Transaction Queue> of a block
@@ -2169,8 +2178,9 @@
     which stores the transactions ready to be included in a block sorted
     according to their priorities (Definition
     <reference|sect-msg-transactions>). The <strong|Transaction Pool>,
-    formally referred to as <math|TP>, is a hash table in which Polkadot RE
-    keeps the list of all valid transactions not in the transaction queue.
+    formally referred to as <math|TP>, is a hash table in which the Polkadot
+    Host keeps the list of all valid transactions not in the transaction
+    queue.
   </definition>
 
   Algorithm <reference|algo-validate-transactions> updates the transaction
@@ -2258,7 +2268,7 @@
     valid.
 
     <item><name|Provided-Tags>(T) is the list of tags that transaction
-    <math|T> provides. Polkadot RE needs to keep track of tags that
+    <math|T> provides. The Polkadot Host needs to keep track of tags that
     transaction <math|T> provides as well as requires after validating it.
 
     <item><name|Insert-At(><math|TQ,T,Requires(R),Priority(R)>) places
@@ -2271,7 +2281,7 @@
 
     <item><name|Propagate(><math|T>) include <math|T> in the next
     <em|transactions message<index|Transaction Message>> sent to all peers of
-    Polkadot RE node.
+    the Polkadot Host node.
   </itemize-minus>
 
   <\algorithm|<label|algo-maintain-transaction-pool><name|Maintain-Transaction-Pool>>
@@ -2284,9 +2294,9 @@
   <subsubsection|Inherents>
 
   Block inherent data represents the totality of inherent extrinsics included
-  in each block. This data is collected or generated by the Polkadot RE and
+  in each block. This data is collected or generated by the Polkadot Host and
   handed to the Runtime for inclusion in the block. It's the responsability
-  of the RE implementation to keep track of those values. Table
+  of the Polkadot Host implementation to keep track of those values. Table
   <reference|tabl-inherent-data> lists these inherent data, identifiers, and
   types. <todo|define uncles>
 
@@ -2308,9 +2318,9 @@
     <reference|defn-scale-list>) representing the totality of inherent
     extrinsics included in each block. The entries of this hash table which
     are listed in Table <reference|tabl-inherent-data> are collected or
-    generated by the Polkadot RE and then handed to the Runtime for inclusion
-    as dercribed in Algorithm <reference|algo-build-block>. The identifiers
-    are 8-byte values.
+    generated by the Polkadot Host and then handed to the Runtime for
+    inclusion as dercribed in Algorithm <reference|algo-build-block>. The
+    identifiers are 8-byte values.
   </definition>
 
   <section|State Replication><label|sect-state-replication>
@@ -2322,11 +2332,12 @@
   specified in Section <reference|sect-block-format>. Like any other
   replicated state machines, state inconsistency happens across Polkadot
   replicas. Section <reference|sect-managing-multiple-states> is giving an
-  overview of how a Polkadot RE node manages multiple variants of the state.
+  overview of how a Polkadot Host node manages multiple variants of the
+  state.
 
   <subsection|Block Format><label|sect-block-format>
 
-  In Polkadot RE, a block is made of two main parts, namely the
+  In the Polkadot Host, a block is made of two main parts, namely the
   <with|font-shape|italic|block header> and the <with|font-shape|italic|list
   of extrinsics>. <em|The Extrinsics> represent the generalization of the
   concept of <em|transaction>, containing any set of data that is external to
@@ -2363,8 +2374,8 @@
       the block body. For example, it can hold the root hash of the Merkle
       trie which stores an ordered list of the extrinsics being validated in
       this block. The <samp|extrinsics_root> is set by the runtime and its
-      value is opaque to Polkadot RE. This element is formally referred to as
-      <strong|<math|H<rsub|e>>>.
+      value is opaque to the Polkadot Host. This element is formally referred
+      to as <strong|<math|H<rsub|e>>>.
 
       <item><strong|<samp|digest:>> this field is used to store any
       chain-specific auxiliary data, which could help the light clients
@@ -2445,7 +2456,7 @@
   <subsubsection|Justified Block Header><label|sect-justified-block-header>
 
   The Justified Block Header is provided by the consensus engine and
-  presented to the Polkadot RE, for the block to be appended to the
+  presented to the Polkadot Host, for the block to be appended to the
   blockchain. It contains the following parts:
 
   <\itemize>
@@ -2466,9 +2477,9 @@
   <subsubsection|Block Body><label|sect-block-body>
 
   The Block Body consists of array extrinsics each encoded as a byte array.
-  The internal of extrinsics is completely opaque to Polkadot RE. As such, it
-  forms the point of Polkadot RE, and is simply a SCALE encoded array of byte
-  arrays. Formally:
+  The internal of extrinsics is completely opaque to the Polkadot Host. As
+  such, from the point of the Polkadot Host, and is simply a SCALE encoded
+  array of byte arrays. Formally:
 
   <\definition>
     <label|defn-block-body>The <strong|body of Block> <math|B> represented as
@@ -2488,23 +2499,25 @@
   with the world state and transitions from the state of the system to a new
   valid state.
 
-  Blocks can be handed to the Polkadot RE both from the network stack for
+  Blocks can be handed to the Polkadot Host both from the network stack for
   example by means of Block response network message (see Section
   <reference|sect-msg-block-response> ) and from the consensus engine.
 
   <subsection|Block Validation><label|sect-block-validation>
 
-  Both the Runtime and the Polkadot RE need to work together to assure block
-  validity. A block is deemed valid if the block author had the authorship
-  right for the slot during which the slot was built as well as if the
-  transactions in the block constitute a valid transition of states. The
-  former criterion is validated by Polkadot RE according to the block
-  production consensus protocol. The latter can be verified by Polkadot RE
-  invoking <verbatim|execute_block> entry into the Runtime as a part of the
-  validation process.
+  Both the Runtime and the Polkadot Host need to work together to assure
+  block validity. A block is deemed valid if the block author had the
+  authorship right for the slot during which the slot was built as well as if
+  the transactions in the block constitute a valid transition of states. The
+  former criterion is validated by the Polkadot Host according to the block
+  production consensus protocol. The latter can be verified by the Polkadot
+  Host invoking <verbatim|execute_block> entry into the Runtime as a part of
+  the validation process.
 
-  Polkadot RE implements the following procedure to assure the validity of
-  the block:
+  \;
+
+  The Polkadot Host implements the following procedure to assure the validity
+  of the block:
 
   <\algorithm|<label|algo-import-and-validate-block><name|Import-and-Validate-Block(<math|B,Just<around|(|B|)>>)>>
     <\algorithmic>
@@ -2572,10 +2585,10 @@
 
   While the state trie structure described in Section
   <reference|sect-state-storage-trie-structure> facilitates and optimizes
-  storing and switching between multiple variants of the state storage,
-  Polkadot RE does not specify how a node is required to accomplish this
-  task. Instead, Polkadot RE is required to implement <name|Set-State-At>
-  operation which behaves as defined in Definition
+  storing and switching between multiple variants of the state storage, the
+  Polkadot Host does not specify how a node is required to accomplish this
+  task. Instead, the Polkadot Host is required to implement
+  <name|Set-State-At> operation which behaves as defined in Definition
   <reference|defn-set-state-at>:
 
   <\definition>
@@ -2627,8 +2640,8 @@
 
   <section|Node Identities and Addresses>
 
-  Similar to other decentralized networks, each Polkadot RE node possesses a
-  network private key and a network public key representing an ED25519 key
+  Similar to other decentralized networks, each Polkadot Host node possesses
+  a network private key and a network public key representing an ED25519 key
   pair <cite|liusvaara_edwards-curve_2017>.
 
   <todo|SPEC: local node's keypair must be passed as part of the network
@@ -2735,8 +2748,8 @@
 
   <subsection|Periodic Ephemeral Substreams>
 
-  A Polkadot RE node should open several substreams. In particular, it should
-  periodically open ephemeral substreams in order to:
+  A Polkadot Host node should open several substreams. In particular, it
+  should periodically open ephemeral substreams in order to:
 
   <\itemize>
     <item>ping the remote peer and check whether the connection is still
@@ -2781,10 +2794,10 @@
 
   <chapter|Consensus><label|chap-consensu>
 
-  Consensus in Polkadot RE is achieved during the execution of two different
-  procedures. The first procedure is block production and the second is
-  finality. Polkadot RE must run these procedures, if and only if it is
-  running on a validator node.
+  Consensus in the Polkadot Host is achieved during the execution of two
+  different procedures. The first procedure is block production and the
+  second is finality. The Polkadot Host must run these procedures, if and
+  only if it is running on a validator node.
 
   <section|Common Consensus Structures>
 
@@ -2890,9 +2903,10 @@
     </itemize-minus>
   </definition>
 
-  Polkadot RE should inspect the digest header of each block and delegates
-  consesus messages to their consensus engines. Consensus engine should react
-  based on the type of consensus messages they receives as follows:
+  The Polkadot Host should inspect the digest header of each block and
+  delegates consesus messages to their consensus engines. Consensus engine
+  should react based on the type of consensus messages they receives as
+  follows:
 
   <\itemize-minus>
     <item><strong|Scheduled Change>: Schedule an authority set change after
@@ -2943,8 +2957,8 @@
 
   <section|Block Production><label|sect-babe><label|sect-block-production>
 
-  Polkadot RE uses BABE protocol <cite|w3f_research_group_blind_2019> for
-  block production. It is designed based on Ouroboros praos
+  The Polkadot Host uses BABE protocol <cite|w3f_research_group_blind_2019>
+  for block production. It is designed based on Ouroboros praos
   <cite|david_ouroboros_2018>. BABE execution happens in sequential
   non-overlapping phases known as an <strong|<em|epoch>>. Each epoch on its
   turn is divided into a predefined number of slots. All slots in each epoch
@@ -2961,8 +2975,8 @@
 
   <\definition>
     A <strong|block producer>, noted by <math|\<cal-P\><rsub|j>>, is a node
-    running Polkadot RE which is authorized to keep a transaction queue and
-    which gets a turn in producing blocks.
+    running the Polkadot Host which is authorized to keep a transaction queue
+    and which gets a turn in producing blocks.
   </definition>
 
   <\definition>
@@ -3574,12 +3588,13 @@
 
   <section|Finality><label|sect-finality>
 
-  Polkadot RE uses GRANDPA Finality protocol <cite|stewart_grandpa:_2019> to
-  finalize blocks. Finality is obtained by consecutive rounds of voting by
-  validator nodes. Validators execute GRANDPA finality process in parallel to
-  Block Production as an independent service. In this section, we describe
-  the different functions that GRANDPA service is supposed to perform to
-  successfully participate in the block finalization process.
+  The Polkadot Host uses GRANDPA Finality protocol
+  <cite|stewart_grandpa:_2019> to finalize blocks. Finality is obtained by
+  consecutive rounds of voting by validator nodes. Validators execute GRANDPA
+  finality process in parallel to Block Production as an independent service.
+  In this section, we describe the different functions that GRANDPA service
+  is supposed to perform to successfully participate in the block
+  finalization process.
 
   <subsection|Preliminaries>
 
@@ -3588,7 +3603,7 @@
     <math|<around|(|k<rsup|pr><rsub|v>,v<rsub|id>|)>> where
     <math|k<rsub|v><rsup|pr>> represents its private key which is an
     <math|ED25519> private key, is a node running GRANDPA protocol, and
-    broadcasts votes to finalize blocks in a Polkadot RE - based chain. The
+    broadcasts votes to finalize blocks in a Polkadot Host - based chain. The
     <strong|set of all GRANDPA voters> is indicated by <math|\<bbb-V\>>. For
     a given block B, we have <todo|change function name, only call at
     genesis, adjust V_B over the sections>
@@ -3619,8 +3634,8 @@
     <strong|r>: is the votin<verbatim|>g round number.
   </definition>
 
-  Now we need to define how Polkadot RE counts the number of votes for block
-  <math|B>. First a vote is defined as:
+  Now we need to define how the Polkadot Host counts the number of votes for
+  block <math|B>. First a vote is defined as:
 
   <\definition>
     <label|defn-vote>A <strong|GRANDPA vote >or simply a vote for block
@@ -4173,10 +4188,10 @@
   <\definition>
     <label|defn-session-key><strong|Session keys> are short-lived keys that
     are used to authenticate validator operations. Session keys are generated
-    by Polkadot RE and should be changed regularly due to security reasons.
-    Nonetheless, no validity period is enforced by Polkadot protocol on
-    session keys. Various types of keys used by Polkadot RE are presented in
-    Table <reference|tabl-session-keys><em|:>
+    by the Polkadot Host and should be changed regularly due to security
+    reasons. Nonetheless, no validity period is enforced by Polkadot protocol
+    on session keys. Various types of keys used by the Polkadot Host are
+    presented in Table <reference|tabl-session-keys><em|:>
 
     <\big-table|<tabular|<tformat|<cwith|5|5|1|-1|cell-tborder|0ln>|<cwith|4|4|1|-1|cell-bborder|0ln>|<cwith|5|5|1|-1|cell-bborder|1ln>|<cwith|5|5|1|1|cell-lborder|0ln>|<cwith|5|5|2|2|cell-rborder|0ln>|<cwith|1|1|1|-1|cell-tborder|1ln>|<cwith|1|1|1|-1|cell-bborder|1ln>|<cwith|2|2|1|-1|cell-tborder|1ln>|<cwith|1|1|1|1|cell-lborder|0ln>|<cwith|1|1|2|2|cell-rborder|0ln>|<cwith|1|1|2|2|cell-width|100>|<cwith|1|1|2|2|cell-hmode|max>|<table|<row|<cell|Protocol>|<cell|Key
     scheme>>|<row|<cell|GRANDPA>|<cell|ED25519>>|<row|<cell|BABE>|<cell|SR25519>>|<row|<cell|I'm
@@ -4186,10 +4201,10 @@
     </big-table>
   </definition>
 
-  Session keys must be accessible by certain Host APIs defined in Appendix
-  <reference|sect-re-api>. Session keys are <em|not> meant to control the
-  majority of the users' funds and should only be used for their intended
-  purpose. <todo|key managing fund need to be defined>
+  Session keys must be accessible by certain Polkadot Host APIs defined in
+  Appendix <reference|sect-re-api>. Session keys are <em|not> meant to
+  control the majority of the users' funds and should only be used for their
+  intended purpose. <todo|key managing fund need to be defined>
 
   <subsection|Holding and staking funds><label|sect-staking-funds>
 
@@ -4218,10 +4233,10 @@
 
   <section|SCALE Codec><label|sect-scale-codec>
 
-  Polkadot RE uses <em|Simple Concatenated Aggregate Little-Endian\Q (SCALE)
-  codec> to encode byte arrays as well as other data structures. SCALE
-  provides a canonical encoding to produce consistent hash values across
-  their implementation, including the Merkle hash proof for the State
+  The Polkadot Host uses <em|Simple Concatenated Aggregate Little-Endian\Q
+  (SCALE) codec> to encode byte arrays as well as other data structures.
+  SCALE provides a canonical encoding to produce consistent hash values
+  across their implementation, including the Merkle hash proof for the State
   Storage.
 
   <\definition>
@@ -4447,18 +4462,19 @@
   a set of key-value pairs, which can be retrieved from
   <cite|web3.0_technologies_foundation_polkadot_2020>. While each of those
   key/value pairs offer important identifyable information which can be used
-  by the Runtime, from Polkadot RE points of view, it is a set of arbitrary
-  key-value pair data as it is chain and network dependent. \ Except for the
-  <verbatim|:code> described in Section <reference|sect-loading-runtime-code>
-  which needs to be identified by the Polkadot RE to load its content as the
-  Runtime. The other keys and values are unspecifed and its usage depends on
-  the chain respectively its corresponding Runtime. The data should be
-  inserted into the state storage with the <verbatim|set_storage> RE API, as
-  defined in Section <reference|sect-set-storage>.
+  by the Runtime, from the Polkadot Host points of view, it is a set of
+  arbitrary key-value pair data as it is chain and network dependent.
+  \ Except for the <verbatim|:code> described in Section
+  <reference|sect-loading-runtime-code> which needs to be identified by the
+  Polkadot Host to load its content as the Runtime. The other keys and values
+  are unspecifed and its usage depends on the chain respectively its
+  corresponding Runtime. The data should be inserted into the state storage
+  with the <verbatim|set_storage> Host API, as defined in Section
+  <reference|sect-set-storage>.
 
   As such, Polkadot does not defined a formal genesis block. Nonetheless for
-  the complatibilty reasons in several algorithms, Polkadot RE defines the
-  <em|genesis header> according to Definition
+  the complatibilty reasons in several algorithms, the Polkadot Host defines
+  the <em|genesis header> according to Definition
   <reference|defn-genesis-header>. By the abuse of terminalogy, \P<em|genesis
   block>\Q refers to the hypothetical parent of block number 1 which holds
   genisis header as its header.
@@ -4480,9 +4496,9 @@
 
   <appendix|Network Messages><label|sect-network-messages>
 
-  In this section, we will specify various types of messages which Polkadot
-  RE receives from the network. Furthermore, we also explain the appropriate
-  responses to those messages.
+  In this section, we will specify various types of messages which the
+  Polkadot Host receives from the network. Furthermore, we also explain the
+  appropriate responses to those messages.
 
   <\definition>
     A <strong|network message> is a byte array, <strong|<math|M>> of length
@@ -4733,8 +4749,8 @@
   </equation*>
 
   Where each <math|E<rsub|i>> is a byte array and represents a sepearate
-  extrinsic. Polkadot RE is indifferent about the content of an extrinsic and
-  treats it as a blob of data.
+  extrinsic. The Polkadot Host is indifferent about the content of an
+  extrinsic and treats it as a blob of data.
 
   <subsection|Consensus Message><label|sect-msg-consensus>
 
@@ -4772,20 +4788,20 @@
 
   \;
 
-  <appendix|Host API><label|appendix-e>
+  <appendix|Polkadot Host API><label|appendix-e>
 
-  The Host API is a set of functions that Polkadot RE exposes to Runtime to
-  access external functions needed for various reasons, such as the Storage
-  of the content, access and manipulation, memory allocation, and also
-  efficiency. The encoding of each data type is specified or referenced in
-  this section. If the encoding is not mentioned, then the default Wasm
+  The Polkadot Host API is a set of functions that the Polkadot Host exposes
+  to Runtime to access external functions needed for various reasons, such as
+  the Storage of the content, access and manipulation, memory allocation, and
+  also efficiency. The encoding of each data type is specified or referenced
+  in this section. If the encoding is not mentioned, then the default Wasm
   encoding is used, such as little-endian byte ordering for integers.
 
   <\notation>
     <label|nota-re-api-at-state>By <math|\<cal-R\>\<cal-E\><rsub|B>> we refer
-    to the API exposed by Polkadot RE which interact, manipulate and response
-    based on the state storage whose state is set at the end of the execution
-    of block <math|B>.
+    to the API exposed by the Polkadot Host which interact, manipulate and
+    response based on the state storage whose state is set at the end of the
+    execution of block <math|B>.
   </notation>
 
   <\definition>
@@ -4794,7 +4810,7 @@
     integers in which the least significant one indicates the pointer to the
     memory buffer. The most significant one provides the size of the buffer.
     This pointer is the primary way to exchange data of arbitrary sizes
-    between the Runtime and the Host.
+    between the Runtime and the Polkadot Host.
   </definition>
 
   \ The functions are specified in each subsequent subsection for each
@@ -6717,12 +6733,12 @@
     <reference|defn-runtime-pointer> indicating the log message.
   </itemize>
 
-  <appendix|Legacy Host API<label|sect-re-api>>
+  <appendix|Legacy Polkadot Host API<label|sect-re-api>>
 
   \;
 
-  The Legacy Host APIs were exceeded and replaces by the current API as
-  described in Appendix <reference|appendix-e>. Those legacy functions are
+  The Legacy Polkadot Host APIs were exceeded and replaces by the current API
+  as described in Appendix <reference|appendix-e>. Those legacy functions are
   only required for executing Runtimes prior the official Polkadot Runtime,
   such as the Kusama test network.
 
@@ -8167,9 +8183,9 @@
 
   <section|List of Runtime Entries><label|sect-list-of-runtime-entries>
 
-  Polkadot RE assumes that at least the following functions are implemented
-  in the Runtime Wasm blob and have been exported as shown in Snippet
-  <reference|snippet-runtime-enteries>:
+  The Polkadot Host assumes that at least the following functions are
+  implemented in the Runtime Wasm blob and have been exported as shown in
+  Snippet <reference|snippet-runtime-enteries>:
 
   <assign|figure-text|<macro|Snippet>>
 
@@ -8249,8 +8265,8 @@
 
   <assign|figure-text|<macro|Figure>>
 
-  The following sections describe the standard based on which Polkadot RE
-  communicates with each runtime entry.
+  The following sections describe the standard based on which the Polkadot
+  Host communicates with each runtime entry.
 
   <section|Argument Specification>
 


### PR DESCRIPTION
Fixed #122.

This just applies to the spec, code base must be adjusted, too (I updated #102). Also, Bill told me a while back that the technical team has started the renames within the Wiki. I'll ask him about that.