### PR TITLE
fix license headers

### DIFF
--- a/test/adapters/kagome/CMakeLists.txt
+++ b/test/adapters/kagome/CMakeLists.txt
@@ -1,3 +1,20 @@
+#Copyright (c) 2019 Web3 Technologies Foundation
+#
+#This file is part of Polkadot Host Test Suite
+#
+#Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#Polkadot Host Tests is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+
 cmake_minimum_required(VERSION 3.12)
 
 

--- a/test/adapters/kagome/cmake/HunterConfig.cmake
+++ b/test/adapters/kagome/cmake/HunterConfig.cmake
@@ -1,3 +1,20 @@
+#Copyright (c) 2019 Web3 Technologies Foundation
+#
+#This file is part of Polkadot Host Test Suite
+#
+#Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#Polkadot Host Tests is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+
 # TODO: Move away from custom kagome branch for testing
 hunter_config(kagome
     URL https://github.com/soramitsu/kagome/archive/af5c718a05a3b734291dd2c4f574c8dffb76ad46.tar.gz

--- a/test/adapters/kagome/cmake/Toolchain.cmake
+++ b/test/adapters/kagome/cmake/Toolchain.cmake
@@ -1,3 +1,20 @@
+#Copyright (c) 2019 Web3 Technologies Foundation
+#
+#This file is part of Polkadot Host Test Suite
+#
+#Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#Polkadot Host Tests is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/test/adapters/kagome/src/extension.cpp
+++ b/test/adapters/kagome/src/extension.cpp
@@ -1,6 +1,20 @@
-/**
- * Copyright Soramitsu Co., Ltd. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (c) 2019 Web3 Technologies Foundation
+ *
+ * This file is part of Polkadot Host Test Suite
+ *
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Polkadot Host Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #define BOOST_ENABLE_ASSERT_HANDLER

--- a/test/adapters/kagome/src/extension.hpp
+++ b/test/adapters/kagome/src/extension.hpp
@@ -1,6 +1,20 @@
-/**
- * Copyright Soramitsu Co., Ltd. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (c) 2019 Web3 Technologies Foundation
+ *
+ * This file is part of Polkadot Host Test Suite
+ *
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Polkadot Host Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef KAGOMECROSSTESTCLI_EXTENSION_HPP

--- a/test/adapters/kagome/src/extension/child_storage.cpp
+++ b/test/adapters/kagome/src/extension/child_storage.cpp
@@ -1,6 +1,20 @@
-/**
- * Copyright Soramitsu Co., Ltd. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (c) 2019 Web3 Technologies Foundation
+ *
+ * This file is part of Polkadot Host Test Suite
+ *
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Polkadot Host Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "child_storage.hpp"

--- a/test/adapters/kagome/src/extension/child_storage.hpp
+++ b/test/adapters/kagome/src/extension/child_storage.hpp
@@ -1,6 +1,20 @@
-/**
- * Copyright Soramitsu Co., Ltd. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (c) 2019 Web3 Technologies Foundation
+ *
+ * This file is part of Polkadot Host Test Suite
+ *
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Polkadot Host Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef KAGOMECROSSTESTCLI_CHILD_STORAGE_EXTENSION_HPP

--- a/test/adapters/kagome/src/extension/crypto.cpp
+++ b/test/adapters/kagome/src/extension/crypto.cpp
@@ -1,6 +1,20 @@
-/**
- * Copyright Soramitsu Co., Ltd. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (c) 2019 Web3 Technologies Foundation
+ *
+ * This file is part of Polkadot Host Test Suite
+ *
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Polkadot Host Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "crypto.hpp"

--- a/test/adapters/kagome/src/extension/crypto.hpp
+++ b/test/adapters/kagome/src/extension/crypto.hpp
@@ -1,6 +1,20 @@
-/**
- * Copyright Soramitsu Co., Ltd. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (c) 2019 Web3 Technologies Foundation
+ *
+ * This file is part of Polkadot Host Test Suite
+ *
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Polkadot Host Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef KAGOMECROSSTESTCLI_CRYPTO_EXTENSION_HPP

--- a/test/adapters/kagome/src/extension/helpers.cpp
+++ b/test/adapters/kagome/src/extension/helpers.cpp
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2019 Web3 Technologies Foundation
+ *
+ * This file is part of Polkadot Host Test Suite
+ *
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Polkadot Host Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include "helpers.hpp"
 
 #include <binaryen/shell-interface.h>

--- a/test/adapters/kagome/src/extension/helpers.hpp
+++ b/test/adapters/kagome/src/extension/helpers.hpp
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2019 Web3 Technologies Foundation
+ *
+ * This file is part of Polkadot Host Test Suite
+ *
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Polkadot Host Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <runtime/wasm_memory.hpp>

--- a/test/adapters/kagome/src/extension/network.cpp
+++ b/test/adapters/kagome/src/extension/network.cpp
@@ -1,6 +1,20 @@
-/**
- * Copyright Soramitsu Co., Ltd. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (c) 2019 Web3 Technologies Foundation
+ *
+ * This file is part of Polkadot Host Test Suite
+ *
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Polkadot Host Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "network.hpp"

--- a/test/adapters/kagome/src/extension/network.hpp
+++ b/test/adapters/kagome/src/extension/network.hpp
@@ -1,6 +1,20 @@
-/**
- * Copyright Soramitsu Co., Ltd. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (c) 2019 Web3 Technologies Foundation
+ *
+ * This file is part of Polkadot Host Test Suite
+ *
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Polkadot Host Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef KAGOMECROSSTESTCLI_NETWORK_EXTENSION_HPP

--- a/test/adapters/kagome/src/extension/storage.cpp
+++ b/test/adapters/kagome/src/extension/storage.cpp
@@ -1,6 +1,20 @@
-/**
- * Copyright Soramitsu Co., Ltd. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (c) 2019 Web3 Technologies Foundation
+ *
+ * This file is part of Polkadot Host Test Suite
+ *
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Polkadot Host Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "storage.hpp"

--- a/test/adapters/kagome/src/extension/storage.hpp
+++ b/test/adapters/kagome/src/extension/storage.hpp
@@ -1,6 +1,20 @@
-/**
- * Copyright Soramitsu Co., Ltd. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (c) 2019 Web3 Technologies Foundation
+ *
+ * This file is part of Polkadot Host Test Suite
+ *
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Polkadot Host Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef KAGOMECROSSTESTCLI_STORAGE_EXTENSION_HPP

--- a/test/adapters/kagome/src/main.cpp
+++ b/test/adapters/kagome/src/main.cpp
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2019 Web3 Technologies Foundation
+ *
+ * This file is part of Polkadot Host Test Suite
+ *
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Polkadot Host Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <iostream>
 
 #define BOOST_ENABLE_ASSERT_HANDLER

--- a/test/adapters/kagome/src/scale_codec.cpp
+++ b/test/adapters/kagome/src/scale_codec.cpp
@@ -1,6 +1,20 @@
-/**
- * Copyright Soramitsu Co., Ltd. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (c) 2019 Web3 Technologies Foundation
+ *
+ * This file is part of Polkadot Host Test Suite
+ *
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Polkadot Host Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "scale_codec.hpp"

--- a/test/adapters/kagome/src/scale_codec.hpp
+++ b/test/adapters/kagome/src/scale_codec.hpp
@@ -1,6 +1,20 @@
-/**
- * Copyright Soramitsu Co., Ltd. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (c) 2019 Web3 Technologies Foundation
+ *
+ * This file is part of Polkadot Host Test Suite
+ *
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Polkadot Host Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef KAGOMECROSSTESTCLI_SCALE_CODEC_HPP

--- a/test/adapters/kagome/src/subcommand_router.hpp
+++ b/test/adapters/kagome/src/subcommand_router.hpp
@@ -1,6 +1,20 @@
-/**
- * Copyright Soramitsu Co., Ltd. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (c) 2019 Web3 Technologies Foundation
+ *
+ * This file is part of Polkadot Host Test Suite
+ *
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Polkadot Host Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef KAGOMECROSSTESTCLI_SUBCOMMAND_ROUTER_HPP

--- a/test/adapters/kagome/src/trie.cpp
+++ b/test/adapters/kagome/src/trie.cpp
@@ -1,6 +1,20 @@
-/**
- * Copyright Soramitsu Co., Ltd. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (c) 2019 Web3 Technologies Foundation
+ *
+ * This file is part of Polkadot Host Test Suite
+ *
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Polkadot Host Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "trie.hpp"

--- a/test/adapters/kagome/src/trie.hpp
+++ b/test/adapters/kagome/src/trie.hpp
@@ -1,6 +1,20 @@
-/**
- * Copyright Soramitsu Co., Ltd. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (c) 2019 Web3 Technologies Foundation
+ *
+ * This file is part of Polkadot Host Test Suite
+ *
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Polkadot Host Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef KAGOMECROSSTESTCLI_TRIE_HPP


### PR DESCRIPTION
Signed-off-by: Yuriy Zarudniy <zarudniy@soramitsu.co.jp>
Update kagome adapter license headers.