### PR TITLE
kagome-adapter: implement host-api storage next-key test 

### DIFF
--- a/test/adapters/kagome-legacy/CMakeLists.txt
+++ b/test/adapters/kagome-legacy/CMakeLists.txt
@@ -36,6 +36,7 @@ set(
   CACHE STRING "Binary cache server"
 )
 
+
 # Setup hunter
 include(cmake/HunterGate.cmake)
 HunterGate(
@@ -44,16 +45,19 @@ HunterGate(
   FILEPATH "${CMAKE_SOURCE_DIR}/cmake/HunterConfig.cmake"
 )
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG HUNTER_ENABLED)
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ${HUNTER_ENABLED})
 
 
 # General config
 project(kagome-adapter-legacy LANGUAGES CXX C)
 
+
 # Find dependencies
 hunter_add_package(kagome)
 
 find_package(kagome REQUIRED)
+
+message(STATUS "Found kagome: ${kagome_INCLUDE_DIRS}")
 
 # FIXME Kagome's package config should do all this!
 find_package(ed25519 REQUIRED)
@@ -66,6 +70,7 @@ find_package(xxhash REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(libp2p REQUIRED)
 find_package(binaryen REQUIRED)
+
 
 # Compile and link tester
 add_executable(kagome-adapter-legacy
@@ -93,9 +98,6 @@ target_include_directories(kagome-adapter-legacy PRIVATE ${kagome_INCLUDE_DIRS})
 target_link_libraries(kagome-adapter-legacy
   Boost::program_options
   ${kagome_LIBRARIES}
-
-  # FIXME Patched-in export required for host-api testing
-  kagome::binaryen_wasm_memory
 )
 
 

--- a/test/adapters/kagome-legacy/cmake/HunterConfig.cmake
+++ b/test/adapters/kagome-legacy/cmake/HunterConfig.cmake
@@ -20,8 +20,8 @@
 
 # Should point to the version of kagome to be tested (currently a custom fork with small fixes atop master)
 hunter_config(kagome
-  URL https://github.com/soramitsu/kagome/archive/27ee11c78767e72f0ecd2c515c77bebc2ff5758d.tar.gz
-  SHA1 a53689530361e12066ae8752a2b60150f7f5164a
+  URL https://github.com/soramitsu/kagome/archive/07536249ac2b1d5d5ee9b6d9455d01b815073304.tar.gz
+  SHA1 888f2c6e06442e3f8a460fa2a10d9f74c34d5891
   CMAKE_ARGS TESTING=OFF
 )
 

--- a/test/adapters/kagome/CMakeLists.txt
+++ b/test/adapters/kagome/CMakeLists.txt
@@ -24,6 +24,7 @@ set(CMAKE_TOOLCHAIN_FILE
   CACHE FILEPATH "Default toolchain"
 )
 
+
 # Setup but disable binary cache by default
 set(
   HUNTER_USE_CACHE_SERVERS "NO"
@@ -35,6 +36,7 @@ set(
   CACHE STRING "Binary cache server"
 )
 
+
 # Setup hunter
 include(cmake/HunterGate.cmake)
 HunterGate(
@@ -43,11 +45,12 @@ HunterGate(
   FILEPATH "${CMAKE_SOURCE_DIR}/cmake/HunterConfig.cmake"
 )
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG HUNTER_ENABLED)
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ${HUNTER_ENABLED})
 
 
 # General config
 project(kagome-adapter LANGUAGES CXX C)
+
 
 # Find dependencies
 hunter_add_package(kagome)
@@ -55,6 +58,14 @@ hunter_add_package(yaml-cpp)
 
 find_package(kagome REQUIRED)
 find_package(yaml-cpp REQUIRED)
+
+message(STATUS "Found kagome: ${kagome_INCLUDE_DIRS}")
+
+# Fix inconsistency between hunterized and upstream package (+ CMake oddity fix)
+if(NOT TARGET yaml-cpp)
+  set_target_properties(yaml-cpp::yaml-cpp PROPERTIES IMPORTED_GLOBAL true)
+  add_library(yaml-cpp ALIAS yaml-cpp::yaml-cpp)
+endif()
 
 # FIXME Kagome's package config should do all this!
 find_package(Boost REQUIRED COMPONENTS filesystem program_options random)
@@ -67,6 +78,7 @@ find_package(xxhash REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(libp2p REQUIRED)
 find_package(binaryen REQUIRED)
+
 
 # Compile and link tester
 add_executable(kagome-adapter
@@ -99,11 +111,8 @@ target_include_directories(kagome-adapter PRIVATE ${kagome_INCLUDE_DIRS})
 
 target_link_libraries(kagome-adapter
   Boost::program_options
-  yaml-cpp::yaml-cpp
+  yaml-cpp
   ${kagome_LIBRARIES}
-
-  # FIXME Patched-in export required for host-api testing
-  kagome::binaryen_wasm_memory
 )
 
 

--- a/test/adapters/kagome/cmake/HunterConfig.cmake
+++ b/test/adapters/kagome/cmake/HunterConfig.cmake
@@ -20,8 +20,8 @@
 
 # Should point to the version of kagome to be tested (currently a custom fork with small fixes atop master)
 hunter_config(kagome
-  URL https://github.com/soramitsu/kagome/archive/2eb1bb7ddb99139614033ea90953684d42d50b54.tar.gz
-  SHA1 2e9f4b1ccfa6229cbc40003eebb58a421c58eb88
+  URL https://github.com/soramitsu/kagome/archive/07536249ac2b1d5d5ee9b6d9455d01b815073304.tar.gz
+  SHA1 888f2c6e06442e3f8a460fa2a10d9f74c34d5891
   CMAKE_ARGS TESTING=OFF
 )
 

--- a/test/adapters/kagome/cmake/HunterConfig.cmake
+++ b/test/adapters/kagome/cmake/HunterConfig.cmake
@@ -20,8 +20,8 @@
 
 # Should point to the version of kagome to be tested (currently a custom fork with small fixes atop master)
 hunter_config(kagome
-  URL https://github.com/soramitsu/kagome/archive/27ee11c78767e72f0ecd2c515c77bebc2ff5758d.tar.gz
-  SHA1 a53689530361e12066ae8752a2b60150f7f5164a
+  URL https://github.com/soramitsu/kagome/archive/2eb1bb7ddb99139614033ea90953684d42d50b54.tar.gz
+  SHA1 2e9f4b1ccfa6229cbc40003eebb58a421c58eb88
   CMAKE_ARGS TESTING=OFF
 )
 

--- a/test/adapters/kagome/src/host_api.cpp
+++ b/test/adapters/kagome/src/host_api.cpp
@@ -103,7 +103,7 @@ void processHostApiCommands(const HostApiCommandArgs& args){
     storage::processRoot(args[0], args[1], args[2], args[3]);
   });
   router.addSubcommand("ext_storage_next_key_version_1", [](const std::vector<std::string>& args) {
-    throw NotImplemented(); // TODO not implemented
+    storage::processNextKey(args[0], args[1], args[2], args[3]);
   });
 
   // test child storage TODO: all not implemented

--- a/test/adapters/kagome/src/host_api/helpers.hpp
+++ b/test/adapters/kagome/src/host_api/helpers.hpp
@@ -29,6 +29,7 @@
 namespace helpers {
 
   using kagome::common::Buffer;
+  using MaybeBuffer = boost::optional<Buffer>;
 
   using kagome::runtime::binaryen::RuntimeManager;
   using kagome::runtime::binaryen::RuntimeApi;

--- a/test/adapters/kagome/src/host_api/storage.cpp
+++ b/test/adapters/kagome/src/host_api/storage.cpp
@@ -32,6 +32,7 @@ namespace storage {
 
     // Compute and print storage root hash
     auto hash = environment.execute<helpers::Buffer>("rtm_ext_storage_root_version_1");
+
     std::cout << hash.toHex() << std::endl;
   }
 
@@ -93,7 +94,7 @@ namespace storage {
     helpers::RuntimeEnvironment environment;
 
     // Check for no data
-    auto exists = environment.execute<uint32_t>("rtm_ext_storage_exists_version_1", key);
+    auto exists = environment.execute<bool>("rtm_ext_storage_exists_version_1", key);
 
     BOOST_ASSERT_MSG(exists == 0, "Storage exists");
 
@@ -101,7 +102,7 @@ namespace storage {
     environment.execute<void>("rtm_ext_storage_set_version_1", key, value);
 
     // Check for data
-    exists = environment.execute<uint32_t>("rtm_ext_storage_exists_version_1", key);
+    exists = environment.execute<bool>("rtm_ext_storage_exists_version_1", key);
 
     BOOST_ASSERT_MSG(exists == 1, "Storage does not exists");
 

--- a/test/adapters/kagome/src/host_api/storage.cpp
+++ b/test/adapters/kagome/src/host_api/storage.cpp
@@ -71,22 +71,22 @@ namespace storage {
     environment.execute<void>("rtm_ext_storage_set_version_1", key, value);
 
     // Retrieve and check stored data
-    auto stored = environment.execute<helpers::Buffer>(
+    auto stored = environment.execute<helpers::MaybeBuffer>(
       "rtm_ext_storage_get_version_1", key
     );
 
-    BOOST_ASSERT_MSG(!stored.empty(), "No value");
-    BOOST_ASSERT_MSG(stored.toString() == value, "Values are different");
+    BOOST_ASSERT_MSG(stored.has_value(), "No value");
+    BOOST_ASSERT_MSG(stored.value().toString() == value, "Values are different");
 
     // Clear data
     environment.execute<void>("rtm_ext_storage_clear_version_1", key);
 
     // Retrieve and check cleared data
-    auto cleared = environment.execute<helpers::Buffer>(
+    auto cleared = environment.execute<helpers::MaybeBuffer>(
       "rtm_ext_storage_get_version_1", key
     );
 
-    BOOST_ASSERT_MSG(cleared.empty(), "Value wasn't deleted");
+    BOOST_ASSERT_MSG(!cleared, "Value wasn't deleted");
   }
 
 
@@ -125,29 +125,29 @@ namespace storage {
     environment.execute<void>("rtm_ext_storage_clear_prefix_version_1", prefix);
 
     // Retrieve first key 
-    auto result = environment.execute<helpers::Buffer>(
+    auto result = environment.execute<helpers::MaybeBuffer>(
       "rtm_ext_storage_get_version_1", key1
     );
 
     // Check if first key was handled correctly
     if (prefix == key1.substr(0, prefix.size())) {
-      BOOST_ASSERT_MSG(result.empty(), "Value1 wasn't deleted");
+      BOOST_ASSERT_MSG(!result, "Value1 wasn't deleted");
     } else {
-      BOOST_ASSERT_MSG(result.toString() == value1, "Value1 was deleted");
+      BOOST_ASSERT_MSG(result.has_value(), "Value1 was deleted");
+      BOOST_ASSERT_MSG(result.value().toString() == value1, "Value1 was changed");
     }
 
     // Retrieve second key
-    result = environment.execute<helpers::Buffer>(
+    result = environment.execute<helpers::MaybeBuffer>(
       "rtm_ext_storage_get_version_1", key2
     );
 
     // Check if first key was handled correctly
     if (prefix == key2.substr(0, prefix.size())) {
-      // Check if key2 was deleted
-      BOOST_ASSERT_MSG(result.empty(), "Value2 wasn't deleted");
+      BOOST_ASSERT_MSG(!result, "Value2 wasn't deleted");
     } else {
-      // Check if key2 was stored correctly
-      BOOST_ASSERT_MSG(result.toString() == value2, "Value2 was deleted");
+      BOOST_ASSERT_MSG(result.has_value(), "Value2 was deleted");
+      BOOST_ASSERT_MSG(result.value().toString() == value2, "Value2 was changed");
     }
   }
 

--- a/test/adapters/kagome/src/host_api/storage.cpp
+++ b/test/adapters/kagome/src/host_api/storage.cpp
@@ -174,32 +174,42 @@ namespace storage {
     helpers::RuntimeEnvironment environment;
 
     // No next key available
-    auto next = environment.execute<helpers::Buffer>("rtm_ext_storage_next_key_version_1", key1);
-    BOOST_ASSERT_MSG(next.empty(), "Next is empty");
+    auto next = environment.execute<helpers::MaybeBuffer>("rtm_ext_storage_next_key_version_1", key1);
+    BOOST_ASSERT_MSG(!next, "Next is not empty");
 
-    next = environment.execute<helpers::Buffer>("rtm_ext_storage_next_key_version_1", key2);
-    BOOST_ASSERT_MSG(next.empty(), "Next is empty");
+    next = environment.execute<helpers::MaybeBuffer>("rtm_ext_storage_next_key_version_1", key2);
+    BOOST_ASSERT_MSG(!next, "Next is not empty");
 
     // Insert data
     environment.execute<void>("rtm_ext_storage_set_version_1", key1, value1);
     environment.execute<void>("rtm_ext_storage_set_version_1", key2, value2);
 
     // Try to read next key
-    next = environment.execute<helpers::Buffer>("rtm_ext_storage_next_key_version_1", key1);
+    next = environment.execute<helpers::MaybeBuffer>("rtm_ext_storage_next_key_version_1", key1);
     if (key1.compare(key2) < 0) {
-        BOOST_ASSERT_MSG(next.toString() == key2, "Next is Key2");
-        std::cout << next.toString() << std::endl;
+        BOOST_ASSERT_MSG(next, "Next is empty");
+
+        auto result = next.value().toString();
+
+        BOOST_ASSERT_MSG(result == key2, "Next is not Key2");
+
+        std::cout << result << std::endl;
     } else {
-        BOOST_ASSERT_MSG(next.empty(), "Next is empty");
+        BOOST_ASSERT_MSG(!next, "Next is not empty");
     }
 
     // Try to read next key
-    next = environment.execute<helpers::Buffer>("rtm_ext_storage_next_key_version_1", key2);
+    next = environment.execute<helpers::MaybeBuffer>("rtm_ext_storage_next_key_version_1", key2);
     if (key2.compare(key1) < 0) {
-        BOOST_ASSERT_MSG(next.toString() == key1, "Next is Key2");
-        std::cout << next.toString() << std::endl;
+        BOOST_ASSERT_MSG(next, "Next is empty");
+
+        auto result = next.value().toString();
+
+        BOOST_ASSERT_MSG(result == key1, "Next is not Key1");
+
+        std::cout << result << std::endl;
     } else {
-        BOOST_ASSERT_MSG(next.empty(), "Next is empty");
+        BOOST_ASSERT_MSG(!next, "Next is not empty");
     }
   }
 

--- a/test/adapters/kagome/src/host_api/storage.cpp
+++ b/test/adapters/kagome/src/host_api/storage.cpp
@@ -41,26 +41,26 @@ namespace storage {
     helpers::RuntimeEnvironment environment;
 
     // Check that key has not been set
-    auto result = environment.execute<helpers::Buffer>(
+    auto result = environment.execute<helpers::MaybeBuffer>(
       "rtm_ext_storage_get_version_1", key
     );
 
-    BOOST_ASSERT_MSG(result.empty(), "Data exists");
+    BOOST_ASSERT_MSG(!result, "Data exists");
 
     // Add data to storage
     environment.execute<void>("rtm_ext_storage_set_version_1", key, value);
 
     // Retrieve data from storage
-    result = environment.execute<helpers::Buffer>(
+    result = environment.execute<helpers::MaybeBuffer>(
       "rtm_ext_storage_get_version_1", key
     );
 
     // Check returned data
-    BOOST_ASSERT_MSG(!result.empty(), "No value");
-    BOOST_ASSERT_MSG(result.toString() == value, "Values are different");
+    BOOST_ASSERT_MSG(result.has_value(), "No value");
+    BOOST_ASSERT_MSG(result.value().toString() == value, "Values are different");
 
     // Print result
-    std::cout << result.toString() << std::endl;
+    std::cout << result.value().toString() << std::endl;
   }
 
 

--- a/test/adapters/kagome/src/host_api/storage.cpp
+++ b/test/adapters/kagome/src/host_api/storage.cpp
@@ -166,4 +166,41 @@ namespace storage {
     std::cout << hash.toHex() << std::endl;
   }
 
+
+  void processNextKey(
+    const std::string_view key1, const std::string_view value1,
+    const std::string_view key2, const std::string_view value2
+  ) {
+    helpers::RuntimeEnvironment environment;
+
+    // No next key available
+    auto next = environment.execute<helpers::Buffer>("rtm_ext_storage_next_key_version_1", key1);
+    BOOST_ASSERT_MSG(next.empty(), "Next is empty");
+
+    next = environment.execute<helpers::Buffer>("rtm_ext_storage_next_key_version_1", key2);
+    BOOST_ASSERT_MSG(next.empty(), "Next is empty");
+
+    // Insert data
+    environment.execute<void>("rtm_ext_storage_set_version_1", key1, value1);
+    environment.execute<void>("rtm_ext_storage_set_version_1", key2, value2);
+
+    // Try to read next key
+    next = environment.execute<helpers::Buffer>("rtm_ext_storage_next_key_version_1", key1);
+    if (key1.compare(key2) < 0) {
+        BOOST_ASSERT_MSG(next.toString() == key2, "Next is Key2");
+        std::cout << next.toString() << std::endl;
+    } else {
+        BOOST_ASSERT_MSG(next.empty(), "Next is empty");
+    }
+
+    // Try to read next key
+    next = environment.execute<helpers::Buffer>("rtm_ext_storage_next_key_version_1", key2);
+    if (key2.compare(key1) < 0) {
+        BOOST_ASSERT_MSG(next.toString() == key1, "Next is Key2");
+        std::cout << next.toString() << std::endl;
+    } else {
+        BOOST_ASSERT_MSG(next.empty(), "Next is empty");
+    }
+  }
+
 } // namespace storage

--- a/test/adapters/kagome/src/host_api/storage.hpp
+++ b/test/adapters/kagome/src/host_api/storage.hpp
@@ -48,4 +48,10 @@ namespace storage {
     const std::string_view key2, const std::string_view value2
   );
 
+  // executes ext_storage_next_key_version_1 test
+  void processNextKey(
+    const std::string_view key1, const std::string_view value1,
+    const std::string_view key2, const std::string_view value2
+  );
+
 } // namespace storage

--- a/test/adapters/substrate/src/host_api/allocator.rs
+++ b/test/adapters/substrate/src/host_api/allocator.rs
@@ -10,7 +10,7 @@ pub fn ext_allocator_malloc_version_1(input: ParsedInput) {
     // Get invalid key
     let res = rtm
         .call("rtm_ext_allocator_malloc_version_1", &value.encode())
-        .decode_val();
+        .decode_vec();
     assert_eq!(res, value);
 
     println!("{}", str(&res));

--- a/test/adapters/substrate/src/host_api/child_storage.rs
+++ b/test/adapters/substrate/src/host_api/child_storage.rs
@@ -17,7 +17,7 @@ pub fn ext_storage_child_set_version_1(input: ParsedInput) {
             "rtm_ext_storage_child_get_version_1",
             &(child_key1, child_definition, child_type, key).encode(),
         )
-        .decode_option();
+        .decode_ovec();
     assert!(res.is_none());
 
     // Set key/value
@@ -32,7 +32,7 @@ pub fn ext_storage_child_set_version_1(input: ParsedInput) {
             "rtm_ext_storage_child_get_version_1",
             &(child_key2, child_definition, child_type, key).encode(),
         )
-        .decode_option();
+        .decode_ovec();
     assert!(res.is_none());
 
     // Get valid key
@@ -41,9 +41,8 @@ pub fn ext_storage_child_set_version_1(input: ParsedInput) {
             "rtm_ext_storage_child_get_version_1",
             &(child_key1, child_definition, child_type, key).encode(),
         )
-        .decode_option()
-        .unwrap()
-        .decode_val();
+        .decode_ovec()
+        .unwrap();
     assert_eq!(res, value);
 
     println!("{}", str(&res));
@@ -79,7 +78,7 @@ pub fn ext_storage_child_read_version_1(input: ParsedInput) {
             )
                 .encode(),
         )
-        .decode_val();
+        .decode_vec();
     assert_eq!(res, vec![0u8; buffer_size as usize]);
 
     // Set key/value
@@ -100,9 +99,9 @@ pub fn ext_storage_child_read_version_1(input: ParsedInput) {
                 offset,
                 buffer_size,
             )
-                .encode(),
+            .encode(),
         )
-        .decode_val();
+        .decode_vec();
     assert_eq!(res, vec![0u8; buffer_size as usize]);
 
     // Get valid key
@@ -119,7 +118,7 @@ pub fn ext_storage_child_read_version_1(input: ParsedInput) {
             )
                 .encode(),
         )
-        .decode_val();
+        .decode_vec();
 
     let offset = offset as usize;
     let buffer_size = buffer_size as usize;
@@ -174,9 +173,8 @@ pub fn ext_storage_child_clear_version_1(input: ParsedInput) {
             "rtm_ext_storage_child_get_version_1",
             &(child_key1, child_definition, child_type, key).encode(),
         )
-        .decode_option()
-        .unwrap()
-        .decode_val();
+        .decode_ovec()
+        .unwrap();
     assert_eq!(res, value);
 
     // Clear value
@@ -191,7 +189,7 @@ pub fn ext_storage_child_clear_version_1(input: ParsedInput) {
             "rtm_ext_storage_child_get_version_1",
             &(child_key1, child_definition, child_type, key).encode(),
         )
-        .decode_option();
+        .decode_ovec();
     assert!(res.is_none());
 }
 
@@ -231,9 +229,8 @@ pub fn ext_storage_child_storage_kill_version_1(input: ParsedInput) {
             "rtm_ext_storage_child_get_version_1",
             &(child_key1, child_definition, child_type, key1).encode(),
         )
-        .decode_option()
-        .unwrap()
-        .decode_val();
+        .decode_ovec()
+        .unwrap();
     assert_eq!(res, value1);
 
     // Get valid value
@@ -242,9 +239,8 @@ pub fn ext_storage_child_storage_kill_version_1(input: ParsedInput) {
             "rtm_ext_storage_child_get_version_1",
             &(child_key1, child_definition, child_type, key2).encode(),
         )
-        .decode_option()
-        .unwrap()
-        .decode_val();
+        .decode_ovec()
+        .unwrap();
     assert_eq!(res, value2);
 
     // Kill child
@@ -259,7 +255,7 @@ pub fn ext_storage_child_storage_kill_version_1(input: ParsedInput) {
             "rtm_ext_storage_child_get_version_1",
             &(child_key1, child_definition, child_type, key1).encode(),
         )
-        .decode_option();
+        .decode_ovec();
     assert!(res.is_none());
 
     // Get invalid killed value
@@ -268,7 +264,7 @@ pub fn ext_storage_child_storage_kill_version_1(input: ParsedInput) {
             "rtm_ext_storage_child_get_version_1",
             &(child_key1, child_definition, child_type, key2).encode(),
         )
-        .decode_option();
+        .decode_ovec();
     assert!(res.is_none());
 }
 
@@ -361,11 +357,11 @@ pub fn ext_storage_child_clear_prefix_version_1(input: ParsedInput) {
             "rtm_ext_storage_child_get_version_1",
             &(child_key1, child_definition, child_type, key1).encode(),
         )
-        .decode_option();
+        .decode_ovec();
     if key1.starts_with(prefix) {
         assert!(res.is_none());
     } else {
-        let val = res.unwrap().decode_val();
+        let val = res.unwrap();
         assert_eq!(val, value1);
         println!("{}", str(&val));
     }
@@ -376,11 +372,11 @@ pub fn ext_storage_child_clear_prefix_version_1(input: ParsedInput) {
             "rtm_ext_storage_child_get_version_1",
             &(child_key1, child_definition, child_type, key2).encode(),
         )
-        .decode_option();
+        .decode_ovec();
     if key2.starts_with(prefix) {
         assert!(res.is_none());
     } else {
-        let val = res.unwrap().decode_val();
+        let val = res.unwrap();
         assert_eq!(val, value2);
         println!("{}", str(&val));
     }
@@ -425,7 +421,7 @@ pub fn ext_storage_child_root_version_1(input: ParsedInput) {
     // Get root
     let res = rtm
         .call("rtm_ext_storage_child_root_version_1", &child_key1.encode())
-        .decode_val();
+        .decode_vec();
 
     println!("{}", hex::encode(res));
 }
@@ -454,7 +450,7 @@ pub fn ext_storage_child_next_key_version_1(input: ParsedInput) {
             "rtm_ext_storage_child_next_key_version_1",
             &(child_key1, child_definition, child_type, key1).encode(),
         )
-        .decode_option();
+        .decode_ovec();
     assert!(res.is_none());
 
     // Set key/value
@@ -473,9 +469,9 @@ pub fn ext_storage_child_next_key_version_1(input: ParsedInput) {
             "rtm_ext_storage_child_next_key_version_1",
             &(child_key1, child_definition, child_type, key1).encode(),
         )
-        .decode_option();
+        .decode_ovec();
     if key1 == track[0] {
-        assert_eq!(res.unwrap().decode_val(), key2);
+        assert_eq!(res.unwrap(), key2);
         println!("{}", str(&key2));
     } else {
         assert!(res.is_none());
@@ -487,9 +483,9 @@ pub fn ext_storage_child_next_key_version_1(input: ParsedInput) {
             "rtm_ext_storage_child_next_key_version_1",
             &(child_key1, child_definition, child_type, key2).encode(),
         )
-        .decode_option();
+        .decode_ovec();
     if key2 == track[0] {
-        assert_eq!(res.unwrap().decode_val(), key1);
+        assert_eq!(res.unwrap(), key1);
         println!("{}", str(&key1));
     } else {
         assert!(res.is_none());
@@ -501,7 +497,7 @@ pub fn ext_storage_child_next_key_version_1(input: ParsedInput) {
             "rtm_ext_storage_child_next_key_version_1",
             &(child_key2, child_definition, child_type, key1).encode(),
         )
-        .decode_option();
+        .decode_ovec();
     assert!(res.is_none());
 
     // Get invalid next key (different child key)
@@ -510,6 +506,6 @@ pub fn ext_storage_child_next_key_version_1(input: ParsedInput) {
             "rtm_ext_storage_child_next_key_version_1",
             &(child_key2, child_definition, child_type, key2).encode(),
         )
-        .decode_option();
+        .decode_ovec();
     assert!(res.is_none());
 }

--- a/test/adapters/substrate/src/host_api/crypto.rs
+++ b/test/adapters/substrate/src/host_api/crypto.rs
@@ -14,7 +14,7 @@ pub fn ext_crypto_ed25519_public_keys_version_1(input: ParsedInput) {
             "rtm_ext_crypto_ed25519_generate_version_1",
             &(DUMMY.0, Some(seed1)).encode(),
         )
-        .decode_val();
+        .decode_vec();
 
     // Generate second key
     let pubkey2 = rtm
@@ -22,16 +22,16 @@ pub fn ext_crypto_ed25519_public_keys_version_1(input: ParsedInput) {
             "rtm_ext_crypto_ed25519_generate_version_1",
             &(DUMMY.0, Some(seed2)).encode(),
         )
-        .decode_val();
+        .decode_vec();
 
     let mut res = rtm
         .call(
             "rtm_ext_crypto_ed25519_public_keys_version_1",
             &DUMMY.0.encode(),
         )
-        .decode_val();
+        .decode_vec();
 
-    res.remove(0);
+    res.remove(0); // TODO: Check content
     assert_eq!(res.len(), 64);
     let res1 = &res[..32]; // first pubkey
     let res2 = &res[32..]; // second pubkey
@@ -58,7 +58,7 @@ pub fn ext_crypto_ed25519_generate_version_1(input: ParsedInput) {
             "rtm_ext_crypto_ed25519_generate_version_1",
             &(DUMMY.0, Some(seed)).encode(),
         )
-        .decode_val();
+        .decode_vec();
 
     println!("{}", hex::encode(res));
 }
@@ -75,16 +75,19 @@ pub fn ext_crypto_ed25519_sign_version_1(input: ParsedInput) {
             "rtm_ext_crypto_ed25519_generate_version_1",
             &(DUMMY.0, Some(seed)).encode(),
         )
-        .decode_val();
+        .decode_vec();
 
     // Sign message
-    let res = rtm
+    let mut res = rtm
         .call(
             "rtm_ext_crypto_ed25519_sign_version_1",
             &(DUMMY.0, &pubkey, msg).encode(),
         )
-        .decode_option()
-        .unwrap();
+        .decode_vec();
+
+    // Check option
+    assert_eq!(res[0], 1u8);
+    res.remove(0);
 
     println!("Message: {}", str(&msg));
     println!("Public key: {}", hex::encode(pubkey));
@@ -103,16 +106,19 @@ pub fn ext_crypto_ed25519_verify_version_1(input: ParsedInput) {
             "rtm_ext_crypto_ed25519_generate_version_1",
             &(DUMMY.0, Some(seed)).encode(),
         )
-        .decode_val();
+        .decode_vec();
 
     // Sign message
-    let sig = rtm
+    let mut sig = rtm
         .call(
             "rtm_ext_crypto_ed25519_sign_version_1",
             &(DUMMY.0, &pubkey, &msg).encode(),
         )
-        .decode_option()
-        .unwrap();
+        .decode_vec();
+
+    // Check option
+    assert_eq!(sig[0], 1u8);
+    sig.remove(0);
 
     // Verify signature
     let verified = rtm
@@ -145,7 +151,7 @@ pub fn ext_crypto_sr25519_public_keys_version_1(input: ParsedInput) {
             "rtm_ext_crypto_sr25519_generate_version_1",
             &(DUMMY.0, Some(seed1)).encode(),
         )
-        .decode_val();
+        .decode_vec();
 
     // Generate second key
     let pubkey2 = rtm
@@ -153,16 +159,16 @@ pub fn ext_crypto_sr25519_public_keys_version_1(input: ParsedInput) {
             "rtm_ext_crypto_sr25519_generate_version_1",
             &(DUMMY.0, Some(seed2)).encode(),
         )
-        .decode_val();
+        .decode_vec();
 
     let mut res = rtm
         .call(
             "rtm_ext_crypto_sr25519_public_keys_version_1",
             &DUMMY.0.encode(),
         )
-        .decode_val();
+        .decode_vec();
 
-    res.remove(0);
+    res.remove(0); // TODO: Check content
     assert_eq!(res.len(), 64);
     let res1 = &res[..32]; // first pubkey
     let res2 = &res[32..]; // second pubkey
@@ -191,7 +197,7 @@ pub fn ext_crypto_sr25519_generate_version_1(input: ParsedInput) {
             "rtm_ext_crypto_sr25519_generate_version_1",
             &(DUMMY.0, seed_opt).encode(),
         )
-        .decode_val();
+        .decode_vec();
 
     println!("{}", hex::encode(res));
 }
@@ -208,16 +214,19 @@ pub fn ext_crypto_sr25519_sign_version_1(input: ParsedInput) {
             "rtm_ext_crypto_sr25519_generate_version_1",
             &(DUMMY.0, Some(seed)).encode(),
         )
-        .decode_val();
+        .decode_vec();
 
     // Sign message
-    let res = rtm
+    let mut res = rtm
         .call(
             "rtm_ext_crypto_sr25519_sign_version_1",
             &(DUMMY.0, &pubkey, msg).encode(),
         )
-        .decode_option()
-        .unwrap();
+        .decode_vec();
+
+    // Check option
+    assert_eq!(res[0], 1u8);
+    res.remove(0);
 
     println!("Message: {}", str(&msg));
     println!("Public key: {}", hex::encode(pubkey));
@@ -236,16 +245,19 @@ pub fn ext_crypto_sr25519_verify_version_1(input: ParsedInput) {
             "rtm_ext_crypto_sr25519_generate_version_1",
             &(DUMMY.0, Some(seed)).encode(),
         )
-        .decode_val();
+        .decode_vec();
 
     // Sign message
-    let sig = rtm
+    let mut sig = rtm
         .call(
             "rtm_ext_crypto_sr25519_sign_version_1",
             &(DUMMY.0, &pubkey, &msg).encode(),
         )
-        .decode_option()
-        .unwrap();
+        .decode_vec();
+
+    // Check option
+    assert_eq!(sig[0], 1u8);
+    sig.remove(0);
 
     let verified = rtm
         .call(
@@ -273,7 +285,7 @@ pub fn ext_hashing_keccak_256_version_1(input: ParsedInput) {
 
     let res = rtm
         .call("rtm_ext_hashing_keccak_256_version_1", &(data).encode())
-        .decode_val();
+        .decode_vec();
 
     println!("{}", hex::encode(res));
 }
@@ -285,7 +297,7 @@ pub fn ext_hashing_sha2_256_version_1(input: ParsedInput) {
 
     let res = rtm
         .call("rtm_ext_hashing_sha2_256_version_1", &(data).encode())
-        .decode_val();
+        .decode_vec();
 
     println!("{}", hex::encode(res));
 }
@@ -297,7 +309,7 @@ pub fn ext_hashing_blake2_128_version_1(input: ParsedInput) {
 
     let res = rtm
         .call("rtm_ext_hashing_blake2_128_version_1", &(data).encode())
-        .decode_val();
+        .decode_vec();
 
     println!("{}", hex::encode(res));
 }
@@ -309,7 +321,7 @@ pub fn ext_hashing_blake2_256_version_1(input: ParsedInput) {
 
     let res = rtm
         .call("rtm_ext_hashing_blake2_256_version_1", &(data).encode())
-        .decode_val();
+        .decode_vec();
 
     println!("{}", hex::encode(res));
 }
@@ -321,7 +333,7 @@ pub fn ext_hashing_twox_256_version_1(input: ParsedInput) {
 
     let res = rtm
         .call("rtm_ext_hashing_twox_256_version_1", &(data).encode())
-        .decode_val();
+        .decode_vec();
 
     println!("{}", hex::encode(res));
 }
@@ -333,7 +345,7 @@ pub fn ext_hashing_twox_128_version_1(input: ParsedInput) {
 
     let res = rtm
         .call("rtm_ext_hashing_twox_128_version_1", &(data).encode())
-        .decode_val();
+        .decode_vec();
 
     println!("{}", hex::encode(res));
 }
@@ -345,7 +357,7 @@ pub fn ext_hashing_twox_64_version_1(input: ParsedInput) {
 
     let res = rtm
         .call("rtm_ext_hashing_twox_64_version_1", &(data).encode())
-        .decode_val();
+        .decode_vec();
 
     println!("{}", hex::encode(res));
 }

--- a/test/adapters/substrate/src/host_api/storage.rs
+++ b/test/adapters/substrate/src/host_api/storage.rs
@@ -5,7 +5,7 @@ pub fn test_storage_init() {
     let mut rtm = Runtime::new();
 
     // Compute and print storage root on init
-    let res = rtm.call("rtm_ext_storage_root_version_1", &[]).decode_val();
+    let res = rtm.call("rtm_ext_storage_root_version_1", &[]).decode_vec();
 
     println!("{}", hex::encode(res));
 }
@@ -19,7 +19,7 @@ pub fn ext_storage_set_version_1(input: ParsedInput) {
     // Get invalid key
     let res = rtm
         .call("rtm_ext_storage_get_version_1", &key.encode())
-        .decode_option();
+        .decode_ovec();
     assert!(res.is_none());
 
     // Set key/value
@@ -28,9 +28,8 @@ pub fn ext_storage_set_version_1(input: ParsedInput) {
     // Get valid key
     let res = rtm
         .call("rtm_ext_storage_get_version_1", &key.encode())
-        .decode_option()
-        .unwrap()
-        .decode_val();
+        .decode_ovec()
+        .unwrap();
     assert_eq!(res, value);
 
     println!("{}", str(&res));
@@ -54,7 +53,7 @@ pub fn ext_storage_read_version_1(input: ParsedInput) {
             "rtm_ext_storage_read_version_1",
             &(key, offset, buffer_size).encode(),
         )
-        .decode_val();
+        .decode_vec();
     assert_eq!(res, vec![0u8; buffer_size as usize]);
 
     // Set key/value
@@ -66,7 +65,7 @@ pub fn ext_storage_read_version_1(input: ParsedInput) {
             "rtm_ext_storage_read_version_1",
             &(key, offset, buffer_size).encode(),
         )
-        .decode_val();
+        .decode_vec();
 
     let offset = offset as usize;
     let buffer_size = buffer_size as usize;
@@ -106,7 +105,7 @@ pub fn ext_storage_clear_version_1(input: ParsedInput) {
     // Get cleared value
     let res = rtm
         .call("rtm_ext_storage_get_version_1", &key.encode())
-        .decode_option();
+        .decode_ovec();
     assert!(res.is_none());
 }
 
@@ -150,23 +149,21 @@ pub fn ext_storage_clear_prefix_version_1(input: ParsedInput) {
     // Check first key
     let res = rtm
         .call("rtm_ext_storage_get_version_1", &key1.encode())
-        .decode_option();
+        .decode_ovec();
     if key1.starts_with(prefix) {
         assert!(res.is_none());
     } else {
-        let val = res.unwrap().decode_val();
-        assert_eq!(val, value1);
+        assert_eq!(res.unwrap(), value1);
     }
 
     // Check second key
     let res = rtm
         .call("rtm_ext_storage_get_version_1", &key2.encode())
-        .decode_option();
+        .decode_ovec();
     if key2.starts_with(prefix) {
         assert!(res.is_none());
     } else {
-        let val = res.unwrap().decode_val();
-        assert_eq!(val, value2);
+        assert_eq!(res.unwrap(), value2);
     }
 }
 
@@ -183,7 +180,7 @@ pub fn ext_storage_root_version_1(input: ParsedInput) {
     let _ = rtm.call("rtm_ext_storage_set_version_1", &(key2, value2).encode());
 
     // Get root
-    let res = rtm.call("rtm_ext_storage_root_version_1", &[]).decode_val();
+    let res = rtm.call("rtm_ext_storage_root_version_1", &[]).decode_vec();
 
     println!("{}", hex::encode(res));
 }
@@ -205,12 +202,12 @@ pub fn ext_storage_next_key_version_1(input: ParsedInput) {
     // No next key available
     let res = rtm
         .call("rtm_ext_storage_next_key_version_1", &key1.encode())
-        .decode_option();
+        .decode_ovec();
     assert!(res.is_none());
 
     let res = rtm
         .call("rtm_ext_storage_next_key_version_1", &key2.encode())
-        .decode_option();
+        .decode_ovec();
     assert!(res.is_none());
 
     // Set key/value
@@ -220,9 +217,10 @@ pub fn ext_storage_next_key_version_1(input: ParsedInput) {
     // Try to read next key
     let res = rtm
         .call("rtm_ext_storage_next_key_version_1", &key1.encode())
-        .decode_option();
+        .decode_ovec();
+
     if key1 == track[0] {
-        assert_eq!(res.unwrap().decode_val(), key2);
+        assert_eq!(res.unwrap(), key2);
         println!("{}", str(&key2));
     } else {
         assert!(res.is_none());
@@ -231,9 +229,10 @@ pub fn ext_storage_next_key_version_1(input: ParsedInput) {
     // Try to read next key
     let res = rtm
         .call("rtm_ext_storage_next_key_version_1", &key2.encode())
-        .decode_option();
+        .decode_ovec();
+
     if key2 == track[0] {
-        assert_eq!(res.unwrap().decode_val(), key1);
+        assert_eq!(res.unwrap(), key1);
         println!("{}", str(&key1));
     } else {
         assert!(res.is_none());

--- a/test/adapters/substrate/src/host_api/storage.rs
+++ b/test/adapters/substrate/src/host_api/storage.rs
@@ -208,6 +208,11 @@ pub fn ext_storage_next_key_version_1(input: ParsedInput) {
         .decode_option();
     assert!(res.is_none());
 
+    let res = rtm
+        .call("rtm_ext_storage_next_key_version_1", &key2.encode())
+        .decode_option();
+    assert!(res.is_none());
+
     // Set key/value
     let _ = rtm.call("rtm_ext_storage_set_version_1", &(key1, value1).encode());
     let _ = rtm.call("rtm_ext_storage_set_version_1", &(key2, value2).encode());

--- a/test/adapters/substrate/src/host_api/trie.rs
+++ b/test/adapters/substrate/src/host_api/trie.rs
@@ -16,7 +16,7 @@ pub fn ext_trie_blake2_256_root_version_1(input: ParsedInput) {
     // Get valid key
     let res = rtm
         .call("rtm_ext_trie_blake2_256_root_version_1", &(trie).encode())
-        .decode_val();
+        .decode_vec();
 
     println!("{}", hex::encode(res));
 }
@@ -36,7 +36,7 @@ pub fn ext_trie_blake2_256_ordered_root_version_1(input: ParsedInput) {
             "rtm_ext_trie_blake2_256_ordered_root_version_1",
             &(trie).encode(),
         )
-        .decode_val();
+        .decode_vec();
 
     println!("{}", hex::encode(res));
 }

--- a/test/adapters/substrate/src/host_api/utils.rs
+++ b/test/adapters/substrate/src/host_api/utils.rs
@@ -112,33 +112,19 @@ impl Runtime {
 }
 
 pub trait Decoder {
-    fn decode_val(&self) -> Vec<u8>;
-    fn decode_option(&self) -> Option<Vec<u8>>;
+    fn decode_vec(&self) -> Vec<u8>;
+    fn decode_ovec(&self) -> Option<Vec<u8>>;
     fn decode_bool(&self) -> bool;
 }
 
 impl Decoder for Vec<u8> {
-    fn decode_val(&self) -> Vec<u8> {
-        Vec::<u8>::decode(&mut self.as_slice()).expect("Failed to decode SCALE encoding")
+    fn decode_vec(&self) -> Vec<u8> {
+        Decode::decode(&mut self.as_slice()).expect("Failed to decode SCALE encoding")
     }
-    fn decode_option(&self) -> Option<Vec<u8>> {
-        let mut option =
-            Vec::<u8>::decode(&mut self.as_slice()).expect("Failed to decode SCALE encoding");
-        match option[0] {
-            0 => {
-                if option.len() > 1 {
-                    panic!("The None value appends additional data");
-                }
-                None
-            }
-            1 => {
-                option.remove(0);
-                Some(option)
-            }
-            _ => panic!("Not a valid Option value"),
-        }
+    fn decode_ovec(&self) -> Option<Vec<u8>> {
+        Decode::decode(&mut self.as_slice()).expect("Failed to decode SCALE encoding")
     }
     fn decode_bool(&self) -> bool {
-        bool::decode(&mut self.as_slice()).expect("Failed to decode SCALE encoding")
+        Decode::decode(&mut self.as_slice()).expect("Failed to decode SCALE encoding")
     }
 }

--- a/test/adapters/wasm/src/lib.rs
+++ b/test/adapters/wasm/src/lib.rs
@@ -100,12 +100,12 @@ impl AsRePtr for Vec<u8> {
 sp_core::wasm_export_functions! {
     fn rtm_ext_storage_get_version_1(
         key_data: Vec<u8>
-    ) -> Vec<u8> {
+    ) -> Option<Vec<u8>> {
         unsafe {
             let value = ext_storage_get_version_1(
                 key_data.as_re_ptr(),
             );
-            from_mem(value)
+            Decode::decode(&mut from_mem(value).as_slice()).unwrap()
         }
     }
     fn rtm_ext_storage_child_get_version_1(
@@ -113,7 +113,7 @@ sp_core::wasm_export_functions! {
         child_definition: Vec<u8>,
         child_type: u32,
         key_data: Vec<u8>
-    ) -> Vec<u8> {
+    ) -> Option<Vec<u8>> {
         unsafe {
             let value = ext_storage_child_get_version_1(
                 child_key.as_re_ptr(),
@@ -121,7 +121,7 @@ sp_core::wasm_export_functions! {
                 child_type,
                 key_data.as_re_ptr(),
             );
-            from_mem(value)
+            Decode::decode(&mut from_mem(value).as_slice()).unwrap()
         }
     }
     fn rtm_ext_storage_read_version_1(
@@ -287,12 +287,12 @@ sp_core::wasm_export_functions! {
             from_mem(value)
         }
     }
-    fn rtm_ext_storage_next_key_version_1(key_data: Vec<u8>) -> Vec<u8> {
+    fn rtm_ext_storage_next_key_version_1(key_data: Vec<u8>) -> Option<Vec<u8>> {
         unsafe {
             let value = ext_storage_next_key_version_1(
                 key_data.as_re_ptr(),
             );
-            from_mem(value)
+            Decode::decode(&mut from_mem(value).as_slice()).unwrap()
         }
     }
     fn rtm_ext_storage_child_next_key_version_1(
@@ -300,7 +300,7 @@ sp_core::wasm_export_functions! {
         child_definition: Vec<u8>,
         child_type: u32,
         key_data: Vec<u8>
-    ) -> Vec<u8> {
+    ) -> Option<Vec<u8>> {
         unsafe {
             let value = ext_storage_child_next_key_version_1(
                 child_key.as_re_ptr(),
@@ -308,7 +308,7 @@ sp_core::wasm_export_functions! {
                 child_type,
                 key_data.as_re_ptr(),
             );
-            from_mem(value)
+            Decode::decode(&mut from_mem(value).as_slice()).unwrap()
         }
     }
     fn rtm_ext_crypto_ed25519_public_keys_version_1(id_data: [u8; 4]) -> Vec<u8> {


### PR DESCRIPTION
This implements the test of `ext_storage_next_key_version_1` host-api for the `kagome-adapter`. It currently fails, as Kagome assumes the passed key has to be a valid, which causes it to panic. In reality it should just return the next lexicographic key in storage or an empty result if there are not further keys after the passed value in storage. 

Before this can be merged the following things have to happen:
 - [x] The spec has to be updated to reflect that the key does not have exists (#272)
 - [x] Fix double encoding in wasm adapter for next_key and get (1d94faf)
 - [x] Update kagome- and substrate-adapter to fixed encoding  (f0341d3, a1d7515, 5af6362) 
 - [x] Depends on Kagome fixing `storage_next_key`, see soramitsu/kagome#510 (not in master, using branch under review)
 - [x] Depends on Kagome merging our fix for `storage_get`, see soramitsu/kagome#518