### PR TITLE
Add test fixture for HostAPI ext_storage_append

### DIFF
--- a/test/adapters/kagome/cmake/HunterConfig.cmake
+++ b/test/adapters/kagome/cmake/HunterConfig.cmake
@@ -20,8 +20,8 @@
 
 # Should point to the version of kagome to be tested (currently a custom fork with small fixes atop master)
 hunter_config(kagome
-  URL https://github.com/soramitsu/kagome/archive/70e4719a81c69c8dc238187a98d1b077f54f0913.tar.gz
-  SHA1 a480c70af74b773a9c335a01e0deb85273b559ff
+  URL https://github.com/soramitsu/kagome/archive/0f5b34e1a6e8219f49cce9aff6fdd2ed04f94c81.tar.gz
+  SHA1 0478facf076ba185a7540ae761f3122617bacdc0
   CMAKE_ARGS TESTING=OFF
 )
 

--- a/test/adapters/kagome/src/host_api.cpp
+++ b/test/adapters/kagome/src/host_api.cpp
@@ -100,6 +100,9 @@ void processHostApiCommands(const HostApiCommandArgs& args){
   router.addSubcommand("ext_storage_clear_prefix_version_1", [](const std::vector<std::string>& args) {
     storage::processClearPrefix(args[0], args[1], args[2], args[3], args[4]);
   });
+  router.addSubcommand("ext_storage_append_version_1", [](const std::vector<std::string>& args) {
+    storage::processAppend(args[0], args[1], args[2], args[3]);
+  });
   router.addSubcommand("ext_storage_root_version_1", [](const std::vector<std::string>& args) {
     storage::processRoot(args[0], args[1], args[2], args[3]);
   });

--- a/test/adapters/kagome/src/host_api/storage.hpp
+++ b/test/adapters/kagome/src/host_api/storage.hpp
@@ -50,6 +50,12 @@ namespace storage {
     const std::string_view key2, const std::string_view value2
   );
 
+  // executes ext_storage_append_version_1 test
+  void processAppend(
+    const std::string_view key1, const std::string_view value1,
+    const std::string_view key2, const std::string_view value2
+  );
+
   // executes ext_storage_root_version_1 test
   void processRoot(
     const std::string_view key1, const std::string_view value1,

--- a/test/adapters/substrate/src/host_api/mod.rs
+++ b/test/adapters/substrate/src/host_api/mod.rs
@@ -22,6 +22,7 @@ pub fn process_host_api_tests(subcmd_matches: &ArgMatches) {
             "ext_storage_clear_version_1"        => storage::ext_storage_clear_version_1(input),
             "ext_storage_exists_version_1"       => storage::ext_storage_exists_version_1(input),
             "ext_storage_clear_prefix_version_1" => storage::ext_storage_clear_prefix_version_1(input),
+            "ext_storage_append_version_1"       => storage::ext_storage_append_version_1(input),
             "ext_storage_root_version_1"         => storage::ext_storage_root_version_1(input),
             "ext_storage_next_key_version_1"     => storage::ext_storage_next_key_version_1(input),
 

--- a/test/adapters/substrate/src/host_api/storage.rs
+++ b/test/adapters/substrate/src/host_api/storage.rs
@@ -157,6 +157,88 @@ pub fn ext_storage_clear_prefix_version_1(input: ParsedInput) {
     }
 }
 
+pub fn ext_storage_append_version_1(input: ParsedInput) {
+    let mut rtm = Runtime::new();
+
+    let key1 = input.get(0);
+    let value1 = input.get(1);
+    let key2 = input.get(2);
+    let value2 = input.get(3);
+
+    let value1_enc = &value1.encode();
+    let value2_enc = &value2.encode();
+
+    // Insert first key
+    let res = rtm
+        .call("rtm_ext_storage_get_version_1", &key1.encode())
+        .decode_ovec();
+    assert!(res.is_none());
+
+    let _ = rtm.call(
+        "rtm_ext_storage_append_version_1",
+        &(key1, value1_enc).encode(),
+    );
+    let _ = rtm.call(
+        "rtm_ext_storage_append_version_1",
+        &(key1, value2_enc).encode(),
+    );
+
+    // Insert second key
+    let res = rtm
+        .call("rtm_ext_storage_get_version_1", &key2.encode())
+        .decode_ovec();
+    assert!(res.is_none());
+
+    let _ = rtm.call(
+        "rtm_ext_storage_append_version_1",
+        &(key2, value2_enc).encode(),
+    );
+    let _ = rtm.call(
+        "rtm_ext_storage_append_version_1",
+        &(key2, value1_enc).encode(),
+    );
+    let _ = rtm.call(
+        "rtm_ext_storage_append_version_1",
+        &(key2, value2_enc).encode(),
+    );
+    let _ = rtm.call(
+        "rtm_ext_storage_append_version_1",
+        &(key2, value1_enc).encode(),
+    );
+
+    // Check first key
+    let res = rtm
+        .call("rtm_ext_storage_get_version_1", &key1.encode())
+        .decode_ovec()
+        .unwrap()
+        .decode_vecvec();
+
+    assert_eq!(res, vec![value1, value2]);
+    println!(
+        "{}",
+        res.iter()
+            .map(|v| String::from_utf8(v.to_vec()).unwrap())
+            .collect::<Vec::<String>>()
+            .join(";")
+    );
+
+    // Check second key
+    let res = rtm
+        .call("rtm_ext_storage_get_version_1", &key2.encode())
+        .decode_ovec()
+        .unwrap()
+        .decode_vecvec();
+
+    assert_eq!(res, vec![value2, value1, value2, value1]);
+    println!(
+        "{}",
+        res.iter()
+            .map(|v| String::from_utf8(v.to_vec()).unwrap())
+            .collect::<Vec::<String>>()
+            .join(";")
+    );
+}
+
 pub fn ext_storage_root_version_1(input: ParsedInput) {
     let mut rtm = Runtime::new();
 

--- a/test/adapters/substrate/src/host_api/utils.rs
+++ b/test/adapters/substrate/src/host_api/utils.rs
@@ -111,19 +111,23 @@ impl Runtime {
 }
 
 pub trait Decoder {
+    fn decode_bool(&self) -> bool;
     fn decode_vec(&self) -> Vec<u8>;
     fn decode_ovec(&self) -> Option<Vec<u8>>;
-    fn decode_bool(&self) -> bool;
+    fn decode_vecvec(&self) -> Vec<Vec<u8>>;
 }
 
 impl Decoder for Vec<u8> {
+    fn decode_bool(&self) -> bool {
+        Decode::decode(&mut self.as_slice()).expect("Failed to decode SCALE encoding")
+    }
     fn decode_vec(&self) -> Vec<u8> {
         Decode::decode(&mut self.as_slice()).expect("Failed to decode SCALE encoding")
     }
     fn decode_ovec(&self) -> Option<Vec<u8>> {
         Decode::decode(&mut self.as_slice()).expect("Failed to decode SCALE encoding")
     }
-    fn decode_bool(&self) -> bool {
+    fn decode_vecvec(&self) -> Vec<Vec<u8>> {
         Decode::decode(&mut self.as_slice()).expect("Failed to decode SCALE encoding")
     }
 }

--- a/test/adapters/wasm/src/lib.rs
+++ b/test/adapters/wasm/src/lib.rs
@@ -17,6 +17,7 @@ extern "C" {
     fn ext_storage_clear_version_1(key: u64);
     fn ext_storage_exists_version_1(key: u64) -> i32;
     fn ext_storage_clear_prefix_version_1(key: u64);
+    fn ext_storage_append_version_1(key: u64, value: u64);
     fn ext_storage_root_version_1() -> u64;
     fn ext_storage_next_key_version_1(key: u64) -> u64;
 
@@ -85,37 +86,36 @@ impl AsRePtr for Vec<u8> {
 
 #[cfg(feature = "runtime-wasm")]
 sp_core::wasm_export_functions! {
-    fn rtm_ext_storage_get_version_1(
-        key_data: Vec<u8>
-    ) -> Option<Vec<u8>> {
+
+    // Storage API
+
+    fn rtm_ext_storage_set_version_1(key: Vec<u8>, value: Vec<u8>) {
+        unsafe {
+            let _ = ext_storage_set_version_1(
+                key.as_re_ptr(),
+                value.as_re_ptr()
+            );
+        }
+    }
+
+    fn rtm_ext_storage_get_version_1(key: Vec<u8>) -> Option<Vec<u8>> {
         unsafe {
             let value = ext_storage_get_version_1(
-                key_data.as_re_ptr(),
+                key.as_re_ptr(),
             );
             Decode::decode(&mut from_mem(value).as_slice()).unwrap()
         }
     }
-    fn rtm_ext_default_child_storage_get_version_1(
-        child_key: Vec<u8>,
-        key_data: Vec<u8>
-    ) -> Option<Vec<u8>> {
-        unsafe {
-            let value = ext_default_child_storage_get_version_1(
-                child_key.as_re_ptr(),
-                key_data.as_re_ptr(),
-            );
-            Decode::decode(&mut from_mem(value).as_slice()).unwrap()
-        }
-    }
+
     fn rtm_ext_storage_read_version_1(
-        key_data: Vec<u8>,
+        key: Vec<u8>,
         offset: u32,
-        buffer_size: u32 // not directly required for PDRE API, only used for testing
+        buffer_size: u32 // buffer size to use in test
     ) -> Option<Vec<u8>> {
         let mut buffer = vec![0u8; buffer_size as usize];
         unsafe {
             let res = ext_storage_read_version_1(
-                key_data.as_re_ptr(),
+                key.as_re_ptr(),
                 buffer.as_re_ptr(),
                 offset
             );
@@ -125,141 +125,155 @@ sp_core::wasm_export_functions! {
                 .map(|n| buffer[..(n.min(buffer_size) as usize)].to_vec())
         }
     }
-    fn rtm_ext_default_child_storage_read_version_1(
-        child_key: Vec<u8>,
-        key_data: Vec<u8>,
-        offset: u32,
-        buffer_size: u32 // not directly required for PDRE API, only used for testing
-    ) -> Option<Vec<u8>> {
-        let mut buffer = vec![0u8; buffer_size as usize];
-        unsafe {
-            let res = ext_default_child_storage_read_version_1(
-                child_key.as_re_ptr(),
-                key_data.as_re_ptr(),
-                buffer.as_re_ptr(),
-                offset
-            );
 
-            Option::<u32>::decode(&mut from_mem(res).as_slice())
-                .unwrap()
-                .map(|n| buffer[..(n.min(buffer_size) as usize)].to_vec())
+    fn rtm_ext_storage_clear_version_1(key: Vec<u8>) {
+        unsafe {
+            let _ = ext_storage_clear_version_1(key.as_re_ptr());
         }
     }
-    fn rtm_ext_storage_set_version_1(
-        key_data: Vec<u8>,
-        value_data: Vec<u8>
-    ) {
+
+    fn rtm_ext_storage_exists_version_1(key: Vec<u8>) -> u32 {
         unsafe {
-            let _ = ext_storage_set_version_1(
-                key_data.as_re_ptr(),
-                value_data.as_re_ptr()
+            ext_storage_exists_version_1(key.as_re_ptr()) as u32
+        }
+    }
+
+    fn rtm_ext_storage_clear_prefix_version_1(key: Vec<u8>) {
+        unsafe {
+            let _ = ext_storage_clear_prefix_version_1(key.as_re_ptr());
+        }
+    }
+
+    fn rtm_ext_storage_append_version_1(key: Vec<u8>, value: Vec<u8>) {
+        unsafe {
+            let _ = ext_storage_append_version_1(
+                key.as_re_ptr(),
+                value.as_re_ptr(),
             );
         }
     }
-    fn rtm_ext_default_child_storage_set_version_1(
-        child_key: Vec<u8>,
-        key_data: Vec<u8>,
-        value_data: Vec<u8>
-    ) {
-        unsafe {
-            let _ = ext_default_child_storage_set_version_1(
-                child_key.as_re_ptr(),
-                key_data.as_re_ptr(),
-                value_data.as_re_ptr()
-            );
-        }
-    }
-    fn rtm_ext_storage_clear_version_1(
-        key_data: Vec<u8>
-    ) {
-        unsafe {
-            let _ = ext_storage_clear_version_1(
-                key_data.as_re_ptr(),
-            );
-        }
-    }
-    fn rtm_ext_default_child_storage_clear_version_1(
-        child_key: Vec<u8>,
-        key_data: Vec<u8>
-    ) {
-        unsafe {
-            let _ = ext_default_child_storage_clear_version_1(
-                child_key.as_re_ptr(),
-                key_data.as_re_ptr(),
-            );
-        }
-    }
-    fn rtm_ext_default_child_storage_storage_kill_version_1(
-        child_key: Vec<u8>,
-    ) {
-        unsafe {
-            let _ = ext_default_child_storage_storage_kill_version_1(
-                child_key.as_re_ptr(),
-            );
-        }
-    }
-    fn rtm_ext_storage_exists_version_1(
-        key_data: Vec<u8>
-    ) -> u32 {
-        unsafe {
-            ext_storage_exists_version_1(
-                key_data.as_re_ptr(),
-            ) as u32
-        }
-    }
-    fn rtm_ext_default_child_storage_exists_version_1(
-        child_key: Vec<u8>,
-        key_data: Vec<u8>
-    ) -> u32 {
-        unsafe {
-            ext_default_child_storage_exists_version_1(
-                child_key.as_re_ptr(),
-                key_data.as_re_ptr(),
-            ) as u32
-        }
-    }
-    fn rtm_ext_storage_clear_prefix_version_1(
-        key_data: Vec<u8>
-    ) {
-        unsafe {
-            let _ = ext_storage_clear_prefix_version_1(
-                key_data.as_re_ptr(),
-            );
-        }
-    }
-    fn rtm_ext_default_child_storage_clear_prefix_version_1(
-        child_key: Vec<u8>,
-        key_data: Vec<u8>
-    ) {
-        unsafe {
-            let _ = ext_default_child_storage_clear_prefix_version_1(
-                child_key.as_re_ptr(),
-                key_data.as_re_ptr(),
-            );
-        }
-    }
+
+
     fn rtm_ext_storage_root_version_1() -> Vec<u8> {
         unsafe {
             let value = ext_storage_root_version_1();
             from_mem(value)
         }
     }
-    fn rtm_ext_default_child_storage_root_version_1(child_key: Vec<u8>) -> Vec<u8> {
+
+    fn rtm_ext_storage_next_key_version_1(key: Vec<u8>) -> Option<Vec<u8>> {
         unsafe {
-            let value = ext_default_child_storage_root_version_1(
-                child_key.as_re_ptr(),
-            );
-            from_mem(value)
+            let value = ext_storage_next_key_version_1(key.as_re_ptr());
+
+            Decode::decode(&mut from_mem(value).as_slice()).unwrap()
         }
     }
-    fn rtm_ext_storage_next_key_version_1(key_data: Vec<u8>) -> Option<Vec<u8>> {
+
+    // Default child storage API
+
+    fn rtm_ext_default_child_storage_set_version_1(
+        child: Vec<u8>,
+        key: Vec<u8>,
+        value: Vec<u8>
+    ) {
         unsafe {
-            let value = ext_storage_next_key_version_1(
-                key_data.as_re_ptr(),
+            let _ = ext_default_child_storage_set_version_1(
+                child.as_re_ptr(),
+                key.as_re_ptr(),
+                value.as_re_ptr()
+            );
+        }
+    }
+
+    fn rtm_ext_default_child_storage_get_version_1(
+        child: Vec<u8>,
+        key: Vec<u8>
+    ) -> Option<Vec<u8>> {
+        unsafe {
+            let value = ext_default_child_storage_get_version_1(
+                child.as_re_ptr(),
+                key.as_re_ptr(),
             );
             Decode::decode(&mut from_mem(value).as_slice()).unwrap()
         }
     }
+
+    fn rtm_ext_default_child_storage_read_version_1(
+        child: Vec<u8>,
+        key: Vec<u8>,
+        offset: u32,
+        buffer_size: u32 // buffer size to use in test
+    ) -> Option<Vec<u8>> {
+        let mut buffer = vec![0u8; buffer_size as usize];
+        unsafe {
+            let res = ext_default_child_storage_read_version_1(
+                child.as_re_ptr(),
+                key.as_re_ptr(),
+                buffer.as_re_ptr(),
+                offset
+            );
+
+            Option::<u32>::decode(&mut from_mem(res).as_slice())
+                .unwrap()
+                .map(|n| buffer[..(n.min(buffer_size) as usize)].to_vec())
+        }
+    }
+
+    fn rtm_ext_default_child_storage_clear_version_1(
+        child: Vec<u8>,
+        key: Vec<u8>
+    ) {
+        unsafe {
+            let _ = ext_default_child_storage_clear_version_1(
+                child.as_re_ptr(),
+                key.as_re_ptr(),
+            );
+        }
+    }
+
+    fn rtm_ext_default_child_storage_storage_kill_version_1(
+        child: Vec<u8>,
+    ) {
+        unsafe {
+            let _ = ext_default_child_storage_storage_kill_version_1(
+                child.as_re_ptr(),
+            );
+        }
+    }
+
+    fn rtm_ext_default_child_storage_exists_version_1(
+        child: Vec<u8>,
+        key: Vec<u8>
+    ) -> u32 {
+        unsafe {
+            ext_default_child_storage_exists_version_1(
+                child.as_re_ptr(),
+                key.as_re_ptr(),
+            ) as u32
+        }
+    }
+
+    fn rtm_ext_default_child_storage_clear_prefix_version_1(
+        child: Vec<u8>,
+        key: Vec<u8>
+    ) {
+        unsafe {
+            let _ = ext_default_child_storage_clear_prefix_version_1(
+                child.as_re_ptr(),
+                key.as_re_ptr(),
+            );
+        }
+    }
+
+    fn rtm_ext_default_child_storage_root_version_1(child: Vec<u8>) -> Vec<u8> {
+        unsafe {
+            let value = ext_default_child_storage_root_version_1(
+                child.as_re_ptr(),
+            );
+            from_mem(value)
+        }
+    }
+
     fn rtm_ext_default_child_storage_next_key_version_1(
         child_key: Vec<u8>,
         key_data: Vec<u8>
@@ -272,6 +286,9 @@ sp_core::wasm_export_functions! {
             Decode::decode(&mut from_mem(value).as_slice()).unwrap()
         }
     }
+
+    // Crypto API
+
     fn rtm_ext_crypto_ed25519_public_keys_version_1(id_data: [u8; 4]) -> Vec<u8> {
         unsafe {
             let value = ext_crypto_ed25519_public_keys_version_1(
@@ -355,6 +372,9 @@ sp_core::wasm_export_functions! {
             from_mem(value)
         }
     }
+
+    // Hashing API
+
     fn rtm_ext_hashing_keccak_256_version_1(data: Vec<u8>) -> Vec<u8> {
         unsafe {
             let value = ext_hashing_keccak_256_version_1(
@@ -411,6 +431,9 @@ sp_core::wasm_export_functions! {
             std::slice::from_raw_parts(value as *mut u8, 8).to_vec()
         }
     }
+
+    // Allocator API
+
     fn rtm_ext_allocator_malloc_version_1(value: Vec<u8>) -> Vec<u8> {
         use std::ptr;
         let size = value.len();
@@ -434,6 +457,9 @@ sp_core::wasm_export_functions! {
             result
         }
     }
+
+    // Trie API
+
     fn rtm_ext_trie_blake2_256_root_version_1(data: Vec<(Vec<u8>, Vec<u8>)>) -> Vec<u8> {
         let data = data.encode();
         unsafe {

--- a/test/fixtures/host-api/HostApiFunctions.jl
+++ b/test/fixtures/host-api/HostApiFunctions.jl
@@ -55,6 +55,7 @@ module HostApiFunctions
 	]
 
 	const key_value_key_value = [
+		"ext_storage_append_version_1",
 		"ext_storage_root_version_1",
 		"ext_storage_next_key_version_1"
 	]

--- a/test/fixtures/host-api/HostApiOutputs.jl
+++ b/test/fixtures/host-api/HostApiOutputs.jl
@@ -263,6 +263,17 @@ module HostApiOutputs
     ]
 
     const key_value_key_value = [
+        # ext_storage_append_version_1
+        "Inverse;Future-proofed\nFuture-proofed;Inverse;Future-proofed;Inverse",
+        "Horizontal;Expanded\nExpanded;Horizontal;Expanded;Horizontal",
+        "portal;pricing structure\npricing structure;portal;pricing structure;portal",
+        "Monitored;emulation\nemulation;Monitored;emulation;Monitored",
+        "secondary;Visionary\nVisionary;secondary;Visionary;secondary",
+        "next generation;approach\napproach;next generation;approach;next generation",
+        "Grass-roots;function\nfunction;Grass-roots;function;Grass-roots",
+        "value-added;Configurable\nConfigurable;value-added;Configurable;value-added",
+        "Reactive;Automated\nAutomated;Reactive;Automated;Reactive",
+        "secondary;toolset\ntoolset;secondary;toolset;secondary",
         # ext_storage_root_version_1
         "88642528f17282b87fabd1f04e75228e2a167b847e6656c9b95beda1ffd24d87",
         "aba4e533d278005c1814c64ccb1f524d5eb425bdaf74870895ce4d0148ede0e9",


### PR DESCRIPTION
This adds a basic test for the `ext_storage_append_version_1` Host API:

- Extend `wasm-adapter` API
- Implement test in substrate-adapter
- Implement test in kagome-adapter
- Extend host-api fixture

Build against soramitsu/kagome#524 for now till merged into master.