### PR TITLE
runtime-spec: Fix build of latexdiff results

### DIFF
--- a/runtime-spec/Makefile
+++ b/runtime-spec/Makefile
@@ -29,6 +29,8 @@ $(REVDIR):
 
 polkadot-runtime-spec.diff.tex: $(SOURCES) $(REVDIR)
 	latexdiff --flatten "$(REVDIR)/runtime-spec.tex" "$$PWD/runtime-spec.tex" > $@
+	# Remove diff on alignat column count (causes crash)
+	sed -i 's@\\begin{alignat\*}{\\DIFadd{\([0-9]\+\)}}@\\begin{alignat\*}{\1}@g' $@
 
 polkadot-runtime-spec.diff.pdf: polkadot-runtime-spec.diff.tex
 	latexmk -pdflua $<

--- a/runtime-spec/c02-weights.tex
+++ b/runtime-spec/c02-weights.tex
@@ -1089,4 +1089,4 @@ next\ weight &=& weight \times (1 + (v \times diff) + (v \times diff)^2 / 2)\\
 
 Polkadot defines the \verb|target_weight| as 0.25 (25\%). More information about
 this algorithm is described in the Web3 Foundation research paper:
-\url{https://research.web3.foundation/en/latest/polkadot/Token%20Economics.html#relay-chain-transaction-fees-and-per-block-transaction-limits}.
+\url{https://research.web3.foundation/en/latest/polkadot/Token\%20Economics.html#relay-chain-transaction-fees-and-per-block-transaction-limits}.


### PR DESCRIPTION
This is the result of an investigation into the latexdiff build failures of the runtime-spec:

 - Fixes an incorrectly escaped url
 - Removes diffs of changes to alignat column counts