### PR TITLE
gossamer-adapter: implement child storage set/get test

### DIFF
--- a/test/adapters/gossamer/host_api/child_storage.go
+++ b/test/adapters/gossamer/host_api/child_storage.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2019 Web3 Technologies Foundation
+
+// This file is part of Polkadot Host Test Suite
+
+// Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot Host Tests is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+
+package host_api
+
+import (
+	"fmt"
+	"os"
+	"bytes"
+
+	"github.com/ChainSafe/gossamer/lib/common/optional"
+	"github.com/ChainSafe/gossamer/lib/runtime"
+	"github.com/ChainSafe/gossamer/lib/scale"
+)
+
+// -- Helpers --
+
+// Helper function to call rtm_ext_default_child_storage_set_version_1
+func child_storage_set(r runtime.Instance, child []byte, key []byte, value []byte) {
+	// Encode inputs
+	child_enc, err := scale.Encode(child)
+	if err != nil {
+		fmt.Println("Encoding child failed: ", err)
+		os.Exit(1)
+	}
+
+	key_enc, err := scale.Encode(key)
+	if err != nil {
+		fmt.Println("Encoding key failed: ", err)
+		os.Exit(1)
+	}
+
+	value_enc, err := scale.Encode(value)
+	if err != nil {
+		fmt.Println("Encoding value failed: ", err)
+		os.Exit(1)
+	}
+
+	args_enc := append(append(child_enc, key_enc...), value_enc...)
+
+	// Set key to value
+	_, err = r.Exec("rtm_ext_default_child_storage_set_version_1", args_enc)
+	if err != nil {
+		fmt.Println("Execution failed: ", err)
+		os.Exit(1)
+	}
+}
+
+// Helper function to call rtm_ext_default_child_storage_get_version_1
+func child_storage_get(r runtime.Instance, child []byte, key []byte) *optional.Bytes {
+	// Encode inputs
+	child_enc, err := scale.Encode(child)
+	if err != nil {
+		fmt.Println("Encoding child failed: ", err)
+		os.Exit(1)
+	}
+
+	key_enc, err := scale.Encode(key)
+	if err != nil {
+		fmt.Println("Encoding key failed: ", err)
+		os.Exit(1)
+	}
+
+	// Retrieve key
+	value_enc, err := r.Exec("rtm_ext_default_child_storage_get_version_1", append(child_enc, key_enc...))
+	if err != nil {
+		fmt.Println("Execution failed: ", err)
+		os.Exit(1)
+	}
+
+	value_opt, err := scale.Decode(value_enc, &optional.Bytes{})
+	if err != nil {
+		fmt.Println("Decoding value failed: ", err)
+		os.Exit(1)
+	}
+	return value_opt.(*optional.Bytes)
+}
+
+// -- Tests --
+
+// Test for rtm_ext_child_storage_set_version_1 and rtm_ext_child_storage_get_version_1
+func test_child_storage_set_get(r runtime.Instance, child1 string, child2 string, key string, value string) {
+	// Get invalid key
+	none1 := child_storage_get(r, []byte(child1), []byte(key))
+
+	if none1.Exists() {
+		fmt.Println("Child1/Key is not empty")
+		os.Exit(1)
+	}
+
+	// Set key to value
+	child_storage_set(r, []byte(child1), []byte(key), []byte(value))
+
+	// Get invalid key (wrong child key)
+	none2 := child_storage_get(r, []byte(child2), []byte(key))
+
+	if none2.Exists() {
+		fmt.Println("Child2/Key is not empty")
+		os.Exit(1)
+	}
+
+	// Get valid key
+	some := child_storage_get(r, []byte(child1), []byte(key))
+
+	if !some.Exists() {
+		fmt.Println("Child1/Key is not set")
+		os.Exit(1)
+	}
+
+	if !bytes.Equal(some.Value(), []byte(value)) {
+		fmt.Printf("Value is different: %s\n", some.Value())
+		os.Exit(1)
+	}
+
+	fmt.Printf("%s\n", some.Value())
+}

--- a/test/adapters/gossamer/host_api/host_api.go
+++ b/test/adapters/gossamer/host_api/host_api.go
@@ -142,8 +142,9 @@ func ProcessHostApiCommand(args []string) {
 		test_allocator_malloc_free(rtm, inputs[0])
 
 	// test child storage api
-	//case "ext_default_child_storage_set_version_1":
-	//case "ext_default_child_storage_get_version_1":
+	case "ext_default_child_storage_set_version_1":
+	case "ext_default_child_storage_get_version_1":
+		test_child_storage_set_get(rtm, inputs[0], inputs[1], inputs[2], inputs[3])
 	//case "ext_default_child_storage_read_version_1":
 	//case "ext_default_child_storage_clear_version_1":
 	//case "ext_default_child_storage_storage_kill_version_1":

--- a/test/adapters/gossamer/host_api/host_api.go
+++ b/test/adapters/gossamer/host_api/host_api.go
@@ -142,9 +142,9 @@ func ProcessHostApiCommand(args []string) {
 		test_allocator_malloc_free(rtm, inputs[0])
 
 	// test child storage api
-	case "ext_default_child_storage_set_version_1":
-	case "ext_default_child_storage_get_version_1":
-		test_child_storage_set_get(rtm, inputs[0], inputs[1], inputs[2], inputs[3])
+	//case "ext_default_child_storage_set_version_1":
+	//case "ext_default_child_storage_get_version_1":
+	//	test_child_storage_set_get(rtm, inputs[0], inputs[1], inputs[2], inputs[3])
 	//case "ext_default_child_storage_read_version_1":
 	//case "ext_default_child_storage_clear_version_1":
 	//case "ext_default_child_storage_storage_kill_version_1":


### PR DESCRIPTION
This implements the most basic child storage test for `ext_default_child_storage_set_version_1` and `ext_default_child_storage_get_version_1`. 

However it fails at the moment because gossamer seems to expect that each child key that is to be used was initialized beforehand with `storage.SetChild(child_key, trie.NewEmptyTrie())` before use, which currently does not happen automatically.

```shell
┌ Error: Adapter failed running `gossamer-adapter host-api --function ext_default_child_storage_get_version_1 --input :child_storage:default:policy,:child_storage:default:full-range,Optional,secondary`:
│ EROR[01-11|19:21:09] [ext_default_child_storage_get_version_1] failed to get child from child storage pkg=runtime module=go-wasmer error="child trie does not exist at key :child_storage:default::child_storage:default:policy" caller=imports.go:498
│ Execution failed:  Failed to call the `rtm_ext_default_child_storage_get_version_1` exported function.
└ @ Main.SpecificationTestsuite.AdapterFixture ~/work/polkadot-spec/polkadot-spec/test/helpers/AdapterFixture.jl:157
```
