### PR TITLE
gossamer-adapter: Add set_get_storage test

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -170,6 +170,31 @@ jobs:
         name: gossamer-adapter
         path: test/lib/libwasmer.so
 
+  build-adapter-gossamer-legacy:
+    name: "[build] gossamer-adapter-legacy"
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Cache go modules
+      uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: go-mod-adapter-gossamer-legacy-${{ hashFiles('test/adapters/gossamer-legacy/go.sum') }}
+        restore-keys: go-mod-adapter-gossamer-legacy-
+    - name: Build gossamer legacy adapter
+      run: make -C test gossamer-adapter-legacy
+    - name: Upload gossamer legacy adapter
+      uses: actions/upload-artifact@v2
+      with:
+        name: gossamer-adapter-legacy
+        path: test/bin/gossamer-adapter-legacy
+    - name: Upload libwasmer.so
+      uses: actions/upload-artifact@v2
+      with:
+        name: gossamer-adapter-legacy
+        path: test/lib/libwasmer.so
+
 
   build-runtime-hostapi:
     name: "[build] hostapi-runtime"
@@ -376,7 +401,7 @@ jobs:
       run: test/runtests.jl gossamer ${{ matrix.fixture }}
 
   test-gossamer-legacy:
-    needs: [ build-adapter-gossamer, build-runtime-hostapi-legacy]
+    needs: [ build-adapter-gossamer-legacy, build-runtime-hostapi-legacy]
     name: "[test-host-api-legacy] gossamer"
     runs-on: ubuntu-20.04
     steps:
@@ -384,14 +409,14 @@ jobs:
       uses: actions/checkout@v2
     - uses: actions/download-artifact@v1
       with:
-        name: gossamer-adapter
+        name: gossamer-adapter-legacy
         path: test/bin
     - uses: actions/download-artifact@v1
       with:
         name: hostapi-runtime-legacy.compact.wasm
         path: test/bin
     - run: |
-        chmod +x test/bin/gossamer-adapter
+        chmod +x test/bin/gossamer-adapter-legacy
         mkdir -p test/lib
         mv test/bin/libwasmer.so test/lib/
     - name: Run test fixture

