### PR TITLE
Define signature for a specific message in a round

### DIFF
--- a/host-spec/c06-consensus.tm
+++ b/host-spec/c06-consensus.tm
@@ -1058,7 +1058,7 @@
     is formally defined as:
 
     <\equation*>
-      Sign<rsup|r,stage><rsub|v<rsub|i>>=Sig<rsub|ED25519><around*|(|Msg,r,id<rsub|\<bbb-V\>>|)>
+      Sign<rsup|r,stage><rsub|v<rsub|i>>:=Sig<rsub|ED25519><around*|(|Msg,r,id<rsub|\<bbb-V\>>|)>
     </equation*>
 
     Where:
@@ -1972,7 +1972,6 @@
     <associate|auto-28|<tuple|6.4.1.2|50>>
     <associate|auto-29|<tuple|6.4.1.3|?>>
     <associate|auto-3|<tuple|6.1.1|37>>
-    <associate|auto-30|<tuple|6.4.1.3|?>>
     <associate|auto-4|<tuple|6.1.2|37>>
     <associate|auto-5|<tuple|6.1|38>>
     <associate|auto-6|<tuple|6.2|39>>
@@ -2037,6 +2036,10 @@
       <tuple|normal|<\surround|<hidden-binding|<tuple>|6.2>|>
         \;
       </surround>|<pageref|auto-17>>
+
+      <tuple|normal|<\surround|<hidden-binding|<tuple>|6.3>|>
+        Signature for a message in a round.
+      </surround>|<pageref|auto-19>>
     </associate>
     <\associate|toc>
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|6<space|2spc>Consensus>
@@ -2103,42 +2106,42 @@
 
       <with|par-left|<quote|2tab>|6.3.2.2<space|2spc>Finalizing Message
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-19>>
+      <no-break><pageref|auto-20>>
 
       <with|par-left|<quote|2tab>|6.3.2.3<space|2spc>Catch-up Messages
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-20>>
+      <no-break><pageref|auto-21>>
 
       <with|par-left|<quote|1tab>|6.3.3<space|2spc>Initiating the GRANDPA
       State <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-21>>
+      <no-break><pageref|auto-22>>
 
       <with|par-left|<quote|2tab>|6.3.3.1<space|2spc>Voter Set Changes
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-22>>
+      <no-break><pageref|auto-23>>
 
       <with|par-left|<quote|1tab>|6.3.4<space|2spc>Voting Process in Round
       <with|mode|<quote|math>|r> <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-23>>
+      <no-break><pageref|auto-24>>
 
       6.4<space|2spc>Block Finalization <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-24>
+      <no-break><pageref|auto-25>
 
       <with|par-left|<quote|1tab>|6.4.1<space|2spc>Catching up
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-25>>
+      <no-break><pageref|auto-26>>
 
       <with|par-left|<quote|2tab>|6.4.1.1<space|2spc>Sending catch-up
       requests <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-26>>
+      <no-break><pageref|auto-27>>
 
       <with|par-left|<quote|2tab>|6.4.1.2<space|2spc>Processing catch-up
       requests <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-27>>
+      <no-break><pageref|auto-28>>
 
       <with|par-left|<quote|2tab>|6.4.1.3<space|2spc>Processing catch-up
       responses <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-28>>
+      <no-break><pageref|auto-29>>
     </associate>
   </collection>
 </auxiliary>

--- a/host-spec/c06-consensus.tm
+++ b/host-spec/c06-consensus.tm
@@ -1,4 +1,4 @@
-<TeXmacs|1.99.12>
+<TeXmacs|1.99.11>
 
 <project|host-spec.tm>
 
@@ -1053,26 +1053,50 @@
   specified in this section.
 
   <\definition>
