### PR TITLE
host-spec: Add update target

### DIFF
--- a/host-spec/Makefile
+++ b/host-spec/Makefile
@@ -9,9 +9,9 @@ GENERATED  := figures/c07-overview.eps
 SOURCES    := host-spec.tm $(CHAPTERS) $(APPENDICES) $(FIGURES) $(GENERATED)
 
 
-.PHONY: all build tex diff clean
+.PHONY: build pdf tex diff temp update clean
 
-all: pdf
+build: pdf
 
 
 pdf: polkadot-host-spec.pdf

--- a/host-spec/Makefile
+++ b/host-spec/Makefile
@@ -49,6 +49,9 @@ polkadot-host-spec.diff.pdf: $(SOURCES) $(REVDIR) host-spec.scm
 	xvfb-run texmacs -b host-spec.scm  -x "(compare-versions-expanded \"$(REVDIR)/host-spec.tm\" \"$$PWD/host-spec.tm\") (export-buffer \"$$PWD/$@\")" -q
 
 
+update: $(SOURCES) host-spec.scm
+	xvfb-run texmacs -b host-spec.scm -x "(update-all \"$$PWD/$<\" \"$(TMPDIR)\")" --quit
+
 clean:
 	rm -rf $(REVDIR) $(GENERATED) polkadot-host-spec.pdf polkadot-host-spec.tex polkadot-host-spec.diff.pdf
 

--- a/host-spec/README.md
+++ b/host-spec/README.md
@@ -15,5 +15,7 @@ Any other formats, like the `.tex` and `.pdf` files are exported from TeXmacs.
 
 ## Command line build and diff support
 
-There is a Makefile to simplify the generation of PDFs and diff PDFs. This feature requires `xvfb` to be installed. To build the `polkadot-host-spec.pdf` just use `make` or `make build`. To generate `polkadot-host-spec.diff.pdf` use `make diff REV=<revision>` where `<revision>` can be any previous revision to which to compare, i.e. a branch, tag or commit. The resulting `polkadot-host-spec.diff.pdf` highlights the differences between the `<revision>` version of the specification with the current version using different colors (red indicates `<revision>` version and green refers to the current version of the text). 
+There is a Makefile to simplify the generation of PDFs and diff PDFs. This feature requires `xvfb` to be installed. To build the `polkadot-host-spec.pdf` just use `make` or `make build`. To generate `polkadot-host-spec.diff.pdf` use `make diff REV=<revision>` where `<revision>` can be any previous revision to which to compare, i.e. a branch, tag or commit. The resulting `polkadot-host-spec.diff.pdf` highlights the differences between the `<revision>` version of the specification with the current version using different colors (red indicates `<revision>` version and green refers to the current version of the text).
+
+To update table of content, bibliography, indices and glossar (e.g. before committing) there is `make update` which runs TeXmacs to update each of them and save the result.
 

--- a/host-spec/host-spec.scm
+++ b/host-spec/host-spec.scm
@@ -32,3 +32,11 @@
   (export-buffer output)
   (generate-all-aux) (inclusions-gc) (update-current-buffer)
   (export-buffer output))
+
+;; This function updates/rebuilds the toc, bibliography, index and glossar
+;; of the document specified. Requires a tempdir to which it triggers a export.
+(tm-define (update-all input tmpdir)
+  (load-buffer input :strict)
+  (buffer-export (current-buffer) (string-append tmpdir "/update-all.export.tmp") "pdf")
+  (generate-all-aux) (inclusions-gc) (update-current-buffer)
+  (buffer-save (current-buffer)))


### PR DESCRIPTION
This PR add `make update` to the host-spec Makefile which runs TeXmacs to update the table of content, the bibliography, indices and glossary.

This should help when merging or cleaning up commits.