--- a/test/adapters/gossamer-legacy/go.mod
+++ b/test/adapters/gossamer-legacy/go.mod
@@ -3,7 +3,7 @@ module w3f/gossamer-adapter-legacy
 require (
 	github.com/ChainSafe/chaindb v0.1.4
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816 // indirect
-	github.com/ChainSafe/gossamer v0.1.1-0.20201014230016-9ebddb3ccf5f
+	github.com/ChainSafe/gossamer v0.1.1-0.20201030012803-12b09c7cdbc2
 	github.com/DataDog/zstd v1.4.5 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/btcsuite/btcd v0.21.0-beta // indirect
@@ -12,7 +12,6 @@ require (
 	github.com/dgraph-io/ristretto v0.0.3 // indirect
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
 	github.com/ethereum/go-ethereum v1.9.20 // indirect
-	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect

--- a/test/adapters/gossamer-legacy/go.sum
+++ b/test/adapters/gossamer-legacy/go.sum
@@ -29,8 +29,8 @@ github.com/ChainSafe/chaindb v0.1.4/go.mod h1:FQQJbGzWe+rOa0aW/wSMz1qfIScauntW0H
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816 h1:X5jJ3e/jgFSnSoYOep/mf6pF1RuLZfvF1ts8NZIyzqE=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/ChainSafe/gossamer v0.1.1-0.20201014230016-9ebddb3ccf5f h1:PLFxkRZE9GjNhxT6TIZKH8t6VRVNOpZsxlCzdTMhgPk=
-github.com/ChainSafe/gossamer v0.1.1-0.20201014230016-9ebddb3ccf5f/go.mod h1:OhH5swWDjaic9lMUZy8+M2I5rcCJBGtdOS/TV3vgFys=
+github.com/ChainSafe/gossamer v0.1.1-0.20201030012803-12b09c7cdbc2 h1:CQ7LwMGDxZDIE7LtI7BOEHwzpRty3jDyN4HsXO+JAA0=
+github.com/ChainSafe/gossamer v0.1.1-0.20201030012803-12b09c7cdbc2/go.mod h1:OhH5swWDjaic9lMUZy8+M2I5rcCJBGtdOS/TV3vgFys=
 github.com/ChainSafe/log15 v1.0.0 h1:vRDVtWtVwIH5uSCBvgTTZh6FA58UBJ6+QiiypaZfBf8=
 github.com/ChainSafe/log15 v1.0.0/go.mod h1:5v1+ALHtdW0NfAeeoYyKmzCAMcAeqkdhIg4uxXWIgOg=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
@@ -158,8 +158,6 @@ github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dT
 github.com/go-sourcemap/sourcemap v2.1.2+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=
-github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=

--- a/test/adapters/gossamer-legacy/host_api/host_api.go
+++ b/test/adapters/gossamer-legacy/host_api/host_api.go
@@ -15,8 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
 
-// this file provide a command line interface to call scale codec go library
-
 package host_api
 
 import (
@@ -24,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/lib/keystore"
@@ -80,7 +79,7 @@ func ProcessHostApiCommand(args []string) {
 	}
 
 	function := *functionTextPtr
-	input := *inputTextPtr
+	inputs   := strings.Split(*inputTextPtr, ",")
 
 	// Initialize runtime environment...
 	var rtm runtime.Instance
@@ -121,36 +120,37 @@ func ProcessHostApiCommand(args []string) {
 
 	// test crypto api
 	case "test_blake2_128",
-		"test_blake2_256",
-		"test_twox_64",
-		"test_twox_128",
-		"test_twox_256",
-		"test_keccak_256":
-		test_crypto_hash(rtm, function[5:], input)
-		//	case "test_blake2_256_enumerated_trie_root":
-		//	case "test_ed25519":
-		//	case "test_sr25519":
-		//	case "test_secp256k1_ecdsa_recover":
+	     "test_blake2_256",
+	     "test_twox_64",
+	     "test_twox_128",
+	     "test_twox_256",
+	     "test_keccak_256":
+		test_crypto_hash(rtm, function[5:], inputs[0])
+	//case "test_blake2_256_enumerated_trie_root":
+	//case "test_ed25519":
+	//case "test_sr25519":
+	//case "test_secp256k1_ecdsa_recover":
 
 	// test storage api
-	//	case "test_clear_prefix":
-	//	case "test_clear_storage":
-	//	case "test_exists_storage":
-	//	case "test_set_get_local_storage":
-	//	case "test_set_get_storage":
-	//	case "test_set_get_storage_into":
-	//	case "test_storage_root":
-	//	case "test_storage_changes_root":
-	//	case "test_local_storage_compare_and_set":
+	//case "test_clear_prefix":
+	//case "test_clear_storage":
+	//case "test_exists_storage":
+	//case "test_set_get_local_storage":
+	case "test_set_get_storage":
+		test_set_get_storage(rtm, inputs[0], inputs[1])
+	//case "test_set_get_storage_into":
+	//case "test_storage_root":
+	//case "test_storage_changes_root":
+	//case "test_local_storage_compare_and_set":
 
 	// test child storage api
-	//	case "test_clear_child_prefix":
-	//	case "test_clear_child_storage":
-	//	case "test_exists_child_storage":
-	//	case "test_kill_child_storage":
-	//	case "test_set_get_child_storage":
-	//	case "test_get_child_storage_into":
-	//	case "test_child_storage_root":
+	//case "test_clear_child_prefix":
+	//case "test_clear_child_storage":
+	//case "test_exists_child_storage":
+	//case "test_kill_child_storage":
+	//case "test_set_get_child_storage":
+	//case "test_get_child_storage_into":
+	//case "test_child_storage_root":
 
 	default:
 		fmt.Println("Not implemented: ", function)

--- a/test/adapters/gossamer-legacy/host_api/storage.go
+++ b/test/adapters/gossamer-legacy/host_api/storage.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2019 Web3 Technologies Foundation
+
+// This file is part of Polkadot Host Test Suite
+
+// Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot Host Tests is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+
+package host_api
+
+import (
+	"fmt"
+	"os"
+	"bytes"
+
+	"github.com/ChainSafe/gossamer/lib/runtime"
+	"github.com/ChainSafe/gossamer/lib/scale"
+)
+
+
+func test_set_get_storage(r runtime.Instance, key string, value string) {
+
+	// Encode inputs
+	key_enc, err := scale.Encode([]byte(key))
+	if err != nil {
+		fmt.Println("Encoding key failed: ", err)
+		os.Exit(1)
+	}
+
+	value_enc, err := scale.Encode([]byte(value))
+	if err != nil {
+		fmt.Println("Encoding value failed: ", err)
+		os.Exit(1)
+	}
+
+	// Get invalid key
+	empty_enc, err := r.Exec("rtm_ext_get_allocated_storage", key_enc)
+	if err != nil {
+		fmt.Println("Execution failed: ", err)
+		os.Exit(1)
+	}
+
+	empty, err := scale.Decode(empty_enc, []byte{})
+	if err != nil {
+		fmt.Println("Decoding value failed: ", err)
+		os.Exit(1)
+	}
+
+	if len(empty.([]byte)) != 0 {
+		fmt.Printf("Key already exists: %s\n", empty)
+		os.Exit(1)
+	}
+
+	// Set key/value
+	_, err = r.Exec("rtm_ext_set_storage", append(key_enc, value_enc...))
+	if err != nil {
+		fmt.Println("Execution failed: ", err)
+		os.Exit(1)
+	}
+
+	// Get valid key
+	result_enc, err := r.Exec("rtm_ext_get_allocated_storage", key_enc)
+	if err != nil {
+		fmt.Println("Execution failed: ", err)
+		os.Exit(1)
+	}
+
+	result, err := scale.Decode(result_enc, []byte{})
+	if err != nil {
+		fmt.Println("Decoding value failed: ", err)
+		os.Exit(1)
+	}
+
+	if !bytes.Equal(result.([]byte), []byte(value)) {
+		fmt.Printf("Value is different: %s\n", result)
+		os.Exit(1)
+	}
+
+	fmt.Printf("%s\n", result)
+}

--- a/test/adapters/gossamer/go.mod
+++ b/test/adapters/gossamer/go.mod
@@ -3,7 +3,7 @@ module w3f/gossamer-adapter
 require (
 	github.com/ChainSafe/chaindb v0.1.4
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816 // indirect
-	github.com/ChainSafe/gossamer v0.1.1-0.20201014230016-9ebddb3ccf5f
+	github.com/ChainSafe/gossamer v0.1.1-0.20201030012803-12b09c7cdbc2
 	github.com/DataDog/zstd v1.4.5 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/btcsuite/btcd v0.21.0-beta // indirect

--- a/test/adapters/gossamer/go.sum
+++ b/test/adapters/gossamer/go.sum
@@ -29,8 +29,8 @@ github.com/ChainSafe/chaindb v0.1.4/go.mod h1:FQQJbGzWe+rOa0aW/wSMz1qfIScauntW0H
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816 h1:X5jJ3e/jgFSnSoYOep/mf6pF1RuLZfvF1ts8NZIyzqE=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/ChainSafe/gossamer v0.1.1-0.20201014230016-9ebddb3ccf5f h1:PLFxkRZE9GjNhxT6TIZKH8t6VRVNOpZsxlCzdTMhgPk=
-github.com/ChainSafe/gossamer v0.1.1-0.20201014230016-9ebddb3ccf5f/go.mod h1:OhH5swWDjaic9lMUZy8+M2I5rcCJBGtdOS/TV3vgFys=
+github.com/ChainSafe/gossamer v0.1.1-0.20201030012803-12b09c7cdbc2 h1:CQ7LwMGDxZDIE7LtI7BOEHwzpRty3jDyN4HsXO+JAA0=
+github.com/ChainSafe/gossamer v0.1.1-0.20201030012803-12b09c7cdbc2/go.mod h1:OhH5swWDjaic9lMUZy8+M2I5rcCJBGtdOS/TV3vgFys=
 github.com/ChainSafe/log15 v1.0.0 h1:vRDVtWtVwIH5uSCBvgTTZh6FA58UBJ6+QiiypaZfBf8=
 github.com/ChainSafe/log15 v1.0.0/go.mod h1:5v1+ALHtdW0NfAeeoYyKmzCAMcAeqkdhIg4uxXWIgOg=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=

--- a/test/adapters/gossamer/host_api/host_api.go
+++ b/test/adapters/gossamer/host_api/host_api.go
@@ -15,8 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
 
-// this file provide a command line interface to call scale codec go library
-
 package host_api
 
 import (
@@ -24,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/lib/keystore"
@@ -80,7 +79,7 @@ func ProcessHostApiCommand(args []string) {
 	}
 
 	function := *functionTextPtr
-	input := *inputTextPtr
+	inputs   := strings.Split(*inputTextPtr, ",")
 
 	// Initialize runtime environment...
 	var rtm runtime.Instance
@@ -121,36 +120,37 @@ func ProcessHostApiCommand(args []string) {
 
 	// test crypto api
 	case "test_blake2_128",
-		"test_blake2_256",
-		"test_twox_64",
-		"test_twox_128",
-		"test_twox_256",
-		"test_keccak_256":
-		test_crypto_hash(rtm, function[5:], input)
-		//	case "test_blake2_256_enumerated_trie_root":
-		//	case "test_ed25519":
-		//	case "test_sr25519":
-		//	case "test_secp256k1_ecdsa_recover":
+	     "test_blake2_256",
+	     "test_twox_64",
+	     "test_twox_128",
+	     "test_twox_256",
+	     "test_keccak_256":
+		test_crypto_hash(rtm, function[5:], inputs[0])
+	//case "test_blake2_256_enumerated_trie_root":
+	//case "test_ed25519":
+	//case "test_sr25519":
+	//case "test_secp256k1_ecdsa_recover":
 
 	// test storage api
-	//	case "test_clear_prefix":
-	//	case "test_clear_storage":
-	//	case "test_exists_storage":
-	//	case "test_set_get_local_storage":
-	//	case "test_set_get_storage":
-	//	case "test_set_get_storage_into":
-	//	case "test_storage_root":
-	//	case "test_storage_changes_root":
-	//	case "test_local_storage_compare_and_set":
+	//case "test_clear_prefix":
+	//case "test_clear_storage":
+	//case "test_exists_storage":
+	//case "test_set_get_local_storage":
+	case "test_set_get_storage":
+		test_set_get_storage(rtm, inputs[0], inputs[1])
+	//case "test_set_get_storage_into":
+	//case "test_storage_root":
+	//case "test_storage_changes_root":
+	//case "test_local_storage_compare_and_set":
 
 	// test child storage api
-	//	case "test_clear_child_prefix":
-	//	case "test_clear_child_storage":
-	//	case "test_exists_child_storage":
-	//	case "test_kill_child_storage":
-	//	case "test_set_get_child_storage":
-	//	case "test_get_child_storage_into":
-	//	case "test_child_storage_root":
+	//case "test_clear_child_prefix":
+	//case "test_clear_child_storage":
+	//case "test_exists_child_storage":
+	//case "test_kill_child_storage":
+	//case "test_set_get_child_storage":
+	//case "test_get_child_storage_into":
+	//case "test_child_storage_root":
 
 	default:
 		fmt.Println("Not implemented: ", function)

--- a/test/adapters/gossamer/host_api/storage.go
+++ b/test/adapters/gossamer/host_api/storage.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2019 Web3 Technologies Foundation
+
+// This file is part of Polkadot Host Test Suite
+
+// Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot Host Tests is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+
+package host_api
+
+import (
+	"fmt"
+	"os"
+	"bytes"
+
+	"github.com/ChainSafe/gossamer/lib/runtime"
+	"github.com/ChainSafe/gossamer/lib/scale"
+)
+
+
+func test_set_get_storage(r runtime.Instance, key string, value string) {
+
+	// Encode inputs
+	key_enc, err := scale.Encode([]byte(key))
+	if err != nil {
+		fmt.Println("Encoding key failed: ", err)
+		os.Exit(1)
+	}
+
+	value_enc, err := scale.Encode([]byte(value))
+	if err != nil {
+		fmt.Println("Encoding value failed: ", err)
+		os.Exit(1)
+	}
+
+	// Get invalid key
+	empty_enc, err := r.Exec("rtm_ext_get_allocated_storage", key_enc)
+	if err != nil {
+		fmt.Println("Execution failed: ", err)
+		os.Exit(1)
+	}
+
+	empty, err := scale.Decode(empty_enc, []byte{})
+	if err != nil {
+		fmt.Println("Decoding value failed: ", err)
+		os.Exit(1)
+	}
+
+	if len(empty.([]byte)) != 0 {
+		fmt.Printf("Key already exists: %s\n", empty)
+		os.Exit(1)
+	}
+
+	// Set key/value
+	_, err = r.Exec("rtm_ext_set_storage", append(key_enc, value_enc...))
+	if err != nil {
+		fmt.Println("Execution failed: ", err)
+		os.Exit(1)
+	}
+
+	// Get valid key
+	result_enc, err := r.Exec("rtm_ext_get_allocated_storage", key_enc)
+	if err != nil {
+		fmt.Println("Execution failed: ", err)
+		os.Exit(1)
+	}
+
+	result, err := scale.Decode(result_enc, []byte{})
+	if err != nil {
+		fmt.Println("Decoding value failed: ", err)
+		os.Exit(1)
+	}
+
+	if !bytes.Equal(result.([]byte), []byte(value)) {
+		fmt.Printf("Value is different: %s\n", result)
+		os.Exit(1)
+	}
+
+	fmt.Printf("%s\n", result)
+}

--- a/test/helpers/AdapterFixture.jl
+++ b/test/helpers/AdapterFixture.jl
@@ -176,16 +176,13 @@ function run(self::Builder, adapter::CmdString)
    end # for inputs
 end
 
-"List of implementations with legacy adapter"
-IMPLEMENTATIONS_WITH_LEGACY_ADAPTER = [ "substrate" "kagome" ]
-
 "Run fixture for each configured implementation, optional flag to use legacy version if available."
 function execute(self::Builder; legacy::Bool=false)
     @testset "$(self.name)" begin
         for implementation in Config.implementations
             adapter = "$implementation-adapter"
 
-            if legacy && implementation in IMPLEMENTATIONS_WITH_LEGACY_ADAPTER
+            if legacy
                 adapter *= "-legacy"
             end
 


### PR DESCRIPTION
 This is how Gossamer's Host API currently returns stored values:

| key | value | result |
| ---- | -------- | ------- |
| static | Inverse | statice |
| function | Horizontal |  functionl |
| Integrated | portal |  portal |
| non-based | Monitored | non-based |
| productivity | secondary | productiv |
| Exclusive | next generation | Exclusiveration |
| disintermediate | Grass-roots | disintermed |
| contingency | value-added | contingency |
| human-resource | Reactive | Reactive |
| Optional | secondary | Option |

Result is the same on wasmer and new wasmtime backend (use `--wasmtime` flag to test).

It looks like there is clearly some kind of order to it, so expect there to be a bug in the storage itself at this point.