+    <label|defn-sign-round-vote><strong|<math|Sign<rsup|r,stage><rsub|v<rsub|i>>>>
+    refers to the signature of a voter for a specific message in a round and
+    is formally defined as:
+
+    <\equation*>
+      Sign<rsup|r,stage><rsub|v<rsub|i>>=Sig<rsub|ED25519><around*|(|Msg,r,id<rsub|\<bbb-V\>>|)>
+    </equation*>
+
+    Where:
+
+    <\big-table|<tabular|<tformat|<cwith|2|3|1|1|cell-halign|r>|<cwith|2|3|1|1|cell-lborder|0ln>|<cwith|2|3|2|2|cell-halign|l>|<cwith|2|3|3|3|cell-halign|l>|<cwith|2|3|3|3|cell-rborder|0ln>|<cwith|2|3|1|3|cell-valign|c>|<table|<row|<cell|Msg>|<cell|the
+    message to be signed>|<cell|arbitrary>>|<row|<cell|r:>|<cell|round
+    number>|<cell|unsigned 64-bit integer>>|<row|<cell|<math|id<rsub|\<bbb-V\>>>>|<cell|authority
+    set Id (Def. <reference|defn-authority-set-id>) of v>|<cell|unsigned
+    64-bit integer>>>>>>
+      Signature for a message in a round.
+    </big-table>
+
+    \;
+  </definition>
+
+  <\definition>
     A vote casted by voter <math|v> should be broadcasted as a
     <strong|message <math|M<rsup|r,stage><rsub|v>>> to the network by voter
     <math|v> with the following structure:
 
     <\eqnarray*>
-      <tformat|<table|<row|<cell|M<rsup|r,stage><rsub|v>>|<cell|\<assign\>>|<cell|Enc<rsub|SC><around*|(|r,id<rsub|\<bbb-V\>>,<math-it|SigMsg>|)>>>|<row|<cell|<math-it|SigMsg>>|<cell|\<assign\>>|<cell|<math-it|Msg>,Sig<rsub|ED25519><around*|(|<math-it|Msg>,r,id<rsub|\<bbb-V\>>|)>,v<rsub|id>>>|<row|<cell|<math-it|Msg>>|<cell|\<assign\>>|<cell|Enc<rsub|SC><around*|(|stage,V<rsup|r,stage><rsub|v>|)>>>>>
+      <tformat|<table|<row|<cell|M<rsup|r,stage><rsub|v>>|<cell|\<assign\>>|<cell|Enc<rsub|SC><around*|(|r,id<rsub|\<bbb-V\>>,<math-it|SigMsg>|)>>>|<row|<cell|<math-it|SigMsg>>|<cell|\<assign\>>|<cell|<math-it|Msg>,Sig<rsup|r,stage><rsub|v<rsub|i>>,v<rsub|id>>>|<row|<cell|<math-it|Msg>>|<cell|\<assign\>>|<cell|Enc<rsub|SC><around*|(|stage,V<rsup|r,stage><rsub|v>|)>>>>>
     </eqnarray*>
 
     Where:
 
     <\center>
       <tabular*|<tformat|<cwith|1|-1|1|1|cell-halign|r>|<cwith|1|-1|1|1|cell-lborder|0ln>|<cwith|1|-1|2|2|cell-halign|l>|<cwith|1|-1|3|3|cell-halign|l>|<cwith|1|-1|3|3|cell-rborder|0ln>|<cwith|1|-1|1|-1|cell-valign|c>|<table|<row|<cell|r:>|<cell|round
-      number>|<cell|unsigned 64 bit integer>>|<row|<cell|<math|id<rsub|\<bbb-V\>>>>|<cell|authority
-      set Id (Definition <reference|defn-authority-set-id>)>|<cell|unsigned
-      64 bit integer>>|<row|<cell|<right-aligned|<math|v<rsub|id>>>:>|<cell|Ed25519
-      public key of <math|v>>|<cell|32 byte
+      number>|<cell|unsigned 64-bit integer>>|<row|<cell|<math|id<rsub|\<bbb-V\>>>>|<cell|authority
+      set Id (Def. <reference|defn-authority-set-id>)>|<cell|unsigned 64-bit
+      integer>>|<row|<cell|<math|Sig<rsup|r,stage><rsub|v<rsub|i>>>>|<cell|signature
+      (Def. <reference|defn-sign-round-vote>)>|<cell|512-bit
+      array>>|<row|<cell|<right-aligned|<math|v<rsub|id>>>:>|<cell|Ed25519
+      public key of <math|v>>|<cell|256-bit
       array>>|<row|<cell|<right-aligned|><math|stage>:>|<cell|0 if it's a
