### PR TITLE
ci: copy releases to github pages

### DIFF
--- a/.github/workflows/specification.yml
+++ b/.github/workflows/specification.yml
@@ -171,3 +171,39 @@ jobs:
         asset_name: polkadot-runtime-spec_${{ github.event.release.tag_name }}.diff_${{ env.REV }}.pdf
         asset_content_type: application/pdf
       if: github.event_name == 'release'
+
+
+  release-pages:
+    needs: [ build-spec-host, build-spec-runtime ]
+    name: Publish release on GitHub Pages
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'release'
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: gh-pages
+    - uses: actions/download-artifact@v1
+      with:
+        name: polkadot-host-spec.pdf
+        path: .
+    - uses: actions/download-artifact@v1
+      with:
+        name: polkadot-runtime-spec.pdf
+        path: .
+    - name: Replace latest release cache file
+      run: |
+        mv polkadot-host-spec.pdf spec/host/latest.pdf
+        mv polkadot-runtime-spec.pdf spec/runtime/latest.pdf
+      if: ${{ ! github.event.release.prerelease }}
+    - name: Replace latest pre-release cache file
+      run: |
+        mv polkadot-host-spec.pdf spec/host/nightly.pdf
+        mv polkadot-runtime-spec.pdf spec/runtime/nightly.pdf
+      if: ${{ github.event.release.prerelease }}
+    - name: Commit and push updated GitHub Pages branch
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add spec/
+        git commit --amend -m "Update specification cache"
+        git push -f


### PR DESCRIPTION
This addition to the CI workflow copies the latest build over to the `gh-pages` branch in preparation to embedded the latest spec on the research page (#28) automatically.

I tested this on my fork and it works as expected, see results [here](https://florianfranzen.github.io/polkadot-spec/).

Releases will be copied to https://w3f.github.io/polkadot-spec/spec/host/latest.pdf, pre-releases to https://w3f.github.io/polkadot-spec/spec/host/nightly.pdf and similar path exists for the runtime spec.