### PR TITLE
Fix arguments section of Core_execute_block

### DIFF
--- a/polkadot-host-spec/ag-runtimeentries.tm
+++ b/polkadot-host-spec/ag-runtimeentries.tm
@@ -1,4 +1,4 @@
-<TeXmacs|1.99.12>
+<TeXmacs|1.99.11>
 
 <project|polkadot_host_spec.tm>
 
@@ -172,8 +172,9 @@
   <strong|Arguments>:
 
   <\itemize>
-    <item>The entry accepts the <em|block data> defined in Definition
-    <reference|defn-block-data> as the only argument.
+    <item>The entry accepts a block consisting of a block header as described
+    in section <reference|defn-block-header> and the block body as described
+    in section <reference|defn-block-body>.
   </itemize>
 
   \;
@@ -507,8 +508,8 @@
 
 <\initial>
   <\collection>
-    <associate|chapter-nr|5>
-    <associate|page-first|101>
+    <associate|chapter-nr|6>
+    <associate|page-first|107>
     <associate|page-height|auto>
     <associate|page-type|letter>
     <associate|page-width|auto>

--- a/polkadot-host-spec/ag-runtimeentries.tm
+++ b/polkadot-host-spec/ag-runtimeentries.tm
@@ -172,9 +172,9 @@
   <strong|Arguments>:
 
   <\itemize>
-    <item>The entry accepts a block consisting of a block header as described
-    in section <reference|defn-block-header> and the block body as described
-    in section <reference|defn-block-body>.
+    <item>The entry accepts a block, represented as a tuple consisting of a
+    block header as described in section <reference|defn-block-header> and
+    the block body as described in section <reference|defn-block-body>.
   </itemize>
 
   \;
@@ -520,43 +520,43 @@
 
 <\references>
   <\collection>
