### PR TITLE
kagome-adapter: add disabled set/get child storage test

### DIFF
--- a/test/adapters/kagome/src/host_api.cpp
+++ b/test/adapters/kagome/src/host_api.cpp
@@ -126,16 +126,18 @@ void processHostApiCommands(const HostApiCommandArgs &args) {
                          storage::processNextKey(args[0], args[1], args[2], args[3]);
                        });
 
-  // test child storage TODO: all not implemented
+  // test child storage (currentyl no upstream support)
   router.addSubcommand("ext_default_child_storage_set_version_1",
                        [](const std::vector<std::string> &args) {
                          BOOST_ASSERT(args.size() == 4);
-                         child_storage::processSetGet(args[0], args[1], args[2], args[3]);
+                         //child_storage::processSetGet(args[0], args[1], args[2], args[3]);
+                         throw NotImplemented(); // Child storage not implemented upstream
                        });
   router.addSubcommand("ext_default_child_storage_get_version_1",
                        [](const std::vector<std::string> &args) {
                          BOOST_ASSERT(args.size() == 4);
-                         child_storage::processSetGet(args[0], args[1], args[2], args[3]);
+                         //child_storage::processSetGet(args[0], args[1], args[2], args[3]);
+                         throw NotImplemented(); // Child storage not implemented upstream
                        });
   router.addSubcommand("ext_default_child_storage_read_version_1",
                        [](const std::vector<std::string> &args) {

--- a/test/adapters/kagome/src/host_api.cpp
+++ b/test/adapters/kagome/src/host_api.cpp
@@ -129,11 +129,13 @@ void processHostApiCommands(const HostApiCommandArgs &args) {
   // test child storage TODO: all not implemented
   router.addSubcommand("ext_default_child_storage_set_version_1",
                        [](const std::vector<std::string> &args) {
-                         throw NotImplemented(); // TODO not implemented
+                         BOOST_ASSERT(args.size() == 4);
+                         child_storage::processSetGet(args[0], args[1], args[2], args[3]);
                        });
   router.addSubcommand("ext_default_child_storage_get_version_1",
                        [](const std::vector<std::string> &args) {
-                         throw NotImplemented(); // TODO not implemented
+                         BOOST_ASSERT(args.size() == 4);
+                         child_storage::processSetGet(args[0], args[1], args[2], args[3]);
                        });
   router.addSubcommand("ext_default_child_storage_read_version_1",
                        [](const std::vector<std::string> &args) {

--- a/test/adapters/kagome/src/host_api/child_storage.cpp
+++ b/test/adapters/kagome/src/host_api/child_storage.cpp
@@ -19,8 +19,51 @@
 
 #include "child_storage.hpp"
 
-// TODO update and implement module
+#include "helpers.hpp"
+
+#include <iostream>
+
 namespace child_storage {
+
+  void processSetGet(
+    const std::string_view child1, const std::string_view child2,
+    const std::string_view key, const std::string_view value
+  ) {
+    helpers::RuntimeEnvironment environment;
+
+    // Check that key has not been set
+    auto result = environment.execute<helpers::MaybeBuffer>(
+      "rtm_ext_default_child_storage_get_version_1", child1, key
+    );
+
+    BOOST_ASSERT_MSG(!result, "Child1 data exists");
+
+    // Add data to storage
+    environment.execute<void>(
+      "rtm_ext_default_child_storage_set_version_1", child1, key, value
+    );
+
+    // Check that key has not been set
+    result = environment.execute<helpers::MaybeBuffer>(
+      "rtm_ext_default_child_storage_get_version_1", child2, key
+    );
+
+    BOOST_ASSERT_MSG(!result, "Child2 data exists");
+
+    // Retrieve data from storage
+    result = environment.execute<helpers::MaybeBuffer>(
+      "rtm_ext_default_child_storage_get_version_1", child1, key
+    );
+
+    // Check returned data
+    BOOST_ASSERT_MSG(result.has_value(), "No value");
+    BOOST_ASSERT_MSG(result.value().toString() == value, "Values are different");
+
+    // Print result
+    std::cout << result.value().toString() << std::endl;
+  }
+
+
   // Input: prefix, child1, child2, key1, value1, key2, value2
   void processExtClearChildPrefix(const std::vector<std::string> &args){}
 
@@ -32,7 +75,4 @@ namespace child_storage {
 
   // Input: child1, child2, key, value
   void processExtKillChildStorage(const std::vector<std::string> &args){}
-
-  // Input: child1, child2, key, value
-  void processExtSetGetChildStorage(const std::vector<std::string> &args){}
 }

--- a/test/adapters/kagome/src/host_api/child_storage.hpp
+++ b/test/adapters/kagome/src/host_api/child_storage.hpp
@@ -24,6 +24,14 @@
 
 // TODO update and implement module
 namespace child_storage {
+  // executes ext_default_child_storage_set_version_1 and
+  // ext_default_child storage_get_version_1 test
+  void processSetGet(
+    const std::string_view child1, const std::string_view child2,
+    const std::string_view key, const std::string_view value
+  );
+
+
   // executes ext_clear_child_prefix tests according to provided args
   // Input: prefix, child1, child2, key1, value1, key2, value2
   // not implemented
@@ -43,9 +51,4 @@ namespace child_storage {
   // Input: child1, child2, key, value
   // not implemented
   void processExtKillChildStorage(const std::vector<std::string> &args);
-
-  // executes ext_get_allocated_child_storage and ext_set_child_storage tests according to provided args
-  // Input: child1, child2, key, value
-  // not implemented
-  void processExtSetGetChildStorage(const std::vector<std::string> &args);
 } // namespace storage


### PR DESCRIPTION
This PR adds the set and get child storage test for kagome. The child storage API is currently not implemented upstream, so it is just disabled for now.