### PR TITLE
wasm-adapter: check storage_read return value and update to default_child_storage

### DIFF
--- a/host-spec/ae-hostapi.tm
+++ b/host-spec/ae-hostapi.tm
@@ -127,11 +127,12 @@
     <item><verbatim|offset>: an u32 integer containing the offset beyond the
     value should be read from.
 
-    <item><verbatim|result>: a pointer-size as defined in Definition
-    <reference|defn-runtime-pointer> indicating the SCALE encoded
-    <verbatim|Option> as defined in Definition <reference|defn-option-type>
-    containing the number of bytes written into the <verbatim|value_out>
-    buffer. Returns <verbatim|None> if the entry does not exists.
+    <item><verbatim|result>: a pointer-size (def.
+    <reference|defn-runtime-pointer>) pointing to a SCALE encoded
+    <verbatim|Option> (def. <reference|defn-option-type>) containing an
+    unsinged 32-bit interger representing the number of bytes left at
+    supplied <verbatim|offset>. Returns <verbatim|None> if the entry does not
+    exists.
   </itemize>
 
   <subsection|<verbatim|ext_storage_clear>>

--- a/test/adapters/kagome/cmake/HunterConfig.cmake
+++ b/test/adapters/kagome/cmake/HunterConfig.cmake
@@ -20,8 +20,8 @@
 
 # Should point to the version of kagome to be tested (currently a custom fork with small fixes atop master)
 hunter_config(kagome
-  URL https://github.com/soramitsu/kagome/archive/07536249ac2b1d5d5ee9b6d9455d01b815073304.tar.gz
-  SHA1 888f2c6e06442e3f8a460fa2a10d9f74c34d5891
+  URL https://github.com/soramitsu/kagome/archive/70e4719a81c69c8dc238187a98d1b077f54f0913.tar.gz
+  SHA1 a480c70af74b773a9c335a01e0deb85273b559ff
   CMAKE_ARGS TESTING=OFF
 )
 

--- a/test/adapters/kagome/src/host_api.cpp
+++ b/test/adapters/kagome/src/host_api.cpp
@@ -108,31 +108,31 @@ void processHostApiCommands(const HostApiCommandArgs& args){
   });
 
   // test child storage TODO: all not implemented
