### PR TITLE
gossamer-adapter: update to use wasmtime

### DIFF
--- a/test/adapters/gossamer/go.mod
+++ b/test/adapters/gossamer/go.mod
@@ -1,9 +1,9 @@
 module w3f/gossamer-adapter
 
 require (
-	github.com/ChainSafe/chaindb v0.0.1
+	github.com/ChainSafe/chaindb v0.1.4 // indirect
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816 // indirect
-	github.com/ChainSafe/gossamer v0.1.1-0.20200818004221-5dbc019b77fe
+	github.com/ChainSafe/gossamer v0.1.1-0.20201010173722-47d7a5bb1b3e
 	github.com/DataDog/zstd v1.4.5 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/btcsuite/btcd v0.21.0-beta // indirect

--- a/test/adapters/gossamer/go.sum
+++ b/test/adapters/gossamer/go.sum
@@ -24,13 +24,14 @@ github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6L
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/ChainSafe/chaindb v0.0.1 h1:A+11ulFG6R/IE6pEBy6j6hTTHTA3BvCVK8jklogW0Uw=
-github.com/ChainSafe/chaindb v0.0.1/go.mod h1:FQQJbGzWe+rOa0aW/wSMz1qfIScauntW0HiynEIezuk=
+github.com/ChainSafe/chaindb v0.1.3/go.mod h1:FQQJbGzWe+rOa0aW/wSMz1qfIScauntW0HiynEIezuk=
+github.com/ChainSafe/chaindb v0.1.4 h1:cXaBIm21aGRijBDPSxkdeXIiuiuNQ4Yc5uV63HrjTg0=
+github.com/ChainSafe/chaindb v0.1.4/go.mod h1:FQQJbGzWe+rOa0aW/wSMz1qfIScauntW0HiynEIezuk=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816 h1:X5jJ3e/jgFSnSoYOep/mf6pF1RuLZfvF1ts8NZIyzqE=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/ChainSafe/gossamer v0.1.1-0.20200818004221-5dbc019b77fe h1:ZOlImyh/7TLRF36TRAtX4zwirZnBF8bzycqTr5ZWFvg=
-github.com/ChainSafe/gossamer v0.1.1-0.20200818004221-5dbc019b77fe/go.mod h1:R8TkzNFYvETd79xG4AxKDTQWw6j54hQwsHOiGIruN94=
+github.com/ChainSafe/gossamer v0.1.1-0.20201010173722-47d7a5bb1b3e h1:u2wRhJVUAn7GetI3Xa1eNssxTF/sYJhf/GIso0DanwE=
+github.com/ChainSafe/gossamer v0.1.1-0.20201010173722-47d7a5bb1b3e/go.mod h1:DMI+cJ9zdLlgt4U3/fPymEow/8tybj41k0fpEGxtMlk=
 github.com/ChainSafe/log15 v1.0.0 h1:vRDVtWtVwIH5uSCBvgTTZh6FA58UBJ6+QiiypaZfBf8=
 github.com/ChainSafe/log15 v1.0.0/go.mod h1:5v1+ALHtdW0NfAeeoYyKmzCAMcAeqkdhIg4uxXWIgOg=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
@@ -76,6 +77,8 @@ github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
+github.com/bytecodealliance/wasmtime-go v0.20.0 h1:omD0VY6IwL60E8YMM8rgcmyGT8O+pqabHAwoPi5il6k=
+github.com/bytecodealliance/wasmtime-go v0.20.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/test/adapters/gossamer/host_api/crypto.go
+++ b/test/adapters/gossamer/host_api/crypto.go
@@ -28,20 +28,20 @@ import (
 )
 
 // Simple wrapper to test hash function that input and output byte arrays
-func test_crypto_hash(r *runtime.Runtime, name string, input string) {
+func test_crypto_hash(r runtime.Instance, name string, input string) {
 	enc, err := scale.Encode([]byte(input))
 	if err != nil {
 		fmt.Println("Encoding failed: ", err)
 		os.Exit(1)
 	}
 
-	output, err := r.Exec("rtm_ext_" + name, enc)
+	output, err := r.Exec("rtm_ext_"+name, enc)
 	if err != nil {
 		fmt.Println("Execution failed: ", err)
 		os.Exit(1)
 	}
 
-	dec, err := scale.Decode(output, []byte{}) 
+	dec, err := scale.Decode(output, []byte{})
 	if err != nil {
 		fmt.Println("Decoding failed: ", err)
 		os.Exit(1)

--- a/test/adapters/gossamer/host_api/host_api.go
+++ b/test/adapters/gossamer/host_api/host_api.go
@@ -27,10 +27,8 @@ import (
 
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/lib/keystore"
-	"github.com/ChainSafe/gossamer/lib/runtime"
+	"github.com/ChainSafe/gossamer/lib/runtime/wasmtime"
 	"github.com/ChainSafe/gossamer/lib/trie"
-
-	database "github.com/ChainSafe/chaindb"
 )
 
 // #include <errno.h>
@@ -46,16 +44,8 @@ func GetRuntimePath() string {
 	return path.Join(dir, RELATIVE_WASM_ADAPTER_PATH)
 }
 
-func GetTestStorage() *state.StorageState {
-	db := database.NewMemDatabase()
-
-	s, err := state.NewStorageState(db, trie.NewEmptyTrie())
-	if err != nil {
-		fmt.Println("Failed initialize storage: ", err)
-		os.Exit(1)
-	}
-
-	return s
+func GetTestStorage() *state.TrieState {
+	return state.NewTrieState(trie.NewEmptyTrie())
 }
 
 func ProcessHostApiCommand(args []string) {
@@ -79,17 +69,17 @@ func ProcessHostApiCommand(args []string) {
 	}
 
 	function := *functionTextPtr
-	input    := *inputTextPtr
-	
-	// Initialize runtime environment
-	cfg := &runtime.Config{
-		Storage:  GetTestStorage(),
-		Keystore: keystore.NewKeystore(),
-		Imports:  runtime.RegisterImports_NodeRuntime,
-		LogLvl:   2, // log15.LvlWarn
-	}
+	input := *inputTextPtr
 
-	rtm, err := runtime.NewRuntimeFromFile(GetRuntimePath(), cfg)
+	// Initialize runtime environment
+	cfg := &wasmtime.Config{
+		Imports: wasmtime.ImportsHostAPITester,
+	}
+	cfg.Storage = GetTestStorage()
+	cfg.Keystore = keystore.NewGenericKeystore("test")
+	cfg.LogLvl = 2
+
+	rtm, err := wasmtime.NewInstanceFromFile(GetRuntimePath(), cfg)
 	if err != nil {
 		fmt.Println("Failed initialize runtime: ", err)
 		os.Exit(1)
@@ -104,31 +94,30 @@ func ProcessHostApiCommand(args []string) {
 	     "test_twox_128",
 	     "test_twox_256":
 		test_crypto_hash(rtm, function[5:], input)
-//	case "test_blake2_256_enumerated_trie_root":
-//	case "test_ed25519":
-//	case "test_sr25519":
-//	case "test_secp256k1_ecdsa_recover":
-
+		//	case "test_blake2_256_enumerated_trie_root":
+		//	case "test_ed25519":
+		//	case "test_sr25519":
+		//	case "test_secp256k1_ecdsa_recover":
 
 	// test storage api
-//	case "test_clear_prefix":
-//	case "test_clear_storage":
-//	case "test_exists_storage":
-//	case "test_set_get_local_storage":
-//	case "test_set_get_storage":
-//	case "test_set_get_storage_into":
-//	case "test_storage_root":
-//	case "test_storage_changes_root":
-//	case "test_local_storage_compare_and_set":
-  
+	//	case "test_clear_prefix":
+	//	case "test_clear_storage":
+	//	case "test_exists_storage":
+	//	case "test_set_get_local_storage":
+	//	case "test_set_get_storage":
+	//	case "test_set_get_storage_into":
+	//	case "test_storage_root":
+	//	case "test_storage_changes_root":
+	//	case "test_local_storage_compare_and_set":
+
 	// test child storage api
-//	case "test_clear_child_prefix":
-//	case "test_clear_child_storage":
-//	case "test_exists_child_storage":
-//	case "test_kill_child_storage":
-//	case "test_set_get_child_storage":
-//	case "test_get_child_storage_into":
-//	case "test_child_storage_root":
+	//	case "test_clear_child_prefix":
+	//	case "test_clear_child_storage":
+	//	case "test_exists_child_storage":
+	//	case "test_kill_child_storage":
+	//	case "test_set_get_child_storage":
+	//	case "test_get_child_storage_into":
+	//	case "test_child_storage_root":
 
 	default:
 		fmt.Println("Not implemented: ", function)


### PR DESCRIPTION
This switches the runtime environment for the Host API tests from wasmer to wasmtime.

Currently break `test_twox_64` which now only returns all-zero hashes.

Build against Gossamer from ChainSafe/gossamer#1127.