### PR TITLE
hostapi-runtime: use imported instead of exported memory

### DIFF
--- a/test/runtimes/hostapi/build.rs
+++ b/test/runtimes/hostapi/build.rs
@@ -39,6 +39,6 @@ fn main() {
 		get_manifest_dir().join("Cargo.toml").to_str().expect("Cargo uses valid paths; qed"),
 		// This instructs LLD to export __heap_base as a global variable, which is used by the
 		// external memory allocator.
-		"-Clink-arg=--export=__heap_base",
+		"-Clink-arg=--export=__heap_base -Clink-arg=--import-memory",
 	);
 }


### PR DESCRIPTION
This should bring the hostapi runtime closer to what main net runtimes are doing. Will need some additional work on each adapter and potentially upstream as well.