### PR TITLE
gossamer-adapter: enable sha2 hashing test

### DIFF
--- a/test/adapters/gossamer/go.mod
+++ b/test/adapters/gossamer/go.mod
@@ -3,7 +3,7 @@ module w3f/gossamer-adapter
 require (
 	github.com/ChainSafe/chaindb v0.1.5-0.20201216022305-705e4f4f2f0d
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816 // indirect
-	github.com/ChainSafe/gossamer v0.2.1-0.20201222150601-3cfd163110ad
+	github.com/ChainSafe/gossamer v0.2.1-0.20210112165754-0767e0043e03
 	github.com/DataDog/zstd v1.4.5 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/btcsuite/btcd v0.21.0-beta // indirect

--- a/test/adapters/gossamer/go.sum
+++ b/test/adapters/gossamer/go.sum
@@ -29,8 +29,8 @@ github.com/ChainSafe/chaindb v0.1.5-0.20201216022305-705e4f4f2f0d/go.mod h1:WC1N
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816 h1:X5jJ3e/jgFSnSoYOep/mf6pF1RuLZfvF1ts8NZIyzqE=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200626160457-b38283118816/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/ChainSafe/gossamer v0.2.1-0.20201222150601-3cfd163110ad h1:G0o7wAmjvUi1zCEqIxdlcBUSKd1s6SkX/Cti0nMIj3A=
-github.com/ChainSafe/gossamer v0.2.1-0.20201222150601-3cfd163110ad/go.mod h1:+30dav/2Qwmq/DowikC96XZ91bh9At6F5tGTYHMpTiQ=
+github.com/ChainSafe/gossamer v0.2.1-0.20210112165754-0767e0043e03 h1:ekqxpz7QxdHnpFC+dPpgfjS44KIHpP/cZVdXUirQSqs=
+github.com/ChainSafe/gossamer v0.2.1-0.20210112165754-0767e0043e03/go.mod h1:rdEo9OLZwI68/Meyysm3s9YbUVXD0Xpmcgsqo9EXTUI=
 github.com/ChainSafe/log15 v1.0.0 h1:vRDVtWtVwIH5uSCBvgTTZh6FA58UBJ6+QiiypaZfBf8=
 github.com/ChainSafe/log15 v1.0.0/go.mod h1:5v1+ALHtdW0NfAeeoYyKmzCAMcAeqkdhIg4uxXWIgOg=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=

--- a/test/adapters/gossamer/host_api/host_api.go
+++ b/test/adapters/gossamer/host_api/host_api.go
@@ -147,7 +147,7 @@ func ProcessHostApiCommand(args []string) {
 	case "ext_hashing_blake2_128_version_1",
 	     "ext_hashing_blake2_256_version_1",
 	     "ext_hashing_keccak_256_version_1",
-	//     "ext_hashing_sha2_256_version_1",
+	     "ext_hashing_sha2_256_version_1",
 	     "ext_hashing_twox_64_version_1",
 	     "ext_hashing_twox_128_version_1",
 	     "ext_hashing_twox_256_version_1":


### PR DESCRIPTION
This PR enables the testing of the the `ext_hashing_sha2_256_version_1` host API.