### PR TITLE
ci: run testsuite on submodule update

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -11,7 +11,8 @@ on:
     - '!test/fixtures/genesis/**'
     - '!test/helpers/ImplementationFixture.jl'
     - '!test/runtimes/tester/**'
-    - '!test/hosts/**'
+    - '!test/hosts/Makefile'
+    - '!test/hosts/substrate'
     - '!test/README.md'
 
 jobs:


### PR DESCRIPTION
With the submodule update in #338, we  now need to run the testsuite workflow when the gossamer or kagome submodule updates.