### PR TITLE
gossamer-adapter: Port tests from legacy API

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -400,6 +400,28 @@ jobs:
     - name: Run test fixture
       run: test/runtests.jl gossamer ${{ matrix.fixture }}
 
+  test-gossamer-wasm:
+    needs: [ build-adapter-gossamer, build-runtime-hostapi]
+    name: "[test-host-api] gossamer"
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - uses: actions/download-artifact@v1
+      with:
+        name: gossamer-adapter
+        path: test/bin
+    - uses: actions/download-artifact@v1
+      with:
+        name: hostapi-runtime.compact.wasm
+        path: test/bin
+    - run: |
+        chmod +x test/bin/gossamer-adapter
+        mkdir -p test/lib
+        mv test/bin/libwasmer.so test/lib/
+    - name: Run test fixture
+      run: test/runtests.jl gossamer host-api
+
   test-gossamer-legacy:
     needs: [ build-adapter-gossamer-legacy, build-runtime-hostapi-legacy]
     name: "[test-host-api-legacy] gossamer"

--- a/test/adapters/gossamer/go.mod
+++ b/test/adapters/gossamer/go.mod
@@ -3,7 +3,7 @@ module w3f/gossamer-adapter
 require (
 	github.com/ChainSafe/chaindb v0.1.4
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816 // indirect
-	github.com/ChainSafe/gossamer v0.1.1-0.20201102161658-0050cc6df470
+	github.com/ChainSafe/gossamer v0.1.1-0.20201109205301-61a9ed757ab3
 	github.com/DataDog/zstd v1.4.5 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/btcsuite/btcd v0.21.0-beta // indirect

--- a/test/adapters/gossamer/go.mod
+++ b/test/adapters/gossamer/go.mod
@@ -3,7 +3,7 @@ module w3f/gossamer-adapter
 require (
 	github.com/ChainSafe/chaindb v0.1.4
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816 // indirect
-	github.com/ChainSafe/gossamer v0.1.1-0.20201030012803-12b09c7cdbc2
+	github.com/ChainSafe/gossamer v0.1.1-0.20201102161658-0050cc6df470
 	github.com/DataDog/zstd v1.4.5 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/btcsuite/btcd v0.21.0-beta // indirect

--- a/test/adapters/gossamer/go.sum
+++ b/test/adapters/gossamer/go.sum
@@ -29,10 +29,8 @@ github.com/ChainSafe/chaindb v0.1.4/go.mod h1:FQQJbGzWe+rOa0aW/wSMz1qfIScauntW0H
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816 h1:X5jJ3e/jgFSnSoYOep/mf6pF1RuLZfvF1ts8NZIyzqE=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/ChainSafe/gossamer v0.1.1-0.20201030012803-12b09c7cdbc2 h1:CQ7LwMGDxZDIE7LtI7BOEHwzpRty3jDyN4HsXO+JAA0=
-github.com/ChainSafe/gossamer v0.1.1-0.20201030012803-12b09c7cdbc2/go.mod h1:OhH5swWDjaic9lMUZy8+M2I5rcCJBGtdOS/TV3vgFys=
-github.com/ChainSafe/gossamer v0.1.1-0.20201102161658-0050cc6df470 h1:iJSrdzzIoAnadkakQmw/xR5HCCl9HtAxocShmkj5CIc=
-github.com/ChainSafe/gossamer v0.1.1-0.20201102161658-0050cc6df470/go.mod h1:OhH5swWDjaic9lMUZy8+M2I5rcCJBGtdOS/TV3vgFys=
+github.com/ChainSafe/gossamer v0.1.1-0.20201109205301-61a9ed757ab3 h1:WTPLSXOK5j0PPXerVEnAK6Zj6XbBHbB0Z+EF0wPTXmA=
+github.com/ChainSafe/gossamer v0.1.1-0.20201109205301-61a9ed757ab3/go.mod h1:OhH5swWDjaic9lMUZy8+M2I5rcCJBGtdOS/TV3vgFys=
 github.com/ChainSafe/log15 v1.0.0 h1:vRDVtWtVwIH5uSCBvgTTZh6FA58UBJ6+QiiypaZfBf8=
 github.com/ChainSafe/log15 v1.0.0/go.mod h1:5v1+ALHtdW0NfAeeoYyKmzCAMcAeqkdhIg4uxXWIgOg=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=

--- a/test/adapters/gossamer/go.sum
+++ b/test/adapters/gossamer/go.sum
@@ -31,6 +31,8 @@ github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816 h1:X5jJ3e/
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/ChainSafe/gossamer v0.1.1-0.20201030012803-12b09c7cdbc2 h1:CQ7LwMGDxZDIE7LtI7BOEHwzpRty3jDyN4HsXO+JAA0=
 github.com/ChainSafe/gossamer v0.1.1-0.20201030012803-12b09c7cdbc2/go.mod h1:OhH5swWDjaic9lMUZy8+M2I5rcCJBGtdOS/TV3vgFys=
+github.com/ChainSafe/gossamer v0.1.1-0.20201102161658-0050cc6df470 h1:iJSrdzzIoAnadkakQmw/xR5HCCl9HtAxocShmkj5CIc=
+github.com/ChainSafe/gossamer v0.1.1-0.20201102161658-0050cc6df470/go.mod h1:OhH5swWDjaic9lMUZy8+M2I5rcCJBGtdOS/TV3vgFys=
 github.com/ChainSafe/log15 v1.0.0 h1:vRDVtWtVwIH5uSCBvgTTZh6FA58UBJ6+QiiypaZfBf8=
 github.com/ChainSafe/log15 v1.0.0/go.mod h1:5v1+ALHtdW0NfAeeoYyKmzCAMcAeqkdhIg4uxXWIgOg=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=

--- a/test/adapters/gossamer/host_api/hashing.go
+++ b/test/adapters/gossamer/host_api/hashing.go
@@ -28,14 +28,15 @@ import (
 )
 
 // Simple wrapper to test hash function that input and output byte arrays
-func test_crypto_hash(r runtime.Instance, name string, input string) {
+func test_hashing(r runtime.Instance, name string, input string) {
+
 	enc, err := scale.Encode([]byte(input))
 	if err != nil {
 		fmt.Println("Encoding failed: ", err)
 		os.Exit(1)
 	}
 
-	output, err := r.Exec("rtm_ext_"+name, enc)
+	output, err := r.Exec("rtm_" + name, enc)
 	if err != nil {
 		fmt.Println("Execution failed: ", err)
 		os.Exit(1)

--- a/test/adapters/gossamer/host_api/host_api.go
+++ b/test/adapters/gossamer/host_api/host_api.go
@@ -86,7 +86,7 @@ func ProcessHostApiCommand(args []string) {
 	if *wasmtimeBoolPtr {
 		// ... using wasmtime
 		cfg := &wasmtime.Config{
-			Imports: wasmtime.ImportsHostAPITester,
+			Imports: wasmtime.ImportsNodeRuntime,
 		}
 		cfg.Storage = GetTestStorage()
 		cfg.Keystore = keystore.NewGenericKeystore("test")
@@ -101,7 +101,7 @@ func ProcessHostApiCommand(args []string) {
 	} else {
 		// ... using wasmer
 		cfg := &wasmer.Config{
-			Imports: wasmer.RegisterImports_NodeRuntime,
+			Imports: wasmer.ImportsNodeRuntime,
 		}
 		cfg.Storage = GetTestStorage()
 		cfg.Keystore = keystore.NewGenericKeystore("test")
@@ -117,40 +117,57 @@ func ProcessHostApiCommand(args []string) {
 
 	// Run requested test function
 	switch function {
-
-	// test crypto api
-	case "test_blake2_128",
-	     "test_blake2_256",
-	     "test_twox_64",
-	     "test_twox_128",
-	     "test_twox_256",
-	     "test_keccak_256":
-		test_crypto_hash(rtm, function[5:], inputs[0])
-	//case "test_blake2_256_enumerated_trie_root":
-	//case "test_ed25519":
-	//case "test_sr25519":
-	//case "test_secp256k1_ecdsa_recover":
-
-	// test storage api
-	//case "test_clear_prefix":
-	//case "test_clear_storage":
-	//case "test_exists_storage":
-	//case "test_set_get_local_storage":
-	case "test_set_get_storage":
-		test_set_get_storage(rtm, inputs[0], inputs[1])
-	//case "test_set_get_storage_into":
-	//case "test_storage_root":
-	//case "test_storage_changes_root":
-	//case "test_local_storage_compare_and_set":
+	// test allocator api
+	//case "ext_allocator_malloc_version_1":
+	//case "ext_allocator_free_version_1":
 
 	// test child storage api
-	//case "test_clear_child_prefix":
-	//case "test_clear_child_storage":
-	//case "test_exists_child_storage":
-	//case "test_kill_child_storage":
-	//case "test_set_get_child_storage":
-	//case "test_get_child_storage_into":
-	//case "test_child_storage_root":
+	//case "ext_default_child_storage_set_version_1":
+	//case "ext_default_child_storage_get_version_1":
+	//case "ext_default_child_storage_read_version_1":
+	//case "ext_default_child_storage_clear_version_1":
+	//case "ext_default_child_storage_storage_kill_version_1":
+	//case "ext_default_child_storage_exists_version_1":
+	//case "ext_default_child_storage_clear_prefix_version_1":
+	//case "ext_default_child_storage_root_version_1":
+	//case "ext_default_child_storage_next_key_version_1":
+
+	// test crypto api
+	//case "ext_crypto_ed25519_public_keys_version_1":
+	//case "ext_crypto_ed25519_generate_version_1":
+	//case "ext_crypto_ed25519_sign_version_1":
+	//case "ext_crypto_ed25519_verify_version_1":
+	//case "ext_crypto_sr25519_public_keys_version_1":
+	//case "ext_crypto_sr25519_generate_version_1":
+	//case "ext_crypto_sr25519_sign_version_1":
+	//case "ext_crypto_sr25519_verify_version_1":
+
+	// test hashing api
+	case "ext_hashing_blake2_128_version_1",
+	     "ext_hashing_blake2_256_version_1",
+	     "ext_hashing_keccak_256_version_1",
+	//     "ext_hashing_sha2_256_version_1",
+	     "ext_hashing_twox_64_version_1",
+	     "ext_hashing_twox_128_version_1",
+	     "ext_hashing_twox_256_version_1":
+		test_hashing(rtm, function, inputs[0])
+
+	// test storage api
+	//case "test_storage_init":
+	case "ext_storage_set_version_1",
+	     "ext_storage_get_version_1":
+		test_storage_set_get(rtm, inputs[0], inputs[1])
+	//case "ext_storage_read_version_1":
+	//case "ext_storage_clear_version_1":
+	//case "ext_storage_exists_version_1":
+	//case "ext_storage_clear_prefix_version_1":
+	//case "ext_storage_append_version_1":
+	//case "ext_storage_root_version_1":
+	//case "ext_storage_next_key_version_1":
+
+	// test trie api
+	//case "ext_trie_blake2_256_root_version_1":
+	//case "ext_trie_blake2_256_ordered_root_version_1":
 
 	default:
 		fmt.Println("Not implemented: ", function)

--- a/test/adapters/gossamer/host_api/host_api.go
+++ b/test/adapters/gossamer/host_api/host_api.go
@@ -60,7 +60,7 @@ func ProcessHostApiCommand(args []string) {
 
 	// List of expected flags
 	functionTextPtr := flag.String("function", "", "Function to call (required).")
-	inputTextPtr := flag.String("input", "", "Input to pass on call (required).")
+	inputTextPtr := flag.String("input", "", "Input to pass on call.")
 	
 	wasmtimeBoolPtr := flag.Bool("wasmtime", false, "Use wasmtime instead of wasmer.")
 
@@ -73,7 +73,7 @@ func ProcessHostApiCommand(args []string) {
 	}
 
 	// Verify that all required flags are provided
-	if (*functionTextPtr == "") || (*inputTextPtr == "") {
+	if (*functionTextPtr == "") {
 		flag.PrintDefaults()
 		os.Exit(1)
 	}

--- a/test/adapters/gossamer/host_api/host_api.go
+++ b/test/adapters/gossamer/host_api/host_api.go
@@ -37,7 +37,7 @@ import (
 // #include <errno.h>
 import "C"
 
-var RELATIVE_WASM_ADAPTER_PATH = "bin/hostapi_runtime_legacy.compact.wasm"
+var RELATIVE_WASM_ADAPTER_PATH = "bin/hostapi_runtime.compact.wasm"
 
 func GetRuntimePath() string {
 	dir, err := os.Getwd()


### PR DESCRIPTION
Updates Gossamer's the Host API Legacy adapter to the current version. 

Also see ChainSafe/gossamer#1164 for upstream changes that were required to make this work.