-    <associate|auto-1|<tuple|A|?>>
-    <associate|auto-10|<tuple|A.2.5|?>>
-    <associate|auto-11|<tuple|A.2|?>>
-    <associate|auto-12|<tuple|A.2.6|?>>
-    <associate|auto-13|<tuple|A.2.7|?>>
-    <associate|auto-14|<tuple|A.3|?>>
-    <associate|auto-15|<tuple|A.4|?>>
-    <associate|auto-16|<tuple|A.5|?>>
-    <associate|auto-17|<tuple|A.6|?>>
-    <associate|auto-18|<tuple|A.2.8|?>>
-    <associate|auto-19|<tuple|A.7|?>>
-    <associate|auto-2|<tuple|A.1|?>>
-    <associate|auto-20|<tuple|A.8|?>>
-    <associate|auto-21|<tuple|A.2.9|?>>
-    <associate|auto-22|<tuple|A.2.10|?>>
-    <associate|auto-3|<tuple|A.1|?>>
-    <associate|auto-4|<tuple|A.2|?>>
-    <associate|auto-5|<tuple|A.2.1|?>>
-    <associate|auto-6|<tuple|A.1|?>>
-    <associate|auto-7|<tuple|A.2.2|?>>
-    <associate|auto-8|<tuple|A.2.3|?>>
-    <associate|auto-9|<tuple|A.2.4|?>>
-    <associate|defn-invalid-transaction|<tuple|A.3|?>>
-    <associate|defn-rt-blockbuilder-finalize-block|<tuple|A.2.10|?>>
-    <associate|defn-rt-core-execute-block|<tuple|A.2.2|?>>
-    <associate|defn-rt-core-version|<tuple|A.2.1|?>>
-    <associate|defn-transaction-validity-error|<tuple|A.2|?>>
-    <associate|defn-unknown-transaction|<tuple|A.4|?>>
-    <associate|defn-valid-transaction|<tuple|A.1|?>>
-    <associate|sect-list-of-runtime-entries|<tuple|A.1|?>>
-    <associate|sect-rte-babeapi-epoch|<tuple|A.2.5|?>>
-    <associate|sect-rte-core-execute-block|<tuple|A.2.2|?>>
-    <associate|sect-rte-grandpa-auth|<tuple|A.2.6|?>>
-    <associate|sect-rte-hash-and-length|<tuple|A.2.4|?>>
-    <associate|sect-rte-validate-transaction|<tuple|A.2.7|?>>
-    <associate|sect-runtime-entries|<tuple|A|?>>
-    <associate|snippet-runtime-enteries|<tuple|A.1|?>>
+    <associate|auto-1|<tuple|A|107>>
+    <associate|auto-10|<tuple|A.2.5|109>>
+    <associate|auto-11|<tuple|A.2|109>>
+    <associate|auto-12|<tuple|A.2.6|109>>
+    <associate|auto-13|<tuple|A.2.7|109>>
+    <associate|auto-14|<tuple|A.3|110>>
+    <associate|auto-15|<tuple|A.4|110>>
+    <associate|auto-16|<tuple|A.5|110>>
+    <associate|auto-17|<tuple|A.6|111>>
+    <associate|auto-18|<tuple|A.2.8|111>>
+    <associate|auto-19|<tuple|A.7|111>>
+    <associate|auto-2|<tuple|A.1|107>>
+    <associate|auto-20|<tuple|A.8|111>>
+    <associate|auto-21|<tuple|A.2.9|112>>
+    <associate|auto-22|<tuple|A.2.10|112>>
+    <associate|auto-3|<tuple|A.1|107>>
+    <associate|auto-4|<tuple|A.2|107>>
+    <associate|auto-5|<tuple|A.2.1|108>>
+    <associate|auto-6|<tuple|A.1|108>>
+    <associate|auto-7|<tuple|A.2.2|108>>
+    <associate|auto-8|<tuple|A.2.3|108>>
+    <associate|auto-9|<tuple|A.2.4|109>>
+    <associate|defn-invalid-transaction|<tuple|A.3|110>>
+    <associate|defn-rt-blockbuilder-finalize-block|<tuple|A.2.10|112>>
+    <associate|defn-rt-core-execute-block|<tuple|A.2.2|108>>
+    <associate|defn-rt-core-version|<tuple|A.2.1|108>>
+    <associate|defn-transaction-validity-error|<tuple|A.2|110>>
+    <associate|defn-unknown-transaction|<tuple|A.4|110>>
+    <associate|defn-valid-transaction|<tuple|A.1|110>>
+    <associate|sect-list-of-runtime-entries|<tuple|A.1|107>>
+    <associate|sect-rte-babeapi-epoch|<tuple|A.2.5|109>>
+    <associate|sect-rte-core-execute-block|<tuple|A.2.2|108>>
+    <associate|sect-rte-grandpa-auth|<tuple|A.2.6|109>>
+    <associate|sect-rte-hash-and-length|<tuple|A.2.4|109>>
+    <associate|sect-rte-validate-transaction|<tuple|A.2.7|109>>
+    <associate|sect-runtime-entries|<tuple|A|107>>
+    <associate|snippet-runtime-enteries|<tuple|A.1|107>>
   </collection>
 </references>
 


### PR DESCRIPTION
The current spec says that the `BlockData` type gets passed on, which is incorrect

**Printscreen**
![image](https://user-images.githubusercontent.com/42901763/84063550-7f6f3c00-a9c1-11ea-8029-c92c3dd74f15.png)

**Corresponding code**
```rust
// In `runtime/src/lib.rs`

/// Block header type as expected by this runtime.
pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
/// Block type as expected by this runtime.
pub type Block = generic::Block<Header, UncheckedExtrinsic>;

// ...

fn execute_block(block: Block) {
	Executive::execute_block(block)
}
```

```rust
// In `primitives/runtime/src/generic/block.rs`

pub struct Block<Header, Extrinsic: MaybeSerialize> {
	/// The block header.
	pub header: Header,
	/// The accompanying extrinsics.
	pub extrinsics: Vec<Extrinsic>,
}
```

```rust
// In `primitives/runtime/src/generic/header.rs`

pub struct Header<Number: Copy + Into<U256> + TryFrom<U256>, Hash: HashT> {
	/// The parent hash.
	pub parent_hash: Hash::Output,
	/// The block number.
	#[cfg_attr(feature = "std", serde(
		serialize_with = "serialize_number",
		deserialize_with = "deserialize_number"))]
	pub number: Number,
	/// The state trie merkle root
	pub state_root: Hash::Output,
	/// The merkle root of the extrinsics.
	pub extrinsics_root: Hash::Output,
	/// A chain-specific digest of data useful for light clients or referencing auxiliary data.
	pub digest: Digest<Hash::Output>,
}
```