-      pre-vote sub-round>|<cell|1 byte>>|<row|<cell|>|<cell|1 if it's a
-      pre-commit sub-round>|<cell|>>|<row|<cell|>|<cell|2 if it's a primary
-      proposal message>|<cell|>>>>>
+      pre-vote sub-round>|<cell|8-bit integer>>|<row|<cell|>|<cell|1 if it's
+      a pre-commit sub-round>|<cell|8-bit integer>>|<row|<cell|>|<cell|2 if
+      it's a primary proposal message>|<cell|8-bit integer>>>>>
     </center>
 
     \;
@@ -1106,11 +1130,12 @@
     equivocatory vote.
 
     In all cases, <math|Sign<rsup|r,stage><rsub|v<rsub|i>><around*|(|B<rprime|'>|)>>
-    is the signature of voter <math|v<rsub|i>\<in\>\<bbb-V\><rsub|B>>
-    broadcasted during either the pre-vote (stage = pv) or the pre-commit
-    (stage = pc) sub-round of round r. A <strong|valid Justification> must
-    only contain up-to one valid vote from each voter and must not contain
-    more than two equivocatory votes from each voter.
+    as defined in Definition <reference|defn-sign-round-vote> is the
+    signature of voter <math|v<rsub|i>\<in\>\<bbb-V\><rsub|B>> broadcasted
+    during either the pre-vote (stage = pv) or the pre-commit (stage = pc)
+    sub-round of round r. A <strong|valid Justification> must only contain
+    up-to one valid vote from each voter and must not contain more than two
+    equivocatory votes from each voter.
 
     We say <math|J<rsup|r,pc><around*|(|B|)>> <strong|justifies the
     finalization> of <math|B<rprime|'>\<geqslant\>B> if the number of valid
@@ -1934,18 +1959,20 @@
     <associate|auto-16|<tuple|6.3.2|45>>
     <associate|auto-17|<tuple|6.2|45>>
     <associate|auto-18|<tuple|6.3.2.1|45>>
-    <associate|auto-19|<tuple|6.3.2.2|46>>
+    <associate|auto-19|<tuple|6.3|46>>
     <associate|auto-2|<tuple|6.1|37>>
-    <associate|auto-20|<tuple|6.3.2.3|46>>
-    <associate|auto-21|<tuple|6.3.3|47>>
-    <associate|auto-22|<tuple|6.3.3.1|47>>
-    <associate|auto-23|<tuple|6.3.4|47>>
-    <associate|auto-24|<tuple|6.4|49>>
-    <associate|auto-25|<tuple|6.4.1|49>>
-    <associate|auto-26|<tuple|6.4.1.1|49>>
-    <associate|auto-27|<tuple|6.4.1.2|49>>
-    <associate|auto-28|<tuple|6.4.1.3|50>>
+    <associate|auto-20|<tuple|6.3.2.2|46>>
+    <associate|auto-21|<tuple|6.3.2.3|47>>
+    <associate|auto-22|<tuple|6.3.3|47>>
+    <associate|auto-23|<tuple|6.3.3.1|47>>
+    <associate|auto-24|<tuple|6.3.4|49>>
+    <associate|auto-25|<tuple|6.4|49>>
+    <associate|auto-26|<tuple|6.4.1|49>>
+    <associate|auto-27|<tuple|6.4.1.1|49>>
+    <associate|auto-28|<tuple|6.4.1.2|50>>
+    <associate|auto-29|<tuple|6.4.1.3|?>>
     <associate|auto-3|<tuple|6.1.1|37>>
+    <associate|auto-30|<tuple|6.4.1.3|?>>
     <associate|auto-4|<tuple|6.1.2|37>>
     <associate|auto-5|<tuple|6.1|38>>
     <associate|auto-6|<tuple|6.2|39>>
@@ -1962,18 +1989,19 @@
     <associate|defn-consensus-message-digest|<tuple|6.2|37>>
     <associate|defn-epoch-slot|<tuple|6.5|39>>
     <associate|defn-epoch-subchain|<tuple|6.7|39>>
-    <associate|defn-finalized-block|<tuple|6.33|49>>
+    <associate|defn-finalized-block|<tuple|6.34|49>>
     <associate|defn-gossip-message|<tuple|6.26|45>>
-    <associate|defn-grandpa-catchup-request-msg|<tuple|6.30|46>>
-    <associate|defn-grandpa-catchup-response-msg|<tuple|6.31|46>>
+    <associate|defn-grandpa-catchup-request-msg|<tuple|6.31|46>>
+    <associate|defn-grandpa-catchup-response-msg|<tuple|6.32|46>>
     <associate|defn-grandpa-completable|<tuple|6.25|45>>
-    <associate|defn-grandpa-justification|<tuple|6.28|46>>
+    <associate|defn-grandpa-justification|<tuple|6.29|46>>
     <associate|defn-grandpa-voter|<tuple|6.14|43>>
+    <associate|defn-sign-round-vote|<tuple|6.27|?>>
     <associate|defn-slot-offset|<tuple|6.11|40>>
     <associate|defn-total-potential-votes|<tuple|6.23|?>>
     <associate|defn-vote|<tuple|6.17|44>>
     <associate|defn-winning-threshold|<tuple|6.8|39>>
-    <associate|exmp-candid-unfinalized|<tuple|6.32|?>>
+    <associate|exmp-candid-unfinalized|<tuple|6.33|?>>
     <associate|note-slot|<tuple|6.6|39>>
     <associate|sect-authority-set|<tuple|6.1.1|37>>
     <associate|sect-babe|<tuple|6.2|39>>

--- a/host-spec/c06-consensus.tm
+++ b/host-spec/c06-consensus.tm
@@ -1058,12 +1058,12 @@
     is formally defined as:
 
     <\equation*>
-      Sign<rsup|r,stage><rsub|v<rsub|i>>:=Sig<rsub|ED25519><around*|(|Msg,r,id<rsub|\<bbb-V\>>|)>
+      Sign<rsup|r,stage><rsub|v<rsub|i>>:=Sig<rsub|ED25519><around*|(|msg,r,id<rsub|\<bbb-V\>>|)>
     </equation*>
 
     Where:
 
-    <\big-table|<tabular|<tformat|<cwith|2|3|1|1|cell-halign|r>|<cwith|2|3|1|1|cell-lborder|0ln>|<cwith|2|3|2|2|cell-halign|l>|<cwith|2|3|3|3|cell-halign|l>|<cwith|2|3|3|3|cell-rborder|0ln>|<cwith|2|3|1|3|cell-valign|c>|<table|<row|<cell|Msg>|<cell|the
+    <\big-table|<tabular|<tformat|<cwith|2|3|1|1|cell-halign|r>|<cwith|2|3|1|1|cell-lborder|0ln>|<cwith|2|3|2|2|cell-halign|l>|<cwith|2|3|3|3|cell-halign|l>|<cwith|2|3|3|3|cell-rborder|0ln>|<cwith|2|3|1|3|cell-valign|c>|<table|<row|<cell|msg>|<cell|the
     message to be signed>|<cell|arbitrary>>|<row|<cell|r:>|<cell|round
     number>|<cell|unsigned 64-bit integer>>|<row|<cell|<math|id<rsub|\<bbb-V\>>>>|<cell|authority
     set Id (Def. <reference|defn-authority-set-id>) of v>|<cell|unsigned
@@ -1080,7 +1080,7 @@
     <math|v> with the following structure:
 
     <\eqnarray*>
-      <tformat|<table|<row|<cell|M<rsup|r,stage><rsub|v>>|<cell|\<assign\>>|<cell|Enc<rsub|SC><around*|(|r,id<rsub|\<bbb-V\>>,<math-it|SigMsg>|)>>>|<row|<cell|<math-it|SigMsg>>|<cell|\<assign\>>|<cell|<math-it|Msg>,Sig<rsup|r,stage><rsub|v<rsub|i>>,v<rsub|id>>>|<row|<cell|<math-it|Msg>>|<cell|\<assign\>>|<cell|Enc<rsub|SC><around*|(|stage,V<rsup|r,stage><rsub|v>|)>>>>>
+      <tformat|<table|<row|<cell|M<rsup|r,stage><rsub|v>>|<cell|\<assign\>>|<cell|Enc<rsub|SC><around*|(|r,id<rsub|\<bbb-V\>>,<math-it|SigMsg>|)>>>|<row|<cell|<math-it|SigMsg>>|<cell|\<assign\>>|<cell|<math-it|msg>,Sig<rsup|r,stage><rsub|v<rsub|i>>,v<rsub|id>>>|<row|<cell|<math-it|msg>>|<cell|\<assign\>>|<cell|Enc<rsub|SC><around*|(|stage,V<rsup|r,stage><rsub|v>|)>>>>>
     </eqnarray*>
 
     Where:


### PR DESCRIPTION
Fixes #283 

I hope I understood your request correctly.

- [x] - Define explicitly Sign r;stage (B 0 ) in definition 6.27. as Sig ED25519 (Msg; r; id V );
- [x] - Verify the definition SigMsg of and replace Sig ED25519 (Msg; r; id V ); with Sign r;stage (B 0 ).
- [x] - Refer to such definition in Definition 6.28.


# Printscreen
![image](https://user-images.githubusercontent.com/42901763/93095492-728a7480-f6a3-11ea-8277-e1026139d166.png)


# Source-Code Description

The structure of the gossip vote itself is correct.

```rust
/// Network level vote message with topic information.
#[derive(Debug, Encode, Decode)]
pub(super) struct VoteMessage<Block: BlockT> {
	/// The round this message is from.
	pub(super) round: Round,
	/// The voter set ID this message is from.
	pub(super) set_id: SetId,
	/// The message itself.
	pub(super) message: SignedMessage<Block>,
}

// ...

/// A signed message.
pub type SignedMessage<Block> = finality_grandpa::SignedMessage<
	<Block as BlockT>::Hash,
	NumberFor<Block>,
	AuthoritySignature,
	AuthorityId,
>;

// ...

/// A signed message.
#[derive(Clone, PartialEq, Eq)]
#[cfg_attr(any(feature = "std", test), derive(Debug))]
#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
pub struct SignedMessage<H, N, S, Id> {
	/// The internal message which has been signed.
	pub message: Message<H, N>,
	/// The signature on the message.
	pub signature: S,
	/// The Id of the signer
	pub id: Id,
}

// ...

/// A protocol message or vote.
#[derive(Clone, PartialEq, Eq)]
#[cfg_attr(any(feature = "std", test), derive(Debug))]
#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
pub enum Message<H, N> {
	/// A prevote message.
	#[cfg_attr(feature = "derive-codec", codec(index = "0"))]
	Prevote(Prevote<H, N>),
	/// A precommit message.
	#[cfg_attr(feature = "derive-codec", codec(index = "1"))]
	Precommit(Precommit<H, N>),
	/// A primary proposal message.
	#[cfg_attr(feature = "derive-codec", codec(index = "2"))]
	PrimaryPropose(PrimaryPropose<H, N>),
}
```

`Prevote`, `Precommit` and `PrimaryPropose` are structured as:

```rust
{
  // The target block's hash.
  pub target_hash: H,
  // The target block's number
  pub target_number: N,
}
```

which we correctly refer to as `V(B)` in the spec.

The signature contains the correct data in the correct order.

```rust
/// Localizes the message to the given set and round and signs the payload.
#[cfg(feature = "std")]
pub fn sign_message<H, N>(
	keystore: &BareCryptoStorePtr,
	message: grandpa::Message<H, N>,
	public: AuthorityId,
	round: RoundNumber,
	set_id: SetId,
) -> Option<grandpa::SignedMessage<H, N, AuthoritySignature, AuthorityId>>
where
	H: Encode,
	N: Encode,
{
	use sp_core::crypto::Public;
	use sp_application_crypto::AppKey;
	use sp_std::convert::TryInto;

	// ***** NOTE *****
	// This ends up calling `localized_payload_with_buffer`,
	// which encodes the data in the correct order.
	let encoded = localized_payload(round, set_id, &message);
	let signature = keystore.read()
		.sign_with(AuthorityId::ID, &public.to_public_crypto_pair(), &encoded[..])
		.ok()?
		.try_into()
		.ok()?;

	Some(grandpa::SignedMessage {
		message,
		signature,
		id: public,
	})
}

// ...

/// Encode round message localized to a given round and set id using the given
/// buffer. The given buffer will be cleared and the resulting encoded payload
/// will always be written to the start of the buffer.
pub fn localized_payload_with_buffer<E: Encode>(
	round: RoundNumber,
	set_id: SetId,
	message: &E,
	buf: &mut Vec<u8>,
) {
	buf.clear();
	(message, round, set_id).encode_to(buf)
}
```