-  router.addSubcommand("ext_storage_child_set_version_1", [](const std::vector<std::string>& args) {
+  router.addSubcommand("ext_default_child_storage_set_version_1", [](const std::vector<std::string>& args) {
     throw NotImplemented(); // TODO not implemented
   });
-  router.addSubcommand("ext_storage_child_get_version_1", [](const std::vector<std::string>& args) {
+  router.addSubcommand("ext_default_child_storage_get_version_1", [](const std::vector<std::string>& args) {
     throw NotImplemented(); // TODO not implemented
   });
-  router.addSubcommand("ext_storage_child_read_version_1", [](const std::vector<std::string>& args) {
+  router.addSubcommand("ext_default_child_storage_read_version_1", [](const std::vector<std::string>& args) {
     throw NotImplemented(); // TODO not implemented
   });
-  router.addSubcommand("ext_storage_child_clear_version_1", [](const std::vector<std::string>& args) {
+  router.addSubcommand("ext_default_child_storage_clear_version_1", [](const std::vector<std::string>& args) {
     throw NotImplemented(); // TODO not implemented
   });
-  router.addSubcommand("ext_storage_child_storage_kill_version_1", [](const std::vector<std::string>& args) {
+  router.addSubcommand("ext_default_child_storage_storage_kill_version_1", [](const std::vector<std::string>& args) {
     throw NotImplemented(); // TODO not implemented
   });
-  router.addSubcommand("ext_storage_child_exists_version_1", [](const std::vector<std::string>& args) {
+  router.addSubcommand("ext_default_child_storage_exists_version_1", [](const std::vector<std::string>& args) {
     throw NotImplemented(); // TODO not implemented
   });
-  router.addSubcommand("ext_storage_child_clear_prefix_version_1", [](const std::vector<std::string>& args) {
+  router.addSubcommand("ext_default_child_storage_clear_prefix_version_1", [](const std::vector<std::string>& args) {
     throw NotImplemented(); // TODO not implemented
   });
-  router.addSubcommand("ext_storage_child_root_version_1", [](const std::vector<std::string>& args) {
+  router.addSubcommand("ext_default_child_storage_root_version_1", [](const std::vector<std::string>& args) {
     throw NotImplemented(); // TODO not implemented
   });
-  router.addSubcommand("ext_storage_child_next_key_version_1", [](const std::vector<std::string>& args) {
+  router.addSubcommand("ext_default_child_storage_next_key_version_1", [](const std::vector<std::string>& args) {
     throw NotImplemented(); // TODO not implemented
   });
 

--- a/test/adapters/kagome/src/host_api.cpp
+++ b/test/adapters/kagome/src/host_api.cpp
@@ -89,7 +89,7 @@ void processHostApiCommands(const HostApiCommandArgs& args){
     storage::processSetGet(args[0], args[1]);
   });
   router.addSubcommand("ext_storage_read_version_1", [](const std::vector<std::string>& args) {
-    throw NotImplemented(); // TODO not implemented
+    storage::processRead(args[0], args[1], std::stoul(args[2]), std::stoul(args[3]));
   });
   router.addSubcommand("ext_storage_clear_version_1", [](const std::vector<std::string>& args) {
     storage::processClear(args[0], args[1]);

--- a/test/adapters/kagome/src/host_api/storage.hpp
+++ b/test/adapters/kagome/src/host_api/storage.hpp
@@ -30,6 +30,14 @@ namespace storage {
   // executes ext_storage_set_version_1/ext_storage_get_version_1 test
   void processSetGet(const std::string_view key, const std::string_view value);
 
+  // executes ext_storage_set_version_1/ext_storage_get_version_1 test
+  void processRead(
+      const std::string_view key,
+      const std::string_view value,
+      const uint32_t offset,
+      const uint32_t length
+  );
+
   // executes ext_storage_clear_version_1 test
   void processClear(const std::string_view key, const std::string_view value);
 

--- a/test/adapters/substrate/Cargo.lock
+++ b/test/adapters/substrate/Cargo.lock
@@ -11,6 +11,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+
+[[package]]
 name = "ahash"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20,10 +35,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.10"
+name = "ahash"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 dependencies = [
  "memchr",
 ]
@@ -74,30 +95,22 @@ checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.46"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
+checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 dependencies = [
- "backtrace-sys",
+ "addr2line",
  "cfg-if",
  "libc",
+ "miniz_oxide",
+ "object",
  "rustc-demangle",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -108,9 +121,9 @@ checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
 
 [[package]]
 name = "base64"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "bitflags"
@@ -153,7 +166,16 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -205,12 +227,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d"
-
-[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,19 +249,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "clear_on_drop"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags 1.2.1",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 dependencies = [
  "bitflags 1.2.1",
 ]
@@ -277,6 +293,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,34 +310,47 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
  "subtle 1.0.0",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
+checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.8.1",
  "rand_core",
- "subtle 2.2.2",
+ "subtle 2.3.0",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core",
+ "subtle 2.3.0",
  "zeroize",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c0346158a19b3627234e15596f5e465c360fcdb97d817bcb255e0510f5a788"
+checksum = "d4d0e2d24e5ee3b23a01de38eefdcd978907890701f08ffffd4cb457ca4ee8d6"
 
 [[package]]
 name = "derive_more"
-version = "0.99.5"
+version = "0.99.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
+checksum = "1dcfabdab475c16a93d669dddfc393027803e347d09663f524447f642fbb84ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -328,32 +363,79 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
 name = "dtoa"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
+checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+
+[[package]]
+name = "dyn-clonable"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e9232f0e607a262ceb9bd5141a3dfb3e4db6994b31989bbfd845878cba59fd4"
+dependencies = [
+ "dyn-clonable-impl",
+ "dyn-clone",
+]
+
+[[package]]
+name = "dyn-clonable-impl"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558e40ea573c374cf53507fd240b7ee2f5477df7cfebdb97323ec61c719399c5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c53dc3a653e0f64081026e4bf048d48fec9fce90c66e8326ca7292df0ff2d82"
+
+[[package]]
+name = "ed25519"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07dfc993ea376e864fe29a4099a61ca0bb994c6d7745a61bf60ddb3d64e05237"
+dependencies = [
+ "signature",
+]
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.0-pre.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
+checksum = "53d2e93f837d749c16d118e7ddf7a4dfd0ac8f452cf51e46e9348824e5ef6851"
 dependencies = [
- "clear_on_drop",
- "curve25519-dalek",
+ "curve25519-dalek 3.0.0",
+ "ed25519",
  "rand",
- "sha2",
+ "serde",
+ "sha2 0.9.1",
+ "zeroize",
 ]
 
 [[package]]
 name = "either"
-version = "1.5.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "environmental"
@@ -526,15 +608,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.1.14"
+name = "generic-array"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
 name = "hash-db"
@@ -566,15 +664,25 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
 dependencies = [
- "ahash",
+ "ahash 0.2.18",
  "autocfg 0.1.7",
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.12"
+name = "hashbrown"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
+checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
+dependencies = [
+ "ahash 0.3.8",
+ "autocfg 1.0.1",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 dependencies = [
  "libc",
 ]
@@ -592,7 +700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.8.1",
 ]
 
 [[package]]
@@ -601,8 +709,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
 dependencies = [
- "digest",
- "generic-array",
+ "digest 0.8.1",
+ "generic-array 0.12.3",
  "hmac",
 ]
 
@@ -654,10 +762,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-sqrt"
-version = "0.1.3"
+name = "instant"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65877bf7d44897a473350b1046277941cee20b263397e90869c50b6e766088b"
+checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "integer-sqrt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "itertools"
@@ -669,10 +789,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "0.4.5"
+name = "itertools"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "keccak"
@@ -682,13 +811,13 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "keccak-hasher"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3468207deea1359a0e921591ae9b4c928733d94eb9d6a2eeda994cfd59f42cf8"
+checksum = "711adba9940a039f4374fc5724c0a5eaca84a2d558cce62256bfe26f0dbef05e"
 dependencies = [
  "hash-db",
  "hash256-std-hasher 0.15.2",
- "tiny-keccak 1.5.0",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -699,9 +828,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.69"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
+checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
 
 [[package]]
 name = "libsecp256k1"
@@ -711,11 +840,11 @@ checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
 dependencies = [
  "arrayref",
  "crunchy",
- "digest",
+ "digest 0.8.1",
  "hmac-drbg",
  "rand",
- "sha2",
- "subtle 2.2.2",
+ "sha2 0.8.2",
+ "subtle 2.3.0",
  "typenum",
 ]
 
@@ -735,19 +864,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.8"
+name = "lock_api"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
 dependencies = [
- "cfg-if",
+ "scopeguard",
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
+name = "log"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "memchr"
@@ -761,10 +893,21 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be512cb2ccb4ecbdca937fdd4a62ea5f09f8e7195466a85e4632b3d5bcce82e6"
 dependencies = [
- "ahash",
+ "ahash 0.2.18",
  "hash-db",
- "hashbrown",
- "parity-util-mem",
+ "hashbrown 0.6.3",
+ "parity-util-mem 0.6.0",
+]
+
+[[package]]
+name = "memory-db"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f36ddb0b2cdc25d38babba472108798e3477f02be5165f038c5e393e50c57a"
+dependencies = [
+ "hash-db",
+ "hashbrown 0.8.2",
+ "parity-util-mem 0.7.0",
 ]
 
 [[package]]
@@ -786,6 +929,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9"
+dependencies = [
+ "adler",
+ "autocfg 1.0.1",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,18 +950,18 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
  "num-traits",
 ]
 
@@ -818,7 +971,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -826,11 +979,11 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -844,12 +997,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.3.1"
+name = "object"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
+checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
+
+[[package]]
+name = "once_cell"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
 dependencies = [
- "parking_lot 0.9.0",
+ "parking_lot 0.11.0",
 ]
 
 [[package]]
@@ -857,6 +1016,12 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "parity-codec"
@@ -869,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.0"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c8f7f4244ddb5c37c103641027a76c530e65e8e4b8240b29f81ea40508b17"
+checksum = "7c740e5fbcb6847058b40ac7e5574766c6388f585e184d769910fe0d3a2ca861"
 dependencies = [
  "arrayvec 0.5.1",
  "bitvec",
@@ -882,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a0ec292e92e8ec7c58e576adacc1e3f399c597c8f263c42f18420abe58e7245"
+checksum = "198db82bb1c18fc00176004462dd809b2a6d851669550aa17af6dacd21ae0c14"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -894,11 +1059,25 @@ dependencies = [
 
 [[package]]
 name = "parity-util-mem"
-version = "0.6.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6e2583649a3ca84894d1d71da249abcfda54d5aca24733d72ca10d0f02361c"
+checksum = "6e42755f26e5ea21a6a819d9e63cbd70713e9867a2b767ec2cc65ca7659532c5"
 dependencies = [
  "cfg-if",
+ "impl-trait-for-tuples",
+ "parity-util-mem-derive",
+ "parking_lot 0.10.2",
+ "winapi",
+]
+
+[[package]]
+name = "parity-util-mem"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297ff91fa36aec49ce183484b102f6b75b46776822bd81525bfc4cc9b0dd0f5c"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.8.2",
  "impl-trait-for-tuples",
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
@@ -934,38 +1113,23 @@ checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
 
 [[package]]
 name = "parking_lot"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
-dependencies = [
- "lock_api",
- "parking_lot_core 0.6.2",
- "rustc_version",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
- "lock_api",
+ "lock_api 0.3.4",
  "parking_lot_core 0.7.2",
 ]
 
 [[package]]
-name = "parking_lot_core"
-version = "0.6.2"
+name = "parking_lot"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
 dependencies = [
- "cfg-if",
- "cloudabi",
- "libc",
- "redox_syscall",
- "rustc_version",
- "smallvec 0.6.13",
- "winapi",
+ "instant",
+ "lock_api 0.4.1",
+ "parking_lot_core 0.8.0",
 ]
 
 [[package]]
@@ -975,18 +1139,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
- "smallvec 1.4.0",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if",
+ "cloudabi 0.1.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
  "winapi",
 ]
 
 [[package]]
 name = "paste"
-version = "0.1.12"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a229b1c58c692edcaa5b9b0948084f130f55d2dcc15b02fcc5340b2b4521476"
+checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
 dependencies = [
  "paste-impl",
  "proc-macro-hack",
@@ -994,14 +1173,11 @@ dependencies = [
 
 [[package]]
 name = "paste-impl"
-version = "0.1.12"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0bf239e447e67ff6d16a8bb5e4d4bd2343acf5066061c0e8e06ac5ba8ca68c"
+checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1016,18 +1192,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.16"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d480cb4e89522ccda96d0eed9af94180b7a5f93fb28f66e1fd7d68431663d1"
+checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.16"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82996f11efccb19b685b14b5df818de31c1edcee3daa256ab5775dd98e72feb"
+checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1042,9 +1218,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.6"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
 name = "primitive-types"
@@ -1066,44 +1242,44 @@ dependencies = [
  "fixed-hash 0.6.1",
  "impl-codec 0.4.2",
  "impl-serde 0.3.1",
- "uint 0.8.3",
+ "uint 0.8.5",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
  "toml",
 ]
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.15"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
+checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.12"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
+checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.4"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
+checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
 ]
@@ -1125,6 +1301,7 @@ dependencies = [
  "rand_chacha",
  "rand_core",
  "rand_hc",
+ "rand_pcg",
 ]
 
 [[package]]
@@ -1156,10 +1333,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.1.56"
+name = "rand_pcg"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "ref-cast"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "745c1787167ddae5569661d5ffb8b25ae5fedbf46717eaa92d652221cec72623"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d21b475ab879ef0e315ad99067fa25778c3b0377f57f1b00207448dac1a3144"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "reference-trie"
@@ -1171,15 +1377,15 @@ dependencies = [
  "hash256-std-hasher 0.15.2",
  "keccak-hasher",
  "parity-scale-codec",
- "trie-db",
+ "trie-db 0.20.1",
  "trie-root",
 ]
 
 [[package]]
 name = "regex"
-version = "1.3.7"
+version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
+checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1189,17 +1395,38 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.17"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
+checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "remove_dir_all"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "rental"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8545debe98b2b139fb04cad8618b530e9b07c152d99a5de83c860b877d67847f"
+dependencies = [
+ "rental-impl",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "rental-impl"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1221,19 +1448,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
 name = "ryu"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "same-file"
@@ -1246,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.8.0-alpha.6"
+version = "0.8.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f238a411de5e1cfe3b104f287aad0a48e4a39d9157171b7761d91d6d4a76610a"
+checksum = "99435a9edd886f5f30be5d8ab0b328b9d1bd06e0949896640cc6311b3c2bd58d"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -1259,6 +1477,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "sc-executor-common",
  "sc-executor-wasmi",
+ "sp-api",
  "sp-core",
  "sp-externalities",
  "sp-io",
@@ -1273,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-common"
-version = "0.8.0-alpha.6"
+version = "0.8.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549d94ce1316c168a72c26abf0bf3390ae76b1645030e2aac9ecf0542b04fa85"
+checksum = "6ff18805f4cdfb46dbaab60765a87d3e3c25ae17032e4b2b807f7844f85ec5f9"
 dependencies = [
  "derive_more",
  "log",
@@ -1291,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmi"
-version = "0.8.0-alpha.6"
+version = "0.8.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7efc6978b59884e1593ec172fe5b1a909c980b0e495897c904da50616c3a7a"
+checksum = "ec579a2de5717d393971b53f7db23b41da1f5da63b175b6e2c14e8e2c373a9b8"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -1313,13 +1532,13 @@ checksum = "021b403afe70d81eea68f6ea12f6b3c9588e5d536a94c3bf80f15e7faa267862"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.1",
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "getrandom",
  "merlin",
  "rand",
  "rand_core",
- "sha2",
- "subtle 2.2.2",
+ "sha2 0.8.2",
+ "subtle 2.3.0",
  "zeroize",
 ]
 
@@ -1328,6 +1547,15 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "secrecy"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9182278ed645df3477a9c27bfee0621c621aa16f6972635f7f795dae3d81070f"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "semver"
@@ -1356,18 +1584,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.110"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
+checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.110"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
+checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1376,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.53"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
+checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
 dependencies = [
  "itoa",
  "ryu",
@@ -1387,27 +1615,46 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c7a592a1ec97c9c1c68d75b6e537dcbf60c7618e038e7841e00af1d9ccf0c4"
+checksum = "ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5"
 dependencies = [
  "dtoa",
  "linked-hash-map",
  "serde",
- "yaml-rust 0.4.3",
+ "yaml-rust 0.4.4",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
+checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
 ]
+
+[[package]]
+name = "sha2"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "signature"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 
 [[package]]
 name = "slab"
@@ -1417,24 +1664,15 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "0.6.13"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
-dependencies = [
- "maybe-uninit",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
+checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "sp-allocator"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532c396c2d6727d9b0d3eee3edbcaf939e78a6ce944fa34c2b98d6a02a2485e"
+checksum = "16378a5000d98a01b87fa8a40a5bf02cc483545cbae8125c456954330eee78e4"
 dependencies = [
  "derive_more",
  "log",
@@ -1444,10 +1682,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-application-crypto"
-version = "2.0.0-alpha.6"
+name = "sp-api"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5dec618ed8ea85fd767358185a412440c02a0adce569c2aa92ee355550d678"
+checksum = "7467f7e20ded41f54cffec173588419dc9c3efb7fb1e73a4541a66774545f9cb"
+dependencies = [
+ "hash-db",
+ "parity-scale-codec",
+ "sp-api-proc-macro",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-version",
+]
+
+[[package]]
+name = "sp-api-proc-macro"
+version = "2.0.0-rc6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da136f7fbc99517e5f6f16401110a16240f99d2fbff738b8666b0b10a1d638c7"
+dependencies = [
+ "blake2-rfc",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sp-application-crypto"
+version = "2.0.0-rc6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f33508e0f9c96186eae2c73482ae02b463cb85fd80d42dc48d7b5cf778aad6ba"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1458,14 +1725,13 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b413966b541aadf8725dddc29daeefa950f45b17208f33302890484c56009bd3"
+checksum = "6f861e78b2de65df52d855ff668a00890160ab66afa25e8203f4240152e89085"
 dependencies = [
  "integer-sqrt",
  "num-traits",
  "parity-scale-codec",
- "primitive-types 0.7.2",
  "serde",
  "sp-debug-derive",
  "sp-std",
@@ -1473,13 +1739,15 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0589a2e394a3dcd5dfd258c5f5bf22e6d0f28ffbd5e6d3a09ad702a6dc1c0152"
+checksum = "146765f2e906030c2d7fba4a685390407d5d0595b7e46716b2bcd6c7ac744579"
 dependencies = [
  "base58",
  "blake2-rfc",
  "byteorder",
+ "derive_more",
+ "dyn-clonable",
  "ed25519-dalek",
  "futures",
  "hash-db",
@@ -1489,16 +1757,18 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log",
+ "merlin",
  "num-traits",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.7.0",
  "parking_lot 0.10.2",
  "primitive-types 0.7.2",
  "rand",
  "regex",
  "schnorrkel",
+ "secrecy",
  "serde",
- "sha2",
+ "sha2 0.8.2",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -1506,7 +1776,7 @@ dependencies = [
  "sp-storage",
  "substrate-bip39",
  "tiny-bip39",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
  "twox-hash",
  "wasmi",
  "zeroize",
@@ -1514,9 +1784,9 @@ dependencies = [
 
 [[package]]
 name = "sp-debug-derive"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df968a922a9d3b3f65d37e91e30904876efce88d017d4448c4babc990a738134"
+checksum = "8fc56e04bc64020aa6c1a35fb74991ab8d2aa46ffc0b133145103d8b6304f195"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1525,20 +1795,21 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
-version = "0.8.0-alpha.6"
+version = "0.8.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06b8ac80a03205205426ae9ef3200133a8ffab4f4f0eeecd3b858034f9e5b02"
+checksum = "62ff5c062c4c36814d8aa21031b3fc7a16816db879965a910b98f49c6d80914e"
 dependencies = [
  "environmental",
+ "parity-scale-codec",
  "sp-std",
  "sp-storage",
 ]
 
 [[package]]
 name = "sp-inherents"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14f699ab5cac6c9e80197774f06a4aa38211cb8acdb8660e328775efa2599e1"
+checksum = "3a0c71c49638e89a2aa252d291625528d67a6efee6df0ffb88cbae32f3ca878e"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -1549,28 +1820,31 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20758b1831f75d58c20ca735d34b96dc792ef8264bf4d4a8c476964d90a6aea7"
+checksum = "3668b7ee3720ffbea89308832f04cee067c8d40a06f9ced818d890cb2aae112f"
 dependencies = [
+ "futures",
  "hash-db",
  "libsecp256k1",
  "log",
  "parity-scale-codec",
+ "parking_lot 0.10.2",
  "sp-core",
  "sp-externalities",
  "sp-runtime-interface",
  "sp-state-machine",
  "sp-std",
+ "sp-tracing",
  "sp-trie",
  "sp-wasm-interface",
 ]
 
 [[package]]
 name = "sp-panic-handler"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef909e5ea664bce0bca723baf352c75125e4ed017843240e91d718df4720e1e4"
+checksum = "56a3e76c47eca218aa86c8a02942c62d71fb47b01feb1fc38d8297f93929a35e"
 dependencies = [
  "backtrace",
  "log",
@@ -1578,15 +1852,16 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1f98caf8bb20c7d69ba3097f3283ebc615f4a33e79ae0ca5934364be5776ac"
+checksum = "8fb489c671d0dc1ec00f83550e259cc75ab5c25d0d41b901c7a35cda99da7964"
 dependencies = [
+ "either",
  "hash256-std-hasher 0.15.2",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.7.0",
  "paste",
  "rand",
  "serde",
@@ -1600,24 +1875,26 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "289491386162a8d867d219f4f4dd3a7c11181c8ee9957e41b8747b555a9f4433"
+checksum = "3b63b4b5e0fd1488b545d908003cd8129c88c066af361f9b6483ac7c97d8f6c1"
 dependencies = [
  "parity-scale-codec",
  "primitive-types 0.7.2",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
  "sp-std",
+ "sp-storage",
+ "sp-tracing",
  "sp-wasm-interface",
  "static_assertions 1.1.0",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609529717f6c9cdd5bb6329c4ca9ddb1d36f698bd1f5dd2bdf0e94c064d7cc5b"
+checksum = "21c3ed5a0258faaa1370859bfdacf27d798f4205161a68289555eb1a1a6a4e41"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -1628,9 +1905,9 @@ dependencies = [
 
 [[package]]
 name = "sp-serializer"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b306e15eb54af25aef9d752c22778da3fa115945e47bf047545be2847cf814"
+checksum = "b99a01e4c61cabad1e383f014e559b1390f5f98c43ccdd0492c0fc195f4a4047"
 dependencies = [
  "serde",
  "serde_json",
@@ -1638,62 +1915,77 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.8.0-alpha.6"
+version = "0.8.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5de28eb08ce52f45ed32257b324766183dfe4d74a29242b934365ff80911ca"
+checksum = "5f1d76c8c207b644ed9cabeeeb9eead95c72691db9e357fe56ab19285b36b2b4"
 dependencies = [
  "hash-db",
+ "itertools 0.9.0",
  "log",
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "rand",
+ "smallvec",
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
  "sp-trie",
- "trie-db",
+ "trie-db 0.22.1",
  "trie-root",
 ]
 
 [[package]]
 name = "sp-std"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca806523d5df8082c89da042e31292f0c8f6e6ad9c3cfc312edfffde6a08490"
+checksum = "dd69654cdd9fa179dad52811220356dc2991f70b3b93e77c27f4e317d58c059b"
 
 [[package]]
 name = "sp-storage"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2cb515df8b37fbdbb6769d2e992748b6134d592ec3b795b8e672621d754f94b"
+checksum = "5c0dba5526e0a1d2acc3d969cdcdf89f4e0395a1a6e807f5aa517ef15bf0e710"
 dependencies = [
  "impl-serde 0.2.3",
+ "parity-scale-codec",
+ "ref-cast",
  "serde",
  "sp-debug-derive",
  "sp-std",
 ]
 
 [[package]]
-name = "sp-trie"
-version = "2.0.0-alpha.6"
+name = "sp-tracing"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4194817027eb92525e9279ec651160d709340d74b707f7648654c8eb2a626be3"
+checksum = "50a43072c8a66b1f6cfec0bee7f3f2aa7866869317b5f430e8a2743551b77c4d"
+dependencies = [
+ "log",
+ "rental",
+ "tracing",
+]
+
+[[package]]
+name = "sp-trie"
+version = "2.0.0-rc6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b27498caf2238d68df9ed9a8bf326622142119328ae41b17cafc36c6acafab"
 dependencies = [
  "hash-db",
- "memory-db",
+ "memory-db 0.24.1",
  "parity-scale-codec",
  "sp-core",
  "sp-std",
- "trie-db",
+ "trie-db 0.22.1",
  "trie-root",
 ]
 
 [[package]]
 name = "sp-version"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "319c37fa4aa91ee9ee9c20a3fab0d5b6b1bbe1dea997319c303f28a62f49765d"
+checksum = "3d075c051dc9dc75685c484463729d50d21930aa9068f652734598f8a882f6e0"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -1704,15 +1996,21 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7584168f2785f6676727545a31a3cd97159d7023d968540b4881a98d73991900"
+checksum = "eeb0c2a1c2bdbbd67c1b8f20a9c85606122e7227b67cf5cd9faf3df2f454a66b"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "sp-std",
  "wasmi",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -1734,7 +2032,7 @@ checksum = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 
 [[package]]
 name = "substrate-adapter"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 dependencies = [
  "base64",
  "blake2-rfc",
@@ -1744,7 +2042,7 @@ dependencies = [
  "hash256-std-hasher 0.12.4",
  "hex",
  "keccak-hasher",
- "memory-db",
+ "memory-db 0.20.1",
  "parity-scale-codec",
  "primitive-types 0.2.4",
  "reference-trie",
@@ -1754,21 +2052,22 @@ dependencies = [
  "sp-io",
  "sp-serializer",
  "sp-state-machine",
- "trie-db",
+ "trie-db 0.20.1",
  "trie-root",
  "wasm-adapter",
 ]
 
 [[package]]
 name = "substrate-bip39"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c004e8166d6e0aa3a9d5fa673e5b7098ff25f930de1013a21341988151e681bb"
+checksum = "bed6646a0159b9935b5d045611560eeef842b78d7adc3ba36f5ca325a13a0236"
 dependencies = [
  "hmac",
  "pbkdf2",
  "schnorrkel",
- "sha2",
+ "sha2 0.8.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -1781,7 +2080,7 @@ dependencies = [
  "build-helper",
  "cargo_metadata",
  "fs2",
- "itertools",
+ "itertools 0.8.2",
  "tempfile",
  "toml",
  "walkdir",
@@ -1796,15 +2095,15 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
-version = "2.2.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
+checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.19"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e5aa70697bb26ee62214ae3288465ecec0000f05182f039b477001f08f5ae7"
+checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1813,9 +2112,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1867,17 +2166,8 @@ dependencies = [
  "pbkdf2",
  "rand",
  "rustc-hash",
- "sha2",
+ "sha2 0.8.2",
  "unicode-normalization",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -1890,6 +2180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
+
+[[package]]
 name = "toml"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,16 +2195,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
+dependencies = [
+ "cfg-if",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcf46c1f1f06aeea2d6b81f3c863d0930a596c86ad1920d4e5bad6dd1d7119a"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "trie-db"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc309f34008563989045a4c4dbcc5770467f3a3785ee80a9b5cc0d83362475f"
 dependencies = [
  "hash-db",
- "hashbrown",
+ "hashbrown 0.6.3",
  "log",
  "rustc-hex",
- "smallvec 1.4.0",
+ "smallvec",
+]
+
+[[package]]
+name = "trie-db"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e55f7ace33d6237e14137e386f4e1672e2a5c6bbc97fef9f438581a143971f0"
+dependencies = [
+ "hash-db",
+ "hashbrown 0.8.2",
+ "log",
+ "rustc-hex",
+ "smallvec",
 ]
 
 [[package]]
@@ -1948,9 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "uint"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173cd16430c206dc1a430af8a89a0e9c076cf15cb42b4aedb10e8cc8fee73681"
+checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -1960,30 +2300,36 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
+checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
 dependencies = [
- "smallvec 1.4.0",
+ "tinyvec",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "walkdir"
@@ -2004,7 +2350,7 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-adapter"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 dependencies = [
  "substrate-wasm-builder",
 ]
@@ -2045,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -2082,27 +2428,27 @@ checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
 
 [[package]]
 name = "yaml-rust"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
+checksum = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
 dependencies = [
  "linked-hash-map",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
+checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/test/adapters/substrate/Cargo.lock
+++ b/test/adapters/substrate/Cargo.lock
@@ -2015,7 +2015,7 @@ checksum = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 
 [[package]]
 name = "substrate-adapter"
-version = "2.0.0-rc6"
+version = "0.8.24"
 dependencies = [
  "base64",
  "blake2-rfc",

--- a/test/adapters/substrate/Cargo.lock
+++ b/test/adapters/substrate/Cargo.lock
@@ -56,6 +56,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,12 +242,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "chrono"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "time",
+]
+
+[[package]]
 name = "clap"
 version = "2.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8c532887f1a292d17de05ae858a8fe50a301e196f9ef0ddb7ccd0d1d00f180"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.9.0",
  "atty",
  "bitflags 0.9.1",
  "strsim",
@@ -625,7 +645,7 @@ checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -734,15 +754,6 @@ dependencies = [
 
 [[package]]
 name = "impl-serde"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e3cae7e99c7ff5a995da2cf78dd0a5383740eda71d98cf7b1910c301ac69b8"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "impl-serde"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
@@ -784,15 +795,6 @@ name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -879,6 +881,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -1241,7 +1252,7 @@ checksum = "c55c21c64d0eaa4d7ed885d959ef2d62d9e488c27c0e02d9aa5ce6c877b7d5f8"
 dependencies = [
  "fixed-hash 0.6.1",
  "impl-codec 0.4.2",
- "impl-serde 0.3.1",
+ "impl-serde",
  "uint 0.8.5",
 ]
 
@@ -1394,6 +1405,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,27 +1427,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "rental"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8545debe98b2b139fb04cad8618b530e9b07c152d99a5de83c860b877d67847f"
-dependencies = [
- "rental-impl",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "rental-impl"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1465,8 +1465,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99435a9edd886f5f30be5d8ab0b328b9d1bd06e0949896640cc6311b3c2bd58d"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -1493,8 +1492,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff18805f4cdfb46dbaab60765a87d3e3c25ae17032e4b2b807f7844f85ec5f9"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "derive_more",
  "log",
@@ -1511,8 +1509,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec579a2de5717d393971b53f7db23b41da1f5da63b175b6e2c14e8e2c373a9b8"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -1651,6 +1648,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signature"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,8 +1677,7 @@ checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16378a5000d98a01b87fa8a40a5bf02cc483545cbae8125c456954330eee78e4"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "derive_more",
  "log",
@@ -1684,8 +1689,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7467f7e20ded41f54cffec173588419dc9c3efb7fb1e73a4541a66774545f9cb"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -1700,8 +1704,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da136f7fbc99517e5f6f16401110a16240f99d2fbff738b8666b0b10a1d638c7"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -1713,8 +1716,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33508e0f9c96186eae2c73482ae02b463cb85fd80d42dc48d7b5cf778aad6ba"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1726,8 +1728,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f861e78b2de65df52d855ff668a00890160ab66afa25e8203f4240152e89085"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -1740,8 +1741,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146765f2e906030c2d7fba4a685390407d5d0595b7e46716b2bcd6c7ac744579"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -1753,7 +1753,7 @@ dependencies = [
  "hash-db",
  "hash256-std-hasher 0.15.2",
  "hex",
- "impl-serde 0.3.1",
+ "impl-serde",
  "lazy_static",
  "libsecp256k1",
  "log",
@@ -1785,8 +1785,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc56e04bc64020aa6c1a35fb74991ab8d2aa46ffc0b133145103d8b6304f195"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1796,8 +1795,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ff5c062c4c36814d8aa21031b3fc7a16816db879965a910b98f49c6d80914e"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -1808,8 +1806,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a0c71c49638e89a2aa252d291625528d67a6efee6df0ffb88cbae32f3ca878e"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -1821,8 +1818,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3668b7ee3720ffbea89308832f04cee067c8d40a06f9ced818d890cb2aae112f"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "futures",
  "hash-db",
@@ -1838,13 +1834,14 @@ dependencies = [
  "sp-tracing",
  "sp-trie",
  "sp-wasm-interface",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56a3e76c47eca218aa86c8a02942c62d71fb47b01feb1fc38d8297f93929a35e"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "backtrace",
  "log",
@@ -1853,8 +1850,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb489c671d0dc1ec00f83550e259cc75ab5c25d0d41b901c7a35cda99da7964"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "either",
  "hash256-std-hasher 0.15.2",
@@ -1876,8 +1872,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b63b4b5e0fd1488b545d908003cd8129c88c066af361f9b6483ac7c97d8f6c1"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "parity-scale-codec",
  "primitive-types 0.7.2",
@@ -1893,8 +1888,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c3ed5a0258faaa1370859bfdacf27d798f4205161a68289555eb1a1a6a4e41"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -1906,8 +1900,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b99a01e4c61cabad1e383f014e559b1390f5f98c43ccdd0492c0fc195f4a4047"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1916,11 +1909,9 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f1d76c8c207b644ed9cabeeeb9eead95c72691db9e357fe56ab19285b36b2b4"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "hash-db",
- "itertools 0.9.0",
  "log",
  "num-traits",
  "parity-scale-codec",
@@ -1930,6 +1921,7 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
+ "sp-std",
  "sp-trie",
  "trie-db 0.22.1",
  "trie-root",
@@ -1938,16 +1930,14 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd69654cdd9fa179dad52811220356dc2991f70b3b93e77c27f4e317d58c059b"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0dba5526e0a1d2acc3d969cdcdf89f4e0395a1a6e807f5aa517ef15bf0e710"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
- "impl-serde 0.2.3",
+ "impl-serde",
  "parity-scale-codec",
  "ref-cast",
  "serde",
@@ -1958,19 +1948,20 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50a43072c8a66b1f6cfec0bee7f3f2aa7866869317b5f430e8a2743551b77c4d"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "log",
- "rental",
+ "parity-scale-codec",
+ "sp-std",
  "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "sp-trie"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b27498caf2238d68df9ed9a8bf326622142119328ae41b17cafc36c6acafab"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "hash-db",
  "memory-db 0.24.1",
@@ -1984,10 +1975,9 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d075c051dc9dc75685c484463729d50d21930aa9068f652734598f8a882f6e0"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
- "impl-serde 0.2.3",
+ "impl-serde",
  "parity-scale-codec",
  "serde",
  "sp-runtime",
@@ -1997,20 +1987,13 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-rc6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb0c2a1c2bdbbd67c1b8f20a9c85606122e7227b67cf5cd9faf3df2f454a66b"
+source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "sp-std",
  "wasmi",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -2080,7 +2063,7 @@ dependencies = [
  "build-helper",
  "cargo_metadata",
  "fs2",
- "itertools 0.8.2",
+ "itertools",
  "tempfile",
  "toml",
  "walkdir",
@@ -2155,6 +2138,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
 name = "tiny-bip39"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2201,19 +2195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
 dependencies = [
  "cfg-if",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2223,6 +2205,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcf46c1f1f06aeea2d6b81f3c863d0930a596c86ad1920d4e5bad6dd1d7119a"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82bb5079aa76438620837198db8a5c529fb9878c730bc2b28179b0241cf04c10"
+dependencies = [
+ "ansi_term 0.12.1",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2347,6 +2371,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-adapter"

--- a/test/adapters/substrate/Cargo.toml
+++ b/test/adapters/substrate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-adapter"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 authors = ["Skalman <skalman@riseup.net>"]
 edition = "2018"
 
@@ -23,16 +23,16 @@ trie-db        = "0.20"
 trie-root      = "0.16"
 
 # state-trie blake2 hashing (TODO: Use substrate implementation?)
-sp-serializer      = "2.0.0-alpha"
+sp-serializer      = "2.0.0-rc6"
 primitive-types    = { version = "0.2",  default-features = false, features = ["codec"] }
 hash256-std-hasher = { version = "0.12", default-features = false }
 blake2-rfc         = "*"
 
 # host-api
-sp-core          = { version = "2.0.0-alpha", default-features = false, features = ["full_crypto"] }
-sp-io            = { version = "2.0.0-alpha", default-features = false }
-sc-executor      = "0.8.0-alpha"
-sp-state-machine = "0.8.0-alpha"
+sp-core          = { version = "2.0.0-rc6", default-features = false, features = ["full_crypto"] }
+sp-io            = { version = "2.0.0-rc6", default-features = false }
+sc-executor      = "0.8.0-rc6"
+sp-state-machine = "0.8.0-rc6"
 
 # host-api shim wasm blob
 runtime = { package = "wasm-adapter", path = "../wasm" }

--- a/test/adapters/substrate/Cargo.toml
+++ b/test/adapters/substrate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-adapter"
-version = "2.0.0-rc6"
+version = "0.8.24"
 authors = ["Skalman <skalman@riseup.net>"]
 edition = "2018"
 
@@ -23,16 +23,16 @@ trie-db        = "0.20"
 trie-root      = "0.16"
 
 # state-trie blake2 hashing (TODO: Use substrate implementation?)
-sp-serializer      = "2.0.0-rc6"
+sp-serializer      = { git = "https://github.com/paritytech/substrate", branch = "master" }
 primitive-types    = { version = "0.2",  default-features = false, features = ["codec"] }
 hash256-std-hasher = { version = "0.12", default-features = false }
 blake2-rfc         = "*"
 
 # host-api
-sp-core          = { version = "2.0.0-rc6", default-features = false, features = ["full_crypto"] }
-sp-io            = { version = "2.0.0-rc6", default-features = false }
-sc-executor      = "0.8.0-rc6"
-sp-state-machine = "0.8.0-rc6"
+sp-core           = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-io             = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-executor       = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-state-machine  = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 # host-api shim wasm blob
 runtime = { package = "wasm-adapter", path = "../wasm" }

--- a/test/adapters/substrate/src/host_api/child_storage.rs
+++ b/test/adapters/substrate/src/host_api/child_storage.rs
@@ -1,36 +1,34 @@
 use crate::host_api::utils::{str, Decoder, ParsedInput, Runtime};
 use parity_scale_codec::Encode;
 
-pub fn ext_storage_child_set_version_1(input: ParsedInput) {
+pub fn ext_default_child_storage_set_version_1(input: ParsedInput) {
     let mut rtm = Runtime::new();
 
     let child_key1 = input.get(0);
     let child_key2 = input.get(1);
-    let child_definition = input.get(2);
-    let child_type = input.get_u32(3);
     let key = input.get(4);
     let value = input.get(5);
 
     // Get invalid key
     let res = rtm
         .call(
-            "rtm_ext_storage_child_get_version_1",
-            &(child_key1, child_definition, child_type, key).encode(),
+            "rtm_ext_default_child_storage_get_version_1",
+            &(child_key1, key).encode(),
         )
         .decode_ovec();
     assert!(res.is_none());
 
     // Set key/value
     let _ = rtm.call(
-        "rtm_ext_storage_child_set_version_1",
-        &(child_key1, child_definition, child_type, key, value).encode(),
+        "rtm_ext_default_child_storage_set_version_1",
+        &(child_key1, key, value).encode(),
     );
 
     // Get invalid key (wrong child key)
     let res = rtm
         .call(
-            "rtm_ext_storage_child_get_version_1",
-            &(child_key2, child_definition, child_type, key).encode(),
+            "rtm_ext_default_child_storage_get_version_1",
+            &(child_key2, key).encode(),
         )
         .decode_ovec();
     assert!(res.is_none());
@@ -38,8 +36,8 @@ pub fn ext_storage_child_set_version_1(input: ParsedInput) {
     // Get valid key
     let res = rtm
         .call(
-            "rtm_ext_storage_child_get_version_1",
-            &(child_key1, child_definition, child_type, key).encode(),
+            "rtm_ext_default_child_storage_get_version_1",
+            &(child_key1, key).encode(),
         )
         .decode_ovec()
         .unwrap();
@@ -48,17 +46,15 @@ pub fn ext_storage_child_set_version_1(input: ParsedInput) {
     println!("{}", str(&res));
 }
 
-pub fn ext_storage_child_get_version_1(input: ParsedInput) {
-    ext_storage_child_set_version_1(input)
+pub fn ext_default_child_storage_get_version_1(input: ParsedInput) {
+    ext_default_child_storage_set_version_1(input)
 }
 
-pub fn ext_storage_child_read_version_1(input: ParsedInput) {
+pub fn ext_default_child_storage_read_version_1(input: ParsedInput) {
     let mut rtm = Runtime::new();
 
     let child_key1 = input.get(0);
     let child_key2 = input.get(1);
-    let child_definition = input.get(2);
-    let child_type = input.get_u32(3);
     let key = input.get(4);
     let value = input.get(5);
     let offset = input.get_u32(6);
@@ -67,11 +63,9 @@ pub fn ext_storage_child_read_version_1(input: ParsedInput) {
     // Get invalid key
     let res = rtm
         .call(
-            "rtm_ext_storage_child_read_version_1",
+            "rtm_ext_default_child_storage_read_version_1",
             &(
                 child_key1,
-                child_definition,
-                child_type,
                 key,
                 offset,
                 buffer_size,
@@ -83,18 +77,16 @@ pub fn ext_storage_child_read_version_1(input: ParsedInput) {
 
     // Set key/value
     let _ = rtm.call(
-        "rtm_ext_storage_child_set_version_1",
-        &(child_key1, child_definition, child_type, key, value).encode(),
+        "rtm_ext_default_child_storage_set_version_1",
+        &(child_key1, key, value).encode(),
     );
 
     // Get invalid key (different child storage)
     let res = rtm
         .call(
-            "rtm_ext_storage_child_read_version_1",
+            "rtm_ext_default_child_storage_read_version_1",
             &(
                 child_key2,
-                child_definition,
-                child_type,
                 key,
                 offset,
                 buffer_size,
@@ -107,11 +99,9 @@ pub fn ext_storage_child_read_version_1(input: ParsedInput) {
     // Get valid key
     let res = rtm
         .call(
-            "rtm_ext_storage_child_read_version_1",
+            "rtm_ext_default_child_storage_read_version_1",
             &(
                 child_key1,
-                child_definition,
-                child_type,
                 key,
                 offset,
                 buffer_size,
@@ -135,33 +125,31 @@ pub fn ext_storage_child_read_version_1(input: ParsedInput) {
     println!("{}", str(&res));
 }
 
-pub fn ext_storage_child_clear_version_1(input: ParsedInput) {
+pub fn ext_default_child_storage_clear_version_1(input: ParsedInput) {
     let mut rtm = Runtime::new();
 
     let child_key1 = input.get(0);
     let child_key2 = input.get(1);
-    let child_definition = input.get(2);
-    let child_type = input.get_u32(3);
     let key = input.get(4);
     let value = input.get(5);
 
     // Set key/value
     let _ = rtm.call(
-        "rtm_ext_storage_child_set_version_1",
-        &(child_key1, child_definition, child_type, key, value).encode(),
+        "rtm_ext_default_child_storage_set_version_1",
+        &(child_key1, key, value).encode(),
     );
 
     // Clear value (other child key)
     let _ = rtm.call(
-        "rtm_ext_storage_child_clear_version_1",
-        &(child_key2, child_definition, child_type, key).encode(),
+        "rtm_ext_default_child_storage_clear_version_1",
+        &(child_key2, key).encode(),
     );
 
     // Get valid key
     let res = rtm
         .call(
-            "rtm_ext_storage_child_get_version_1",
-            &(child_key1, child_definition, child_type, key).encode(),
+            "rtm_ext_default_child_storage_get_version_1",
+            &(child_key1, key).encode(),
         )
         .decode_ovec()
         .unwrap();
@@ -169,27 +157,25 @@ pub fn ext_storage_child_clear_version_1(input: ParsedInput) {
 
     // Clear value
     let _ = rtm.call(
-        "rtm_ext_storage_child_clear_version_1",
-        &(child_key1, child_definition, child_type, key).encode(),
+        "rtm_ext_default_child_storage_clear_version_1",
+        &(child_key1, key).encode(),
     );
 
     // Get cleared value
     let res = rtm
         .call(
-            "rtm_ext_storage_child_get_version_1",
-            &(child_key1, child_definition, child_type, key).encode(),
+            "rtm_ext_default_child_storage_get_version_1",
+            &(child_key1, key).encode(),
         )
         .decode_ovec();
     assert!(res.is_none());
 }
 
-pub fn ext_storage_child_storage_kill_version_1(input: ParsedInput) {
+pub fn ext_default_child_storage_storage_kill_version_1(input: ParsedInput) {
     let mut rtm = Runtime::new();
 
     let child_key1 = input.get(0);
     let child_key2 = input.get(1);
-    let child_definition = input.get(2);
-    let child_type = input.get_u32(3);
     let key1 = input.get(4);
     let value1 = input.get(5);
     let key2 = input.get(6);
@@ -197,27 +183,27 @@ pub fn ext_storage_child_storage_kill_version_1(input: ParsedInput) {
 
     // Set key/value
     let _ = rtm.call(
-        "rtm_ext_storage_child_set_version_1",
-        &(child_key1, child_definition, child_type, key1, value1).encode(),
+        "rtm_ext_default_child_storage_set_version_1",
+        &(child_key1, key1, value1).encode(),
     );
 
     // Set key/value
     let _ = rtm.call(
-        "rtm_ext_storage_child_set_version_1",
-        &(child_key1, child_definition, child_type, key2, value2).encode(),
+        "rtm_ext_default_child_storage_set_version_1",
+        &(child_key1, key2, value2).encode(),
     );
 
     // Kill child (different child key)
     let _ = rtm.call(
-        "rtm_ext_storage_child_storage_kill_version_1",
-        &(child_key2, child_definition, child_type).encode(),
+        "rtm_ext_default_child_storage_storage_kill_version_1",
+        &(child_key2).encode(),
     );
 
     // Get valid value
     let res = rtm
         .call(
-            "rtm_ext_storage_child_get_version_1",
-            &(child_key1, child_definition, child_type, key1).encode(),
+            "rtm_ext_default_child_storage_get_version_1",
+            &(child_key1, key1).encode(),
         )
         .decode_ovec()
         .unwrap();
@@ -226,8 +212,8 @@ pub fn ext_storage_child_storage_kill_version_1(input: ParsedInput) {
     // Get valid value
     let res = rtm
         .call(
-            "rtm_ext_storage_child_get_version_1",
-            &(child_key1, child_definition, child_type, key2).encode(),
+            "rtm_ext_default_child_storage_get_version_1",
+            &(child_key1, key2).encode(),
         )
         .decode_ovec()
         .unwrap();
@@ -235,15 +221,15 @@ pub fn ext_storage_child_storage_kill_version_1(input: ParsedInput) {
 
     // Kill child
     let _ = rtm.call(
-        "rtm_ext_storage_child_storage_kill_version_1",
-        &(child_key1, child_definition, child_type).encode(),
+        "rtm_ext_default_child_storage_storage_kill_version_1",
+        &(child_key1).encode(),
     );
 
     // Get invalid killed value
     let res = rtm
         .call(
-            "rtm_ext_storage_child_get_version_1",
-            &(child_key1, child_definition, child_type, key1).encode(),
+            "rtm_ext_default_child_storage_get_version_1",
+            &(child_key1, key1).encode(),
         )
         .decode_ovec();
     assert!(res.is_none());
@@ -251,43 +237,41 @@ pub fn ext_storage_child_storage_kill_version_1(input: ParsedInput) {
     // Get invalid killed value
     let res = rtm
         .call(
-            "rtm_ext_storage_child_get_version_1",
-            &(child_key1, child_definition, child_type, key2).encode(),
+            "rtm_ext_default_child_storage_get_version_1",
+            &(child_key1, key2).encode(),
         )
         .decode_ovec();
     assert!(res.is_none());
 }
 
-pub fn ext_storage_child_exists_version_1(input: ParsedInput) {
+pub fn ext_default_child_storage_exists_version_1(input: ParsedInput) {
     let mut rtm = Runtime::new();
 
     let child_key1 = input.get(0);
     let child_key2 = input.get(1);
-    let child_definition = input.get(2);
-    let child_type = input.get_u32(3);
     let key = input.get(4);
     let value = input.get(5);
 
     // Check if key exists (invalid)
     let res = rtm
         .call(
-            "rtm_ext_storage_child_exists_version_1",
-            &(child_key1, child_definition, child_type, key).encode(),
+            "rtm_ext_default_child_storage_exists_version_1",
+            &(child_key1, key).encode(),
         )
         .decode_bool();
     assert_eq!(res, false);
 
     // Set key/value
     let _ = rtm.call(
-        "rtm_ext_storage_child_set_version_1",
-        &(child_key1, child_definition, child_type, key, value).encode(),
+        "rtm_ext_default_child_storage_set_version_1",
+        &(child_key1, key, value).encode(),
     );
 
     // Check if key exists (invalid, different child key)
     let res = rtm
         .call(
-            "rtm_ext_storage_child_exists_version_1",
-            &(child_key2, child_definition, child_type, key).encode(),
+            "rtm_ext_default_child_storage_exists_version_1",
+            &(child_key2, key).encode(),
         )
         .decode_bool();
     assert_eq!(res, false);
@@ -295,8 +279,8 @@ pub fn ext_storage_child_exists_version_1(input: ParsedInput) {
     // Check if key exists
     let res = rtm
         .call(
-            "rtm_ext_storage_child_exists_version_1",
-            &(child_key1, child_definition, child_type, key).encode(),
+            "rtm_ext_default_child_storage_exists_version_1",
+            &(child_key1, key).encode(),
         )
         .decode_bool();
     assert_eq!(res, true);
@@ -304,13 +288,11 @@ pub fn ext_storage_child_exists_version_1(input: ParsedInput) {
     println!("true");
 }
 
-pub fn ext_storage_child_clear_prefix_version_1(input: ParsedInput) {
+pub fn ext_default_child_storage_clear_prefix_version_1(input: ParsedInput) {
     let mut rtm = Runtime::new();
 
     let child_key1 = input.get(0);
     let child_key2 = input.get(1);
-    let child_definition = input.get(2);
-    let child_type = input.get_u32(3);
     let prefix = input.get(4);
     let key1 = input.get(5);
     let value1 = input.get(6);
@@ -319,33 +301,33 @@ pub fn ext_storage_child_clear_prefix_version_1(input: ParsedInput) {
 
     // Set key/value
     let _ = rtm.call(
-        "rtm_ext_storage_child_set_version_1",
-        &(child_key1, child_definition, child_type, key1, value1).encode(),
+        "rtm_ext_default_child_storage_set_version_1",
+        &(child_key1, key1, value1).encode(),
     );
 
     // Set key/value
     let _ = rtm.call(
-        "rtm_ext_storage_child_set_version_1",
-        &(child_key1, child_definition, child_type, key2, value2).encode(),
+        "rtm_ext_default_child_storage_set_version_1",
+        &(child_key1, key2, value2).encode(),
     );
 
     // Clear value (different key)
     let _ = rtm.call(
-        "rtm_ext_storage_child_clear_prefix_version_1",
-        &(child_key2, child_definition, child_type, prefix).encode(),
+        "rtm_ext_default_child_storage_clear_prefix_version_1",
+        &(child_key2, prefix).encode(),
     );
 
     // Clear value
     let _ = rtm.call(
-        "rtm_ext_storage_child_clear_prefix_version_1",
-        &(child_key1, child_definition, child_type, prefix).encode(),
+        "rtm_ext_default_child_storage_clear_prefix_version_1",
+        &(child_key1, prefix).encode(),
     );
 
     // Check first key
     let res = rtm
         .call(
-            "rtm_ext_storage_child_get_version_1",
-            &(child_key1, child_definition, child_type, key1).encode(),
+            "rtm_ext_default_child_storage_get_version_1",
+            &(child_key1, key1).encode(),
         )
         .decode_ovec();
     if key1.starts_with(prefix) {
@@ -359,8 +341,8 @@ pub fn ext_storage_child_clear_prefix_version_1(input: ParsedInput) {
     // Check second key
     let res = rtm
         .call(
-            "rtm_ext_storage_child_get_version_1",
-            &(child_key1, child_definition, child_type, key2).encode(),
+            "rtm_ext_default_child_storage_get_version_1",
+            &(child_key1, key2).encode(),
         )
         .decode_ovec();
     if key2.starts_with(prefix) {
@@ -372,13 +354,11 @@ pub fn ext_storage_child_clear_prefix_version_1(input: ParsedInput) {
     }
 }
 
-pub fn ext_storage_child_root_version_1(input: ParsedInput) {
+pub fn ext_default_child_storage_root_version_1(input: ParsedInput) {
     let mut rtm = Runtime::new();
 
     let child_key1 = input.get(0);
     let _child_key2 = input.get(1);
-    let child_definition = input.get(2);
-    let child_type = input.get_u32(3);
     let key1 = input.get(4);
     let value1 = input.get(5);
     let key2 = input.get(6);
@@ -386,20 +366,20 @@ pub fn ext_storage_child_root_version_1(input: ParsedInput) {
 
     // Set key/value
     let _ = rtm.call(
-        "rtm_ext_storage_child_set_version_1",
-        &(child_key1, child_definition, child_type, key1, value1).encode(),
+        "rtm_ext_default_child_storage_set_version_1",
+        &(child_key1, key1, value1).encode(),
     );
 
     // Set key/value
     let _ = rtm.call(
-        "rtm_ext_storage_child_set_version_1",
-        &(child_key1, child_definition, child_type, key2, value2).encode(),
+        "rtm_ext_default_child_storage_set_version_1",
+        &(child_key1, key2, value2).encode(),
     );
 
     // Set key/value (different child key)
     /* TODO: Inserting this will cause the root hash to change.
                 Wait for new changes before testing again.
-    let _ = rtm.call("rtm_ext_storage_child_set_version_1", &(
+    let _ = rtm.call("rtm_ext_default_child_storage_set_version_1", &(
         child_key2,
         child_definition,
         child_type,
@@ -410,19 +390,17 @@ pub fn ext_storage_child_root_version_1(input: ParsedInput) {
 
     // Get root
     let res = rtm
-        .call("rtm_ext_storage_child_root_version_1", &child_key1.encode())
+        .call("rtm_ext_default_child_storage_root_version_1", &child_key1.encode())
         .decode_vec();
 
     println!("{}", hex::encode(res));
 }
 
-pub fn ext_storage_child_next_key_version_1(input: ParsedInput) {
+pub fn ext_default_child_storage_next_key_version_1(input: ParsedInput) {
     let mut rtm = Runtime::new();
 
     let child_key1 = input.get(0);
     let child_key2 = input.get(1);
-    let child_definition = input.get(2);
-    let child_type = input.get_u32(3);
     let key1 = input.get(4);
     let value1 = input.get(5);
     let key2 = input.get(6);
@@ -437,27 +415,27 @@ pub fn ext_storage_child_next_key_version_1(input: ParsedInput) {
     // No next key available
     let res = rtm
         .call(
-            "rtm_ext_storage_child_next_key_version_1",
-            &(child_key1, child_definition, child_type, key1).encode(),
+            "rtm_ext_default_child_storage_next_key_version_1",
+            &(child_key1, key1).encode(),
         )
         .decode_ovec();
     assert!(res.is_none());
 
     // Set key/value
     let _ = rtm.call(
-        "rtm_ext_storage_child_set_version_1",
-        &(child_key1, child_definition, child_type, key1, value1).encode(),
+        "rtm_ext_default_child_storage_set_version_1",
+        &(child_key1, key1, value1).encode(),
     );
     let _ = rtm.call(
-        "rtm_ext_storage_child_set_version_1",
-        &(child_key1, child_definition, child_type, key2, value2).encode(),
+        "rtm_ext_default_child_storage_set_version_1",
+        &(child_key1, key2, value2).encode(),
     );
 
     // Try to read next key
     let res = rtm
         .call(
-            "rtm_ext_storage_child_next_key_version_1",
-            &(child_key1, child_definition, child_type, key1).encode(),
+            "rtm_ext_default_child_storage_next_key_version_1",
+            &(child_key1, key1).encode(),
         )
         .decode_ovec();
     if key1 == track[0] {
@@ -470,8 +448,8 @@ pub fn ext_storage_child_next_key_version_1(input: ParsedInput) {
     // Try to read next key
     let res = rtm
         .call(
-            "rtm_ext_storage_child_next_key_version_1",
-            &(child_key1, child_definition, child_type, key2).encode(),
+            "rtm_ext_default_child_storage_next_key_version_1",
+            &(child_key1, key2).encode(),
         )
         .decode_ovec();
     if key2 == track[0] {
@@ -484,8 +462,8 @@ pub fn ext_storage_child_next_key_version_1(input: ParsedInput) {
     // Get invalid next key (different child key)
     let res = rtm
         .call(
-            "rtm_ext_storage_child_next_key_version_1",
-            &(child_key2, child_definition, child_type, key1).encode(),
+            "rtm_ext_default_child_storage_next_key_version_1",
+            &(child_key2, key1).encode(),
         )
         .decode_ovec();
     assert!(res.is_none());
@@ -493,8 +471,8 @@ pub fn ext_storage_child_next_key_version_1(input: ParsedInput) {
     // Get invalid next key (different child key)
     let res = rtm
         .call(
-            "rtm_ext_storage_child_next_key_version_1",
-            &(child_key2, child_definition, child_type, key2).encode(),
+            "rtm_ext_default_child_storage_next_key_version_1",
+            &(child_key2, key2).encode(),
         )
         .decode_ovec();
     assert!(res.is_none());

--- a/test/adapters/substrate/src/host_api/child_storage.rs
+++ b/test/adapters/substrate/src/host_api/child_storage.rs
@@ -6,8 +6,8 @@ pub fn ext_default_child_storage_set_version_1(input: ParsedInput) {
 
     let child_key1 = input.get(0);
     let child_key2 = input.get(1);
-    let key = input.get(4);
-    let value = input.get(5);
+    let key = input.get(2);
+    let value = input.get(3);
 
     // Get invalid key
     let res = rtm
@@ -55,10 +55,10 @@ pub fn ext_default_child_storage_read_version_1(input: ParsedInput) {
 
     let child_key1 = input.get(0);
     let child_key2 = input.get(1);
-    let key = input.get(4);
-    let value = input.get(5);
-    let offset = input.get_u32(6);
-    let buffer_size = input.get_u32(7);
+    let key = input.get(2);
+    let value = input.get(3);
+    let offset = input.get_u32(4);
+    let buffer_size = input.get_u32(5);
 
     // Get invalid key
     let res = rtm
@@ -130,8 +130,8 @@ pub fn ext_default_child_storage_clear_version_1(input: ParsedInput) {
 
     let child_key1 = input.get(0);
     let child_key2 = input.get(1);
-    let key = input.get(4);
-    let value = input.get(5);
+    let key = input.get(2);
+    let value = input.get(3);
 
     // Set key/value
     let _ = rtm.call(
@@ -176,10 +176,10 @@ pub fn ext_default_child_storage_storage_kill_version_1(input: ParsedInput) {
 
     let child_key1 = input.get(0);
     let child_key2 = input.get(1);
-    let key1 = input.get(4);
-    let value1 = input.get(5);
-    let key2 = input.get(6);
-    let value2 = input.get(7);
+    let key1 = input.get(2);
+    let value1 = input.get(3);
+    let key2 = input.get(4);
+    let value2 = input.get(5);
 
     // Set key/value
     let _ = rtm.call(
@@ -249,8 +249,8 @@ pub fn ext_default_child_storage_exists_version_1(input: ParsedInput) {
 
     let child_key1 = input.get(0);
     let child_key2 = input.get(1);
-    let key = input.get(4);
-    let value = input.get(5);
+    let key = input.get(2);
+    let value = input.get(3);
 
     // Check if key exists (invalid)
     let res = rtm
@@ -293,11 +293,11 @@ pub fn ext_default_child_storage_clear_prefix_version_1(input: ParsedInput) {
 
     let child_key1 = input.get(0);
     let child_key2 = input.get(1);
-    let prefix = input.get(4);
-    let key1 = input.get(5);
-    let value1 = input.get(6);
-    let key2 = input.get(7);
-    let value2 = input.get(8);
+    let prefix = input.get(2);
+    let key1 = input.get(3);
+    let value1 = input.get(4);
+    let key2 = input.get(5);
+    let value2 = input.get(6);
 
     // Set key/value
     let _ = rtm.call(
@@ -359,10 +359,10 @@ pub fn ext_default_child_storage_root_version_1(input: ParsedInput) {
 
     let child_key1 = input.get(0);
     let _child_key2 = input.get(1);
-    let key1 = input.get(4);
-    let value1 = input.get(5);
-    let key2 = input.get(6);
-    let value2 = input.get(7);
+    let key1 = input.get(2);
+    let value1 = input.get(3);
+    let key2 = input.get(4);
+    let value2 = input.get(5);
 
     // Set key/value
     let _ = rtm.call(
@@ -401,10 +401,10 @@ pub fn ext_default_child_storage_next_key_version_1(input: ParsedInput) {
 
     let child_key1 = input.get(0);
     let child_key2 = input.get(1);
-    let key1 = input.get(4);
-    let value1 = input.get(5);
-    let key2 = input.get(6);
-    let value2 = input.get(7);
+    let key1 = input.get(2);
+    let value1 = input.get(3);
+    let key2 = input.get(4);
+    let value2 = input.get(5);
 
     // Keep track of the ordering of the keys
     let mut track = vec![];

--- a/test/adapters/substrate/src/host_api/child_storage.rs
+++ b/test/adapters/substrate/src/host_api/child_storage.rs
@@ -76,10 +76,10 @@ pub fn ext_storage_child_read_version_1(input: ParsedInput) {
                 offset,
                 buffer_size,
             )
-                .encode(),
+            .encode(),
         )
-        .decode_vec();
-    assert_eq!(res, vec![0u8; buffer_size as usize]);
+        .decode_ovec();
+    assert!(res.is_none());
 
     // Set key/value
     let _ = rtm.call(
@@ -101,8 +101,8 @@ pub fn ext_storage_child_read_version_1(input: ParsedInput) {
             )
             .encode(),
         )
-        .decode_vec();
-    assert_eq!(res, vec![0u8; buffer_size as usize]);
+        .decode_ovec();
+    assert!(res.is_none());
 
     // Get valid key
     let res = rtm
@@ -118,31 +118,21 @@ pub fn ext_storage_child_read_version_1(input: ParsedInput) {
             )
                 .encode(),
         )
-        .decode_vec();
+        .decode_ovec()
+        .unwrap();
 
     let offset = offset as usize;
     let buffer_size = buffer_size as usize;
 
     if offset < value.len() {
-        // Make sure `to_compare` does not exceed the length of the actual value
-        let mut to_compare;
-        if offset + buffer_size > value.len() {
-            to_compare = value[(offset)..value.len()].to_vec();
-        } else {
-            to_compare = value[(offset)..(offset + buffer_size)].to_vec();
-        }
+        let end = std::cmp::min(offset + buffer_size, value.len());
 
-        // If the buffer is bigger than `to_compare`, fill the rest with zeroes
-        while to_compare.len() < buffer_size as usize {
-            to_compare.push(0);
-        }
-
-        assert_eq!(res, to_compare);
+        assert_eq!(res, value[offset..end].to_vec());
     } else {
-        assert_eq!(res, vec![0; buffer_size])
+        assert!(res.is_empty());
     }
 
-    println!("{}", str(&res).trim_matches(char::from(0)));
+    println!("{}", str(&res));
 }
 
 pub fn ext_storage_child_clear_version_1(input: ParsedInput) {

--- a/test/adapters/substrate/src/host_api/mod.rs
+++ b/test/adapters/substrate/src/host_api/mod.rs
@@ -26,15 +26,15 @@ pub fn process_host_api_tests(subcmd_matches: &ArgMatches) {
             "ext_storage_next_key_version_1"     => storage::ext_storage_next_key_version_1(input),
 
             // child storage api
-            "ext_storage_child_set_version_1" => child_storage::ext_storage_child_set_version_1(input),
-            "ext_storage_child_get_version_1" => child_storage::ext_storage_child_get_version_1(input),
-            "ext_storage_child_read_version_1" => child_storage::ext_storage_child_read_version_1(input),
-            "ext_storage_child_clear_version_1" => child_storage::ext_storage_child_clear_version_1(input),
-            "ext_storage_child_storage_kill_version_1" => child_storage::ext_storage_child_storage_kill_version_1(input),
-            "ext_storage_child_exists_version_1" => child_storage::ext_storage_child_exists_version_1(input),
-            "ext_storage_child_clear_prefix_version_1" => child_storage::ext_storage_child_clear_prefix_version_1(input),
-            "ext_storage_child_root_version_1" => child_storage::ext_storage_child_root_version_1(input),
-            "ext_storage_child_next_key_version_1" => child_storage::ext_storage_child_next_key_version_1(input),
+            "ext_storage_child_set_version_1" => child_storage::ext_default_child_storage_set_version_1(input),
+            "ext_storage_child_get_version_1" => child_storage::ext_default_child_storage_get_version_1(input),
+            "ext_storage_child_read_version_1" => child_storage::ext_default_child_storage_read_version_1(input),
+            "ext_storage_child_clear_version_1" => child_storage::ext_default_child_storage_clear_version_1(input),
+            "ext_storage_child_storage_kill_version_1" => child_storage::ext_default_child_storage_storage_kill_version_1(input),
+            "ext_storage_child_exists_version_1" => child_storage::ext_default_child_storage_exists_version_1(input),
+            "ext_storage_child_clear_prefix_version_1" => child_storage::ext_default_child_storage_clear_prefix_version_1(input),
+            "ext_storage_child_root_version_1" => child_storage::ext_default_child_storage_root_version_1(input),
+            "ext_storage_child_next_key_version_1" => child_storage::ext_default_child_storage_next_key_version_1(input),
 
             // crypto api
             "ext_crypto_ed25519_public_keys_version_1" => crypto::ext_crypto_ed25519_public_keys_version_1(input),

--- a/test/adapters/substrate/src/host_api/mod.rs
+++ b/test/adapters/substrate/src/host_api/mod.rs
@@ -26,15 +26,15 @@ pub fn process_host_api_tests(subcmd_matches: &ArgMatches) {
             "ext_storage_next_key_version_1"     => storage::ext_storage_next_key_version_1(input),
 
             // child storage api
-            "ext_storage_child_set_version_1" => child_storage::ext_default_child_storage_set_version_1(input),
-            "ext_storage_child_get_version_1" => child_storage::ext_default_child_storage_get_version_1(input),
-            "ext_storage_child_read_version_1" => child_storage::ext_default_child_storage_read_version_1(input),
-            "ext_storage_child_clear_version_1" => child_storage::ext_default_child_storage_clear_version_1(input),
-            "ext_storage_child_storage_kill_version_1" => child_storage::ext_default_child_storage_storage_kill_version_1(input),
-            "ext_storage_child_exists_version_1" => child_storage::ext_default_child_storage_exists_version_1(input),
-            "ext_storage_child_clear_prefix_version_1" => child_storage::ext_default_child_storage_clear_prefix_version_1(input),
-            "ext_storage_child_root_version_1" => child_storage::ext_default_child_storage_root_version_1(input),
-            "ext_storage_child_next_key_version_1" => child_storage::ext_default_child_storage_next_key_version_1(input),
+            "ext_default_child_storage_set_version_1" => child_storage::ext_default_child_storage_set_version_1(input),
+            "ext_default_child_storage_get_version_1" => child_storage::ext_default_child_storage_get_version_1(input),
+            "ext_default_child_storage_read_version_1" => child_storage::ext_default_child_storage_read_version_1(input),
+            "ext_default_child_storage_clear_version_1" => child_storage::ext_default_child_storage_clear_version_1(input),
+            "ext_default_child_storage_storage_kill_version_1" => child_storage::ext_default_child_storage_storage_kill_version_1(input),
+            "ext_default_child_storage_exists_version_1" => child_storage::ext_default_child_storage_exists_version_1(input),
+            "ext_default_child_storage_clear_prefix_version_1" => child_storage::ext_default_child_storage_clear_prefix_version_1(input),
+            "ext_default_child_storage_root_version_1" => child_storage::ext_default_child_storage_root_version_1(input),
+            "ext_default_child_storage_next_key_version_1" => child_storage::ext_default_child_storage_next_key_version_1(input),
 
             // crypto api
             "ext_crypto_ed25519_public_keys_version_1" => crypto::ext_crypto_ed25519_public_keys_version_1(input),

--- a/test/adapters/substrate/src/host_api/storage.rs
+++ b/test/adapters/substrate/src/host_api/storage.rs
@@ -53,8 +53,8 @@ pub fn ext_storage_read_version_1(input: ParsedInput) {
             "rtm_ext_storage_read_version_1",
             &(key, offset, buffer_size).encode(),
         )
-        .decode_vec();
-    assert_eq!(res, vec![0u8; buffer_size as usize]);
+        .decode_ovec();
+    assert!(res.is_none());
 
     // Set key/value
     let _ = rtm.call("rtm_ext_storage_set_version_1", &(key, value).encode());
@@ -65,31 +65,21 @@ pub fn ext_storage_read_version_1(input: ParsedInput) {
             "rtm_ext_storage_read_version_1",
             &(key, offset, buffer_size).encode(),
         )
-        .decode_vec();
+        .decode_ovec()
+        .unwrap();
 
     let offset = offset as usize;
     let buffer_size = buffer_size as usize;
 
     if offset < value.len() {
-        // Make sure `to_compare` does not exceed the length of the actual value
-        let mut to_compare;
-        if offset + buffer_size > value.len() {
-            to_compare = value[(offset)..value.len()].to_vec();
-        } else {
-            to_compare = value[(offset)..(offset + buffer_size)].to_vec();
-        }
+        let end = std::cmp::min(offset + buffer_size, value.len());
 
-        // If the buffer is bigger than `to_compare`, fill the rest with zeroes
-        while to_compare.len() < buffer_size as usize {
-            to_compare.push(0);
-        }
-
-        assert_eq!(res, to_compare);
+        assert_eq!(res, value[offset..end].to_vec());
     } else {
-        assert_eq!(res, vec![0; buffer_size])
+        assert!(res.is_empty())
     }
 
-    println!("{}", str(&res).trim_matches(char::from(0)));
+    println!("{}", str(&res));
 }
 
 pub fn ext_storage_clear_version_1(input: ParsedInput) {

--- a/test/adapters/substrate/src/host_api/utils.rs
+++ b/test/adapters/substrate/src/host_api/utils.rs
@@ -12,7 +12,7 @@ use sp_core::{
     offchain::OffchainExt,
     testing::KeyStore,
     traits::KeystoreExt, 
-    //traits::MissingHostFunctions, // TODO for > alpha.6
+    traits::MissingHostFunctions,
     Blake2Hasher,
 };
 use sp_state_machine::TestExternalities as CoreTestExternalities;
@@ -98,7 +98,6 @@ impl Runtime {
             WasmExecutionMethod::Interpreted,
             Some(8), // heap_pages
             SubstrateHostFunctions::host_functions(),
-            false, // allow_missing_func_import // TODO Remove > alpha.6
             8 // max_runtime_instances
         ).call_in_wasm(
             &self.blob,
@@ -106,7 +105,7 @@ impl Runtime {
             method,
             data,
             &mut extext,
-            //MissingHostFunctions::Disallow // TODO Needed in > alpha.6
+            MissingHostFunctions::Disallow,
         ).unwrap()
     }
 }

--- a/test/adapters/wasm/Cargo.lock
+++ b/test/adapters/wasm/Cargo.lock
@@ -12,9 +12,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.10"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
+checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 dependencies = [
  "memchr",
 ]
@@ -38,9 +38,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "build-helper"
@@ -89,9 +89,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "derive_more"
-version = "0.99.7"
+version = "0.99.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2127768764f1556535c01b5326ef94bd60ff08dcfbdc544d53e69ed155610f5d"
+checksum = "1dcfabdab475c16a93d669dddfc393027803e347d09663f524447f642fbb84ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.5.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "fixed-hash"
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
+checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 dependencies = [
  "libc",
 ]
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "lazy_static"
@@ -201,15 +201,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.71"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
 
 [[package]]
 name = "log"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
 ]
@@ -222,18 +222,18 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.0"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c8f7f4244ddb5c37c103641027a76c530e65e8e4b8240b29f81ea40508b17"
+checksum = "7c740e5fbcb6847058b40ac7e5574766c6388f585e184d769910fe0d3a2ca861"
 dependencies = [
  "arrayvec",
  "byte-slice-cast",
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a0ec292e92e8ec7c58e576adacc1e3f399c597c8f263c42f18420abe58e7245"
+checksum = "198db82bb1c18fc00176004462dd809b2a6d851669550aa17af6dacd21ae0c14"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "parity-util-mem"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6e2583649a3ca84894d1d71da249abcfda54d5aca24733d72ca10d0f02361c"
+checksum = "297ff91fa36aec49ce183484b102f6b75b46776822bd81525bfc4cc9b0dd0f5c"
 dependencies = [
  "cfg-if",
  "impl-trait-for-tuples",
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
+checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
 name = "primitive-types"
@@ -304,27 +304,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
  "toml",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.18"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
+checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
+checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
 ]
@@ -372,24 +372,24 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "ref-cast"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a214c7875e1b63fc1618db7c80efc0954f6156c9ff07699fd9039e255accdd1"
+checksum = "745c1787167ddae5569661d5ffb8b25ae5fedbf46717eaa92d652221cec72623"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eb59cda66fcb9aec25841fb76bc01d2b34282dcdd705028da297db6f3eec8"
+checksum = "7d21b475ab879ef0e315ad99067fa25778c3b0377f57f1b00207448dac1a3144"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -416,9 +416,9 @@ checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "remove_dir_all"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
 ]
@@ -451,6 +451,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9182278ed645df3477a9c27bfee0621c621aa16f6972635f7f795dae3d81070f"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,15 +486,15 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.111"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
+checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.111"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
+checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -494,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.53"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
+checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
 dependencies = [
  "itoa",
  "ryu",
@@ -505,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "2.0.0-rc2"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa9131cde687315ba8220fb5a5c8d20f578b806a8aa62dd58a6d074620e67f7"
+checksum = "146765f2e906030c2d7fba4a685390407d5d0595b7e46716b2bcd6c7ac744579"
 dependencies = [
  "byteorder",
  "derive_more",
@@ -518,6 +527,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
  "primitive-types",
+ "secrecy",
  "sp-debug-derive",
  "sp-runtime-interface",
  "sp-std",
@@ -527,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "sp-debug-derive"
-version = "2.0.0-rc2"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75b20e97569b77fe3e973f9c95965fd5e3b87592bf479067a14de923fa0f602"
+checksum = "8fc56e04bc64020aa6c1a35fb74991ab8d2aa46ffc0b133145103d8b6304f195"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -538,14 +548,15 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "2.0.0-rc2"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f94a8b74729dd6c13424a03a2717ed0ac9a2f43613148db88728942327bea3e"
+checksum = "3b63b4b5e0fd1488b545d908003cd8129c88c066af361f9b6483ac7c97d8f6c1"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "sp-runtime-interface-proc-macro",
  "sp-std",
+ "sp-storage",
  "sp-tracing",
  "sp-wasm-interface",
  "static_assertions",
@@ -553,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "2.0.0-rc2"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "480b49e81062a4b08200d47ea60c27d3c9b9f931d4dd3b1b6e6c5f0c0dc1a1f8"
+checksum = "21c3ed5a0258faaa1370859bfdacf27d798f4205161a68289555eb1a1a6a4e41"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -566,16 +577,17 @@ dependencies = [
 
 [[package]]
 name = "sp-std"
-version = "2.0.0-rc2"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "652e90f1e036a1499c79c5c2d8569709dd31a1ea263c99da47b3c7f2121a938a"
+checksum = "dd69654cdd9fa179dad52811220356dc2991f70b3b93e77c27f4e317d58c059b"
 
 [[package]]
 name = "sp-storage"
-version = "2.0.0-rc2"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b12ec4ed124bb8d03cbc17575a34d2ee7c6b780c83d2e63a532cf7c1195997"
+checksum = "5c0dba5526e0a1d2acc3d969cdcdf89f4e0395a1a6e807f5aa517ef15bf0e710"
 dependencies = [
+ "parity-scale-codec",
  "ref-cast",
  "sp-debug-derive",
  "sp-std",
@@ -583,15 +595,15 @@ dependencies = [
 
 [[package]]
 name = "sp-tracing"
-version = "2.0.0-rc2"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9096b3de76b42bd2cc1f8890c6e416ada152deb937c1a7974270e3c14a595b0e"
+checksum = "50a43072c8a66b1f6cfec0bee7f3f2aa7866869317b5f430e8a2743551b77c4d"
 
 [[package]]
 name = "sp-wasm-interface"
-version = "2.0.0-rc2"
+version = "2.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae20ed52dc510fc23f79854dd71a5fd6160e40ab05e540c483ebbd59cbba08f"
+checksum = "eeb0c2a1c2bdbbd67c1b8f20a9c85606122e7227b67cf5cd9faf3df2f454a66b"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -623,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"
+checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -634,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -678,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "uint"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173cd16430c206dc1a430af8a89a0e9c076cf15cb42b4aedb10e8cc8fee73681"
+checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -690,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "walkdir"
@@ -713,7 +725,7 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-adapter"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -733,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -764,6 +776,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zeroize"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"

--- a/test/adapters/wasm/Cargo.toml
+++ b/test/adapters/wasm/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "wasm-adapter"
-version = "2.0.0-alpha.6"
+version = "2.0.0-rc6"
 edition = "2018"
 build = "build.rs"
 
 [dependencies]
-sp-core            = { version = "2.0.0-alpha", default-features = false, optional = true }
+sp-core            = { version = "2.0.0-rc6", default-features = false, optional = true }
 parity-scale-codec = { version = "1.3",         default-features = false, optional = true }
 
 [build-dependencies]

--- a/test/adapters/wasm/src/lib.rs
+++ b/test/adapters/wasm/src/lib.rs
@@ -10,69 +10,56 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 #[cfg(feature = "runtime-wasm")]
 extern "C" {
-    fn ext_storage_get_version_1(key: u64) -> u64;
-    fn ext_storage_child_get_version_1(child_key: u64, def: u64, child_type: u32, key: u64) -> u64;
-    fn ext_storage_read_version_1(key: u64, out: u64, offset: u32) -> u64;
-    fn ext_storage_child_read_version_1(
-        child_key: u64,
-        def: u64,
-        child_type: u32,
-        key: u64,
-        out: u64,
-        offset: u32,
-    ) -> u64;
+    // Storage API
     fn ext_storage_set_version_1(key: u64, value: u64);
-    fn ext_storage_child_set_version_1(
-        child_key: u64,
-        def: u64,
-        child_type: u32,
-        key: u64,
-        value: u64,
-    );
+    fn ext_storage_get_version_1(key: u64) -> u64;
+    fn ext_storage_read_version_1(key: u64, out: u64, offset: u32) -> u64;
     fn ext_storage_clear_version_1(key: u64);
-    fn ext_storage_child_clear_version_1(child_key: u64, def: u64, child_type: u32, key: u64);
-    fn ext_storage_child_storage_kill_version_1(child_key: u64, def: u64, child_type: u32);
     fn ext_storage_exists_version_1(key: u64) -> i32;
-    fn ext_storage_child_exists_version_1(
-        child_key: u64,
-        def: u64,
-        child_type: u32,
-        key: u64,
-    ) -> i32;
     fn ext_storage_clear_prefix_version_1(key: u64);
-    fn ext_storage_child_clear_prefix_version_1(
-        child_key: u64,
-        def: u64,
-        child_type: u32,
-        key: u64,
-    );
     fn ext_storage_root_version_1() -> u64;
-    fn ext_storage_child_root_version_1(child_key: u64) -> u64;
     fn ext_storage_next_key_version_1(key: u64) -> u64;
-    fn ext_storage_child_next_key_version_1(
-        child_key: u64,
-        def: u64,
-        child_type: u32,
-        key: u64,
-    ) -> u64;
+
+    // Default child stoage API
+    fn ext_default_child_storage_set_version_1(child: u64, key: u64, value: u64);
+    fn ext_default_child_storage_get_version_1(child: u64, key: u64) -> u64;
+    fn ext_default_child_storage_read_version_1(child: u64, key: u64, out: u64, offset: u32) -> u64;
+    fn ext_default_child_storage_clear_version_1(child: u64, key: u64);
+    fn ext_default_child_storage_storage_kill_version_1(child: u64);
+    fn ext_default_child_storage_exists_version_1(child: u64, key: u64) -> i32;
+    fn ext_default_child_storage_clear_prefix_version_1(child: u64, key: u64);
+    fn ext_default_child_storage_root_version_1(child: u64) -> u64;
+    fn ext_default_child_storage_next_key_version_1(child: u64, key: u64) -> u64;
+
+    // Crypto API
     fn ext_crypto_ed25519_public_keys_version_1(id: u32) -> u64;
     fn ext_crypto_ed25519_generate_version_1(id: u32, seed: u64) -> u32;
     fn ext_crypto_ed25519_sign_version_1(id: u32, pubkey: u32, msg: u64) -> u64;
     fn ext_crypto_ed25519_verify_version_1(sig: u32, msg: u64, pubkey: u32) -> i32;
+
     fn ext_crypto_sr25519_public_keys_version_1(id: u32) -> u64;
     fn ext_crypto_sr25519_generate_version_1(id: u32, seed: u64) -> u32;
     fn ext_crypto_sr25519_sign_version_1(id: u32, pubkey: u32, msg: u64) -> u64;
     fn ext_crypto_sr25519_verify_version_1(sig: u32, msg: u64, pubkey: u32) -> i32;
+
     fn ext_crypto_secp256k1_ecdsa_recover_version_1(sig: u32, msg: u32) -> u64;
+
+    // Hashing API
     fn ext_hashing_keccak_256_version_1(data: u64) -> i32;
     fn ext_hashing_sha2_256_version_1(data: u64) -> i32;
+
     fn ext_hashing_blake2_128_version_1(data: u64) -> i32;
     fn ext_hashing_blake2_256_version_1(data: u64) -> i32;
+
     fn ext_hashing_twox_256_version_1(data: u64) -> i32;
     fn ext_hashing_twox_128_version_1(data: u64) -> i32;
     fn ext_hashing_twox_64_version_1(data: u64) -> i32;
+
+    // Allocator API
     fn ext_allocator_malloc_version_1(size: u32) -> u32;
     fn ext_allocator_free_version_1(ptr: u32);
+
+    // Trie API
     fn ext_trie_blake2_256_root_version_1(data: u64) -> u32;
     fn ext_trie_blake2_256_ordered_root_version_1(data: u64) -> u32;
 }
@@ -108,17 +95,13 @@ sp_core::wasm_export_functions! {
             Decode::decode(&mut from_mem(value).as_slice()).unwrap()
         }
     }
-    fn rtm_ext_storage_child_get_version_1(
+    fn rtm_ext_default_child_storage_get_version_1(
         child_key: Vec<u8>,
-        child_definition: Vec<u8>,
-        child_type: u32,
         key_data: Vec<u8>
     ) -> Option<Vec<u8>> {
         unsafe {
-            let value = ext_storage_child_get_version_1(
+            let value = ext_default_child_storage_get_version_1(
                 child_key.as_re_ptr(),
-                child_definition.as_re_ptr(),
-                child_type,
                 key_data.as_re_ptr(),
             );
             Decode::decode(&mut from_mem(value).as_slice()).unwrap()
@@ -142,20 +125,16 @@ sp_core::wasm_export_functions! {
                 .map(|n| buffer[..(n.min(buffer_size) as usize)].to_vec())
         }
     }
-    fn rtm_ext_storage_child_read_version_1(
+    fn rtm_ext_default_child_storage_read_version_1(
         child_key: Vec<u8>,
-        child_definition: Vec<u8>,
-        child_type: u32,
         key_data: Vec<u8>,
         offset: u32,
         buffer_size: u32 // not directly required for PDRE API, only used for testing
     ) -> Option<Vec<u8>> {
         let mut buffer = vec![0u8; buffer_size as usize];
         unsafe {
-            let res = ext_storage_child_read_version_1(
+            let res = ext_default_child_storage_read_version_1(
                 child_key.as_re_ptr(),
-                child_definition.as_re_ptr(),
-                child_type,
                 key_data.as_re_ptr(),
                 buffer.as_re_ptr(),
                 offset
@@ -177,18 +156,14 @@ sp_core::wasm_export_functions! {
             );
         }
     }
-    fn rtm_ext_storage_child_set_version_1(
+    fn rtm_ext_default_child_storage_set_version_1(
         child_key: Vec<u8>,
-        child_definition: Vec<u8>,
-        child_type: u32,
         key_data: Vec<u8>,
         value_data: Vec<u8>
     ) {
         unsafe {
-            let _ = ext_storage_child_set_version_1(
+            let _ = ext_default_child_storage_set_version_1(
                 child_key.as_re_ptr(),
-                child_definition.as_re_ptr(),
-                child_type,
                 key_data.as_re_ptr(),
                 value_data.as_re_ptr()
             );
@@ -203,31 +178,23 @@ sp_core::wasm_export_functions! {
             );
         }
     }
-    fn rtm_ext_storage_child_clear_version_1(
+    fn rtm_ext_default_child_storage_clear_version_1(
         child_key: Vec<u8>,
-        child_definition: Vec<u8>,
-        child_type: u32,
         key_data: Vec<u8>
     ) {
         unsafe {
-            let _ = ext_storage_child_clear_version_1(
+            let _ = ext_default_child_storage_clear_version_1(
                 child_key.as_re_ptr(),
-                child_definition.as_re_ptr(),
-                child_type,
                 key_data.as_re_ptr(),
             );
         }
     }
-    fn rtm_ext_storage_child_storage_kill_version_1(
+    fn rtm_ext_default_child_storage_storage_kill_version_1(
         child_key: Vec<u8>,
-        child_definition: Vec<u8>,
-        child_type: u32,
     ) {
         unsafe {
-            let _ = ext_storage_child_storage_kill_version_1(
+            let _ = ext_default_child_storage_storage_kill_version_1(
                 child_key.as_re_ptr(),
-                child_definition.as_re_ptr(),
-                child_type
             );
         }
     }
@@ -240,17 +207,13 @@ sp_core::wasm_export_functions! {
             ) as u32
         }
     }
-    fn rtm_ext_storage_child_exists_version_1(
+    fn rtm_ext_default_child_storage_exists_version_1(
         child_key: Vec<u8>,
-        child_definition: Vec<u8>,
-        child_type: u32,
         key_data: Vec<u8>
     ) -> u32 {
         unsafe {
-            ext_storage_child_exists_version_1(
+            ext_default_child_storage_exists_version_1(
                 child_key.as_re_ptr(),
-                child_definition.as_re_ptr(),
-                child_type,
                 key_data.as_re_ptr(),
             ) as u32
         }
@@ -264,17 +227,13 @@ sp_core::wasm_export_functions! {
             );
         }
     }
-    fn rtm_ext_storage_child_clear_prefix_version_1(
+    fn rtm_ext_default_child_storage_clear_prefix_version_1(
         child_key: Vec<u8>,
-        child_definition: Vec<u8>,
-        child_type: u32,
         key_data: Vec<u8>
     ) {
         unsafe {
-            let _ = ext_storage_child_clear_prefix_version_1(
+            let _ = ext_default_child_storage_clear_prefix_version_1(
                 child_key.as_re_ptr(),
-                child_definition.as_re_ptr(),
-                child_type,
                 key_data.as_re_ptr(),
             );
         }
@@ -285,9 +244,9 @@ sp_core::wasm_export_functions! {
             from_mem(value)
         }
     }
-    fn rtm_ext_storage_child_root_version_1(child_key: Vec<u8>) -> Vec<u8> {
+    fn rtm_ext_default_child_storage_root_version_1(child_key: Vec<u8>) -> Vec<u8> {
         unsafe {
-            let value = ext_storage_child_root_version_1(
+            let value = ext_default_child_storage_root_version_1(
                 child_key.as_re_ptr(),
             );
             from_mem(value)
@@ -301,17 +260,13 @@ sp_core::wasm_export_functions! {
             Decode::decode(&mut from_mem(value).as_slice()).unwrap()
         }
     }
-    fn rtm_ext_storage_child_next_key_version_1(
+    fn rtm_ext_default_child_storage_next_key_version_1(
         child_key: Vec<u8>,
-        child_definition: Vec<u8>,
-        child_type: u32,
         key_data: Vec<u8>
     ) -> Option<Vec<u8>> {
         unsafe {
-            let value = ext_storage_child_next_key_version_1(
+            let value = ext_default_child_storage_next_key_version_1(
                 child_key.as_re_ptr(),
-                child_definition.as_re_ptr(),
-                child_type,
                 key_data.as_re_ptr(),
             );
             Decode::decode(&mut from_mem(value).as_slice()).unwrap()

--- a/test/adapters/wasm/src/lib.rs
+++ b/test/adapters/wasm/src/lib.rs
@@ -128,16 +128,19 @@ sp_core::wasm_export_functions! {
         key_data: Vec<u8>,
         offset: u32,
         buffer_size: u32 // not directly required for PDRE API, only used for testing
-    ) -> Vec<u8> {
+    ) -> Option<Vec<u8>> {
         let mut buffer = vec![0u8; buffer_size as usize];
         unsafe {
-            ext_storage_read_version_1(
+            let res = ext_storage_read_version_1(
                 key_data.as_re_ptr(),
                 buffer.as_re_ptr(),
                 offset
             );
+
+            Option::<u32>::decode(&mut from_mem(res).as_slice())
+                .unwrap()
+                .map(|n| buffer[..(n.min(buffer_size) as usize)].to_vec())
         }
-        buffer.to_vec()
     }
     fn rtm_ext_storage_child_read_version_1(
         child_key: Vec<u8>,
@@ -146,10 +149,10 @@ sp_core::wasm_export_functions! {
         key_data: Vec<u8>,
         offset: u32,
         buffer_size: u32 // not directly required for PDRE API, only used for testing
-    ) -> Vec<u8> {
+    ) -> Option<Vec<u8>> {
         let mut buffer = vec![0u8; buffer_size as usize];
         unsafe {
-            ext_storage_child_read_version_1(
+            let res = ext_storage_child_read_version_1(
                 child_key.as_re_ptr(),
                 child_definition.as_re_ptr(),
                 child_type,
@@ -157,8 +160,11 @@ sp_core::wasm_export_functions! {
                 buffer.as_re_ptr(),
                 offset
             );
+
+            Option::<u32>::decode(&mut from_mem(res).as_slice())
+                .unwrap()
+                .map(|n| buffer[..(n.min(buffer_size) as usize)].to_vec())
         }
-        buffer.to_vec()
     }
     fn rtm_ext_storage_set_version_1(
         key_data: Vec<u8>,

--- a/test/fixtures/host-api/HostApiFunctions.jl
+++ b/test/fixtures/host-api/HostApiFunctions.jl
@@ -25,27 +25,27 @@ module HostApiFunctions
 		"ext_storage_exists_version_1"
 	]
 
-	const child_child_def_type_key_value = [
-		"ext_storage_child_set_version_1",
-		"ext_storage_child_get_version_1",
-		"ext_storage_child_clear_version_1",
-		"ext_storage_child_exists_version_1"
+	const child_key_value = [
+		"ext_default_child_storage_set_version_1",
+		"ext_default_child_storage_get_version_1",
+		"ext_default_child_storage_clear_version_1",
+		"ext_default_child_storage_exists_version_1"
 	]
 
-	const child_child_def_type_prefix_key_value_key_value = [
-		"ext_storage_child_clear_prefix_version_1"
+	const child_prefix_key_value_key_value = [
+		"ext_default_child_storage_clear_prefix_version_1"
 	]
 
-	const child_child_def_type_key_value_key_value = [
-		"ext_storage_child_storage_kill_version_1",
-		"ext_storage_child_root_version_1",
-		"ext_storage_child_next_key_version_1"
+	const child_key_value_key_value = [
+		"ext_default_child_storage_storage_kill_version_1",
+		"ext_default_child_storage_root_version_1",
+		"ext_default_child_storage_next_key_version_1"
 	]
 
-	const child_def_type_key_value_offset_buffer_size = [
-		"ext_storage_child_read_version_1"
+	const child_key_value_offset_buffer_size = [
+		"ext_default_child_storage_read_version_1"
 	]
-
+	
 	const key_value_offset_buffer_size = [
 		"ext_storage_read_version_1"
 	]

--- a/test/fixtures/host-api/HostApiInputs.jl
+++ b/test/fixtures/host-api/HostApiInputs.jl
@@ -1,49 +1,6 @@
 module HostApiInputs
-    # Only used by new APIs, not legacy
-	const child_def_child_type = [
-	  [
-		"Ameliorated", # child key definition
-		1 # child type
-	  ],
-	  [
-		"radical",
-		1
-	  ],
-	  [
-		"forecast",
-		1
-	  ],
-	  [
-		"well-modulated",
-		1
-	  ],
-	  [
-		"Vision-oriented",
-		1
-	  ],
-	  [
-		"needs-based",
-		1
-	  ],
-	  [
-		"heuristic",
-		1
-	  ],
-	  [
-		"system engine",
-		1
-	  ],
-	  [
-		"paradigm",
-		1
-	  ],
-	  [
-		"Devolved",
-		1
-	  ]
-	]
 
-	# Contains (mostly valid) prefixes of the corresponding keys
+    # Contains (mostly valid) prefixes of the corresponding keys
     const prefix_key_value_key_value = [
       [
         "stat", # prefix

--- a/test/fixtures/host-api/HostApiOutputs.jl
+++ b/test/fixtures/host-api/HostApiOutputs.jl
@@ -166,8 +166,8 @@ module HostApiOutputs
         "",
     ]
 
-    const child_child_def_type_key_value = [
-        # ext_storage_child_set_version_1
+    const child_key_value = [
+        # ext_default_child_storage_set_version_1
         "Inverse\n",
         "Horizontal\n",
         "portal\n",
@@ -178,7 +178,7 @@ module HostApiOutputs
         "value-added\n",
         "Reactive\n",
         "secondary\n",
-        # ext_storage_child_get_version_1
+        # ext_default_child_storage_get_version_1
         "Inverse\n",
         "Horizontal\n",
         "portal\n",
@@ -189,7 +189,7 @@ module HostApiOutputs
         "value-added\n",
         "Reactive\n",
         "secondary\n",
-        # ext_storage_child_clear_version_1
+        # ext_default_child_storage_clear_version_1
         nothing,
         nothing,
         nothing,
@@ -200,7 +200,7 @@ module HostApiOutputs
         nothing,
         nothing,
         nothing,
-        # ext_storage_child_exists_version_1
+        # ext_default_child_storage_exists_version_1
         "true\n",
         "true\n",
         "true\n",
@@ -213,7 +213,7 @@ module HostApiOutputs
         "true\n",
     ]
 
-    const child_child_def_type_prefix_key_value_key_value = [
+    const child_prefix_key_value_key_value = [
         "Future-proofed\n",
         "Horizontal\n",
         "pricing structure\n",
@@ -226,8 +226,8 @@ module HostApiOutputs
         "secondary\ntoolset\n"
     ]
 
-    const child_child_def_type_key_value_key_value = [
-        # ext_storage_child_storage_kill_version_1
+    const child_key_value_key_value = [
+        # ext_default_child_storage_storage_kill_version_1
         nothing,
         nothing,
         nothing,
@@ -238,7 +238,7 @@ module HostApiOutputs
         nothing,
         nothing,
         nothing,
-        # ext_storage_child_root_version_1
+        # ext_default_child_storage_root_version_1
         "e04eb753bc044436c6624b2062f7ad2be3bf19c62ed6f10aa2d7ee2586828cd5\n",
         "e563e5520daa936c3629783df1390428bf1a57bf2ea2e30d26efe54bd225e706\n",
         "10577651a2a8b02fa35d6aaed6e9cdceb26db2bf76746b4135401dd9fa4661d5\n",
@@ -249,7 +249,7 @@ module HostApiOutputs
         "803205f7b32b7aadcf4955a2f934a065060da645a45c817f26c90025f8e4a978\n",
         "41d7e4e8d2198d42c00a753db0f11dde0d2288ce0d148a83e9e774eafbf17584\n",
         "3b71375a64a94627d03b257d2d2538474ac0263c0a5e6872d848ce6889092e15\n",
-        # ext_storage_child_next_key_version
+        # ext_default_child_storage_next_key_version
         "static\n",
         "function\n",
         "budgetary management\n",

--- a/test/fixtures/host-api/include.jl
+++ b/test/fixtures/host-api/include.jl
@@ -19,40 +19,36 @@ HOSTAPI_FIXTURE_DATASETS = [
         ],
         HostApiOutputs.value .* "\n",
     ],[
-        HostApiFunctions.child_child_def_type_key_value,
+        HostApiFunctions.child_key_value,
         [
             HostApiInputs.child_child,
-            HostApiInputs.child_def_child_type,
             HostApiInputs.key_value_1,
         ],
-        HostApiOutputs.child_child_def_type_key_value,
+        HostApiOutputs.child_key_value,
     ],[
-        HostApiFunctions.child_def_type_key_value_offset_buffer_size,
+        HostApiFunctions.child_key_value_offset_buffer_size,
         [
             HostApiInputs.child_child,
-            HostApiInputs.child_def_child_type,
             HostApiInputs.key_value_1,
             HostApiInputs.offset,
             HostApiInputs.buffer_size,
         ],
         HostApiOutputs.key_value_offset_buffer_size .* "\n",
     ],[
-        HostApiFunctions.child_child_def_type_prefix_key_value_key_value,
+        HostApiFunctions.child_prefix_key_value_key_value,
         [
             HostApiInputs.child_child,
-            HostApiInputs.child_def_child_type,
             HostApiInputs.prefix_key_value_key_value,
         ],
-        HostApiOutputs.child_child_def_type_prefix_key_value_key_value,
+        HostApiOutputs.child_prefix_key_value_key_value,
     ],[
-        HostApiFunctions.child_child_def_type_key_value_key_value,
+        HostApiFunctions.child_key_value_key_value,
         [
             HostApiInputs.child_child,
-            HostApiInputs.child_def_child_type,
             HostApiInputs.key_value_1,
             HostApiInputs.key_value_2,
         ],
-        HostApiOutputs.child_child_def_type_key_value_key_value,
+        HostApiOutputs.child_key_value_key_value,
     ],[
         HostApiFunctions.key_value,
         [


### PR DESCRIPTION
I noticed we actually do not check the value returned by `ext_storage_read_version_1`, this PR fixes that. As a result we also learned that each implementation kind of does their own thing, so before this can be merged upstream will have to fix their implementations. Because I had to update substrate to the latest version for the fix, I was also required updates to the new child storage API.

### List of changes
 - Check `ext_storage_read` return value in wasm-adapter (4c2b00f)
 - Update kagome-adapter to new return value and latest kagome (for soramitsu/kagome#531)
 - Update substrate-adapter to new return value and substrate used for polkadot v0.8.24 (for paritytech/substrate#7084)
 - Update spec that return value is "bytes left at offset" (4904861)
 - Update `..._storage_child_...` to `..._default_child_storage_...` API
   -  wasm-adapter (6889971)
   -  substrate-adapter (a68d570) 
   -  host-api fixture (de311af)