### PR TITLE
ci: upload runtime-spec diff to seperate artifact

### DIFF
--- a/.github/workflows/specification.yml
+++ b/.github/workflows/specification.yml
@@ -159,7 +159,7 @@ jobs:
     - name: Upload runtime specification diff
       uses: actions/upload-artifact@v1
       with:
-        name: polkadot-runtime-spec.pdf
+        name: polkadot-runtime-spec.diff.pdf
         path: runtime-spec/polkadot-runtime-spec.diff.pdf
     - name: Release runtime specification diff
       uses: actions/upload-release-asset@v1


### PR DESCRIPTION
This fixes a "copy-and-waste" error in the CI config, which should result in runtime spec and diff being provided in separate artifacts, as initially intended.