### PR TITLE
gossamer-adapter: update storage test to use badgerDB

### DIFF
--- a/test/adapters/gossamer/go.mod
+++ b/test/adapters/gossamer/go.mod
@@ -3,7 +3,7 @@ module w3f/gossamer-adapter
 require (
 	github.com/ChainSafe/chaindb v0.1.4
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816 // indirect
-	github.com/ChainSafe/gossamer v0.1.1-0.20201014230016-9ebddb3ccf5f
+	github.com/ChainSafe/gossamer v0.1.1-0.20201016170636-8c9ec601fbbd
 	github.com/DataDog/zstd v1.4.5 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/btcsuite/btcd v0.21.0-beta // indirect

--- a/test/adapters/gossamer/go.sum
+++ b/test/adapters/gossamer/go.sum
@@ -31,6 +31,8 @@ github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816 h1:X5jJ3e/
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/ChainSafe/gossamer v0.1.1-0.20201014230016-9ebddb3ccf5f h1:PLFxkRZE9GjNhxT6TIZKH8t6VRVNOpZsxlCzdTMhgPk=
 github.com/ChainSafe/gossamer v0.1.1-0.20201014230016-9ebddb3ccf5f/go.mod h1:OhH5swWDjaic9lMUZy8+M2I5rcCJBGtdOS/TV3vgFys=
+github.com/ChainSafe/gossamer v0.1.1-0.20201016170636-8c9ec601fbbd h1:eQtgotVsJpRHkeRTGSmP6YyIunimk+tEWGp4P51jQgM=
+github.com/ChainSafe/gossamer v0.1.1-0.20201016170636-8c9ec601fbbd/go.mod h1:OhH5swWDjaic9lMUZy8+M2I5rcCJBGtdOS/TV3vgFys=
 github.com/ChainSafe/log15 v1.0.0 h1:vRDVtWtVwIH5uSCBvgTTZh6FA58UBJ6+QiiypaZfBf8=
 github.com/ChainSafe/log15 v1.0.0/go.mod h1:5v1+ALHtdW0NfAeeoYyKmzCAMcAeqkdhIg4uxXWIgOg=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=

--- a/test/adapters/gossamer/host_api/host_api.go
+++ b/test/adapters/gossamer/host_api/host_api.go
@@ -99,7 +99,7 @@ func ProcessHostApiCommand(args []string) {
 		}
 		cfg.Storage = GetTestStorage()
 		cfg.Keystore = keystore.NewGenericKeystore("test")
-		cfg.LogLvl = 5
+		cfg.LogLvl = 2
 
 		r, err := wasmtime.NewInstanceFromFile(GetRuntimePath(), cfg)
 		if err != nil {
@@ -114,7 +114,7 @@ func ProcessHostApiCommand(args []string) {
 		}
 		cfg.Storage = GetTestStorage()
 		cfg.Keystore = keystore.NewGenericKeystore("test")
-		cfg.LogLvl = 5
+		cfg.LogLvl = 2
 
 		r, err := wasmer.NewInstanceFromFile(GetRuntimePath(), cfg)
 		if err != nil {

--- a/test/adapters/gossamer/host_api/storage.go
+++ b/test/adapters/gossamer/host_api/storage.go
@@ -18,14 +18,13 @@
 package host_api
 
 import (
+	"bytes"
 	"fmt"
 	"os"
-	"bytes"
 
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	"github.com/ChainSafe/gossamer/lib/scale"
 )
-
 
 func test_set_get_storage(r runtime.Instance, key string, value string) {
 


### PR DESCRIPTION
updated storage test to use badgerDB, this is because `chaindb.MemDatabase` is backed by a mapping which is not safe for use with the interpreters. works now for me:
```
$ ./gossamer-adapter host-api --function test_set_get_storage --input "static,Inverse" --wasmtime
Inverse
$ ./gossamer-adapter host-api --function test_set_get_storage --input "static,Inverse" 
Inverse
```

closes https://github.com/ChainSafe/gossamer/issues/1143