### PR TITLE
Fix and improve kagome buil

### DIFF
--- a/test/adapters/kagome/CMakeLists.txt
+++ b/test/adapters/kagome/CMakeLists.txt
@@ -26,12 +26,7 @@ set(CMAKE_TOOLCHAIN_FILE
 
 
 # Setup hunter
-include(cmake/HunterGate.cmake)
-HunterGate(
-    URL "https://github.com/soramitsu/soramitsu-hunter/archive/v0.23.253-soramitsu4.tar.gz"
-    SHA1 "e55ec201201d1e5726b0c849c1c8e2fee003ab9f"
-    FILEPATH "${CMAKE_SOURCE_DIR}/cmake/HunterConfig.cmake"
-)
+include(cmake/HunterInit.cmake)
 
 set(CMAKE_FIND_PACKAGE_PREFER_CONFIG HUNTER_ENABLED)
 

--- a/test/adapters/kagome/cmake/HunterConfig.cmake
+++ b/test/adapters/kagome/cmake/HunterConfig.cmake
@@ -17,6 +17,11 @@
 
 # TODO: Move away from custom kagome branch for testing
 hunter_config(kagome
-    URL https://github.com/soramitsu/kagome/archive/af5c718a05a3b734291dd2c4f574c8dffb76ad46.tar.gz
-    SHA1 81f456bb92d06e7b5861dacb66d4ff77515dadf6
+    URL https://github.com/soramitsu/kagome/archive/219d46ff77ae8b77974373653ce25e720ef0645f.tar.gz
+    SHA1 1a0827b729b4dc1e40e37887df53f05bbcac3607
 )
+hunter_config(libsecp256k1
+    URL https://github.com/soramitsu/soramitsu-libsecp256k1/archive/c7630e1bac638c0f16ee66d4dce7b5c49eecbaa5.zip
+    SHA1 179e316b0fe5150f1b05ca70ec2ac1490fe2cb3b
+    CMAKE_ARGS SECP256K1_BUILD_TEST=OFF
+    )

--- a/test/adapters/kagome/cmake/HunterInit.cmake
+++ b/test/adapters/kagome/cmake/HunterInit.cmake
@@ -1,0 +1,31 @@
+# specify GITHUB_HUNTER_TOKEN and GITHUB_HUNTER_USERNAME to automatically upload binary cache to github.com/soramitsu/hunter-binary-cache
+# https://docs.hunter.sh/en/latest/user-guides/hunter-user/github-cache-server.html
+string(COMPARE EQUAL "$ENV{GITHUB_HUNTER_TOKEN}" "" password_is_empty)
+string(COMPARE EQUAL "$ENV{GITHUB_HUNTER_USERNAME}" "" username_is_empty)
+
+# binary cache can be uploaded to soramitsu/hunter-binary-cache so others will not build same dependencies twice
+if (NOT password_is_empty AND NOT username_is_empty)
+    option(HUNTER_RUN_UPLOAD "Upload cache binaries" YES)
+    message("Binary cache uploading is ENABLED.")
+else ()
+    option(HUNTER_RUN_UPLOAD "Upload cache binaries" NO)
+    message("Binary cache uploading is DISABLED.")
+endif ()
+
+set(
+    HUNTER_PASSWORDS_PATH "${CMAKE_CURRENT_LIST_DIR}/HunterPasswords.cmake"
+    CACHE FILEPATH "Hunter passwords"
+)
+
+set(
+    HUNTER_CACHE_SERVERS "https://github.com/soramitsu/hunter-binary-cache;"
+    CACHE STRING "Binary cache server"
+)
+
+include(${CMAKE_CURRENT_LIST_DIR}/HunterGate.cmake)
+
+HunterGate(
+    URL https://github.com/soramitsu/soramitsu-hunter/archive/v0.23.254-soramitsu1.tar.gz
+    SHA1 7819e7dd14f58b6df2fd7f2bc835265d60add3f5
+    FILEPATH "${CMAKE_CURRENT_LIST_DIR}/HunterConfig.cmake"
+)

--- a/test/adapters/kagome/cmake/HunterPasswords.cmake
+++ b/test/adapters/kagome/cmake/HunterPasswords.cmake
@@ -1,0 +1,11 @@
+hunter_upload_password(
+  # REPO_OWNER + REPO = https://github.com/forexample/hunter-cache
+  REPO_OWNER "soramitsu"
+  REPO "hunter-binary-cache"
+
+  # USERNAME = warchant
+  USERNAME "$ENV{GITHUB_HUNTER_USERNAME}"
+
+  # PASSWORD = GitHub token saved as a secure environment variable
+  PASSWORD "$ENV{GITHUB_HUNTER_TOKEN}"
+)


### PR DESCRIPTION
Fix of build kagome over hunter package manager.
Activate hunters binary cache for accelerate building.

Signed-off-by: Dmitriy Khaustov aka xDimon <khaustov.dm@gmail.com>