### PR TITLE
kagome-adapter-legacy: Re-enable ext_blake2_256_enumerated_trie_root test

### DIFF
--- a/test/adapters/kagome-legacy/src/extension/crypto.cpp
+++ b/test/adapters/kagome-legacy/src/extension/crypto.cpp
@@ -51,8 +51,6 @@ namespace crypto {
 
   // Input: value1, value2
   void processExtBlake2_256EnumeratedTrieRoot(const std::vector<std::string> &args) {
-    throw NotImplemented();
-
     helpers::RuntimeEnvironment environment;
 
     // Parse input arguments


### PR DESCRIPTION
This is the last outstanding issue I could not resolve in #256 and because it is in the legacy host api, I split this of into a separate issue. It came up with the switch to calling the api through the `wasm-adapter-legacy`.

So far I could not figure out why this fails, it should call the runtime in the exact same way the substrate-adapter-legacy does (down to the scale encoding of the arguments, as far as I could check). Without further debugging inside kagome, I can only assume it is an issue there.

Example failure from CI:
```
┌ Error: Adapter failed running `kagome-adapter-legacy host-api --function test_blake2_256_enumerated_trie_root --input static,Inverse`:
│ [trap unreachable]
│ Error inside function 'R helpers::RuntimeEnvironment::execute(std::string_view, Args&& ...) [with R = kagome::common::Buffer; Args = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::vector<unsigned int, std::allocator<unsigned int> >&}; std::string_view = std::basic_string_view<char>]' in file '/home/runner/work/polkadot-spec/polkadot-spec/test/adapters/kagome-legacy/src/extension/helpers.hpp' on line '51' when evaluating 'result': An error occurred during an export call execution
│ terminate called after throwing an instance of 'boost::wrapexcept<std::system_error>'
│   what():  An error occurred during an export call execution
└ @ Main.SpecificationTestsuite.AdapterFixture ~/work/polkadot-spec/polkadot-spec/test/helpers/AdapterFixture.jl:157
Host API Legacy: Test Failed at /home/runner/work/polkadot-spec/polkadot-spec/test/helpers/AdapterFixture.jl:158
  Expression: success(proc)
Stacktrace:
 [1] run(::Main.SpecificationTestsuite.AdapterFixture.Builder, ::String) at /home/runner/work/polkadot-spec/polkadot-spec/test/helpers/AdapterFixture.jl:158
 [2] macro expansion at /home/runner/work/polkadot-spec/polkadot-spec/test/helpers/AdapterFixture.jl:192 [inlined]
 [3] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Test/src/Test.jl:1115 [inlined]
 [4] execute(::Main.SpecificationTestsuite.AdapterFixture.Builder; legacy::Bool) at /home/runner/work/polkadot-spec/polkadot-spec/test/helpers/AdapterFixture.jl:185
```