### PR TITLE
ci: only run on push events on master

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,16 +2,8 @@ name: Integration Testsuite
 
 on:
   push:
-    paths:
-    - '.github/workflows/integration.yml'
-    - 'test/**'
-    - '!test/adapters/**'
-    - 'test/adapters/substrate/**'
-    - '!test/fixtures/**'
-    - 'test/fixtures/genesis/**'
-    - '!test/helpers/AdapterFixture.jl'
-    - '!test/runtimes/hostapi/**'
-    - '!test/README.md'
+    branches:
+    - master
   pull_request:
     paths:
     - '.github/workflows/integration.yml'

--- a/.github/workflows/specification.yml
+++ b/.github/workflows/specification.yml
@@ -2,11 +2,8 @@ name: Specification Publication
 
 on:
   push:
-    paths:
-    - '.github/workflows/specification.yml'
-    - '.github/apt-texmacs.asc'
-    - 'host-spec/**'
-    - 'runtime-spec/**'
+    branches:
+    - master
   pull_request:
     paths:
     - '.github/workflows/specification.yml'

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -2,14 +2,8 @@ name: Conformance Testsuite
 
 on:
   push:
-    paths:
-    - '.github/workflows/testsuite.yml'
-    - 'test/**'
-    - '!test/fixtures/genesis/**'
-    - '!test/helpers/ImplementationFixture.jl'
-    - '!test/runtimes/tester/**'
-    - '!test/hosts/**'
-    - '!test/README.md'
+    branches:
+    - master
   pull_request:
     paths:
     - '.github/workflows/testsuite.yml'


### PR DESCRIPTION
Currently we run the CI for pushes to any branch. That means if we open a pull-request from one of our branches to master (which is our default workflow), the CI is run twice, once for the PR and ones for the push to the associated branch.

This PR changes that, by only running for pushes to the master branch. It also removes the filter list for pushes, which means that all workflows always run for pushes to master, which I think makes sense to detect any potential issues. 

If you find it useful to have the Ci run for some of the branches you work on, we could also add wildcards for that, e.g. `staging/**` or similar. This would then mean that you would have to rename the branch before you open a PR to avoid running the CI twice. So not really a perfect solution. It seems however that GitHub can not detect that a push is part of an open PR at the moment.