### PR TITLE
kagome-adapter: Add host-api allocator test

### DIFF
--- a/test/adapters/kagome/CMakeLists.txt
+++ b/test/adapters/kagome/CMakeLists.txt
@@ -82,6 +82,8 @@ add_executable(kagome-adapter
   src/host_api.hpp
   src/host_api/helpers.cpp
   src/host_api/helpers.hpp
+  src/host_api/allocator.cpp
+  src/host_api/allocator.hpp
   src/host_api/crypto.cpp
   src/host_api/crypto.hpp
   src/host_api/hashing.cpp

--- a/test/adapters/kagome/src/host_api.cpp
+++ b/test/adapters/kagome/src/host_api.cpp
@@ -25,6 +25,7 @@
 #include "subcommand.hpp"
 
 #include "host_api.hpp"
+#include "host_api/allocator.hpp"
 #include "host_api/crypto.hpp"
 #include "host_api/hashing.hpp"
 #include "host_api/storage.hpp"
@@ -184,12 +185,12 @@ void processHostApiCommands(const HostApiCommandArgs& args){
     hashing::processHashFunction("twox", 32, args[0]);
   });
 
-  // test allocator TODO: all not implemented
+  // test allocator
   router.addSubcommand("ext_allocator_malloc_version_1", [](const std::vector<std::string>& args) {
-    throw NotImplemented(); // TODO not implemented
+    allocator::processMallocFree(args[0]);
   });
   router.addSubcommand("ext_allocator_free_version_1", [](const std::vector<std::string>& args) {
-    throw NotImplemented(); // TODO not implemented
+    allocator::processMallocFree(args[0]);
   });
 
   // test trie hashes

--- a/test/adapters/kagome/src/host_api/allocator.cpp
+++ b/test/adapters/kagome/src/host_api/allocator.cpp
@@ -17,30 +17,25 @@
  * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "hashing.hpp"
+#include "allocator.hpp"
 
 #include "helpers.hpp"
 
 #include <iostream>
-#include <sstream>
 
-namespace hashing {
+namespace allocator {
 
-  void processHashFunction(
-    const std::string_view name, uint32_t size, const std::string_view input
-  ) {
+  void processMallocFree(const std::string_view value) {
     helpers::RuntimeEnvironment environment;
 
-    // Call hash function
-    std::stringstream function;
-    function << "rtm_ext_hashing_" << name << "_" << size * 8 << "_version_1";
+    // The Wasm function tests both the allocation and freeing of the buffer
+    auto result = environment.execute<helpers::Buffer>(
+      "rtm_ext_allocator_malloc_version_1", value
+    );
 
-    auto hash = environment.execute<helpers::Buffer>(function.str(), input);
+    BOOST_ASSERT_MSG(result.toString() == value, "Values are different");
 
-    BOOST_ASSERT_MSG(hash.size() == size, "Incorrect hash size.");
-
-    // Print result
-    std::cout << hash.toHex() << std::endl;
+    std::cout << result.toString() << std::endl;
   }
 
 }

--- a/test/adapters/kagome/src/host_api/allocator.hpp
+++ b/test/adapters/kagome/src/host_api/allocator.hpp
@@ -17,30 +17,15 @@
  * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "hashing.hpp"
+#pragma once
 
-#include "helpers.hpp"
+#include <string>
+#include <vector>
 
-#include <iostream>
-#include <sstream>
+namespace allocator {
+  // executes ext_allocator_malloc and ext_allocator_free tests according to provided arg
+  // Input: value
+  void processMallocFree(const std::string_view value);
 
-namespace hashing {
+} // namespace allocator
 
-  void processHashFunction(
-    const std::string_view name, uint32_t size, const std::string_view input
-  ) {
-    helpers::RuntimeEnvironment environment;
-
-    // Call hash function
-    std::stringstream function;
-    function << "rtm_ext_hashing_" << name << "_" << size * 8 << "_version_1";
-
-    auto hash = environment.execute<helpers::Buffer>(function.str(), input);
-
-    BOOST_ASSERT_MSG(hash.size() == size, "Incorrect hash size.");
-
-    // Print result
-    std::cout << hash.toHex() << std::endl;
-  }
-
-}


### PR DESCRIPTION
This PR implements the `ext_allocator_malloc_version_1` and `ext_allocator_free_version_1` test for the `kagome-adapter`.