### PR TITLE
gossamer-adapter: Add trie root test

### DIFF
--- a/test/adapters/gossamer/go.mod
+++ b/test/adapters/gossamer/go.mod
@@ -3,7 +3,7 @@ module w3f/gossamer-adapter
 require (
 	github.com/ChainSafe/chaindb v0.1.5-0.20201216022305-705e4f4f2f0d
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816 // indirect
-	github.com/ChainSafe/gossamer v0.2.1-0.20201221145038-bcbb8561fa24
+	github.com/ChainSafe/gossamer v0.2.1-0.20201222150601-3cfd163110ad
 	github.com/DataDog/zstd v1.4.5 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/btcsuite/btcd v0.21.0-beta // indirect

--- a/test/adapters/gossamer/go.sum
+++ b/test/adapters/gossamer/go.sum
@@ -29,8 +29,8 @@ github.com/ChainSafe/chaindb v0.1.5-0.20201216022305-705e4f4f2f0d/go.mod h1:WC1N
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816 h1:X5jJ3e/jgFSnSoYOep/mf6pF1RuLZfvF1ts8NZIyzqE=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/ChainSafe/gossamer v0.2.1-0.20201221145038-bcbb8561fa24 h1:2+YPUUkvR1Y5Brn1wsenkX+nIqcWO3eW7CLOAVfB49o=
-github.com/ChainSafe/gossamer v0.2.1-0.20201221145038-bcbb8561fa24/go.mod h1:+30dav/2Qwmq/DowikC96XZ91bh9At6F5tGTYHMpTiQ=
+github.com/ChainSafe/gossamer v0.2.1-0.20201222150601-3cfd163110ad h1:G0o7wAmjvUi1zCEqIxdlcBUSKd1s6SkX/Cti0nMIj3A=
+github.com/ChainSafe/gossamer v0.2.1-0.20201222150601-3cfd163110ad/go.mod h1:+30dav/2Qwmq/DowikC96XZ91bh9At6F5tGTYHMpTiQ=
 github.com/ChainSafe/log15 v1.0.0 h1:vRDVtWtVwIH5uSCBvgTTZh6FA58UBJ6+QiiypaZfBf8=
 github.com/ChainSafe/log15 v1.0.0/go.mod h1:5v1+ALHtdW0NfAeeoYyKmzCAMcAeqkdhIg4uxXWIgOg=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=

--- a/test/adapters/gossamer/host_api/host_api.go
+++ b/test/adapters/gossamer/host_api/host_api.go
@@ -166,7 +166,8 @@ func ProcessHostApiCommand(args []string) {
 	//case "ext_storage_next_key_version_1":
 
 	// test trie api
-	//case "ext_trie_blake2_256_root_version_1":
+	case "ext_trie_blake2_256_root_version_1":
+		test_trie_root(rtm, inputs[0], inputs[1], inputs[2], inputs[3], inputs[4], inputs[5])
 	case "ext_trie_blake2_256_ordered_root_version_1":
 		test_trie_ordered_root(rtm, inputs[0], inputs[1], inputs[2])
 

--- a/test/adapters/gossamer/host_api/trie.go
+++ b/test/adapters/gossamer/host_api/trie.go
@@ -25,6 +25,38 @@ import (
 	"github.com/ChainSafe/gossamer/lib/scale"
 )
 
+
+func test_trie_root(r runtime.Instance, key1 string, value1 string, key2 string, value2 string, key3 string, value3 string) {
+	// Construct and encode input
+	trie := []string{key1, value1, key2, value2, key3, value3}
+
+	trie_enc, err := scale.Encode(trie)
+	if err != nil {
+		fmt.Println("Encoding input failed: ", err)
+		os.Exit(1)
+	}
+
+	// Change encoding to key-value tuples by fixing encoded list length
+	trie_enc[0] = trie_enc[0] / 2
+
+	// Compute ordered root hash
+	hash_enc, err := r.Exec("rtm_ext_trie_blake2_256_root_version_1", trie_enc)
+
+	if err != nil {
+		fmt.Println("Execution failed: ", err)
+		os.Exit(1)
+	}
+
+	// Decode and print result
+	hash, err := scale.Decode(hash_enc, []byte{})
+	if err != nil {
+		fmt.Println("Decoding value failed: ", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("%x\n", hash.([]byte)[:])
+}
+
 func test_trie_ordered_root(r runtime.Instance, value1 string, value2 string, value3 string) {
 	// Construct and encode input
 	trie := []string{value1, value2, value3}


### PR DESCRIPTION
Adds support for the `ext_trie_blake2_256_root_version_1` test to gossamer-adapter.

Upstream support for this API is sill lacking, so this will be on hold till upstream implements aforementioned API.