### PR TITLE
Overhaul Runtime API section

### DIFF
--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -932,7 +932,7 @@
   <\itemize-dot>
     <item>A SCALE encoded <verbatim|Option> as defined in Definition
     <reference|defn-option-type> containing an array of varying size
-    representing the seed.
+    indicating the seed.
   </itemize-dot>
 
   \;
@@ -940,12 +940,38 @@
   <strong|Return>:
 
   <\itemize-dot>
-    <item>An array of varying size containg the session keys.
+    <item>An array of varying size containg the encoded session keys.
   </itemize-dot>
 
   <subsection|<verbatim|SessionKeys_decode_session_keys>>
 
+  Decodes the given public session keys. Returns a list of raw public keys
+  including key type.
+
   \;
+
+  <strong|Arguments>:
+
+  <\itemize-dot>
+    <item>An array of varying size containing the encoded public session
+    keys.
+  </itemize-dot>
+
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>An array of varying size containg tuple pairs of the following
+    format:
+
+    <\equation*>
+      <around*|(|k,k<rsub|id>|)>
+    </equation*>
+
+    where <math|k> is an array of varying size containg the raw public key
+    and <math|k<rsub|id>> is a 4-byte array indicating the key type.
+  </itemize-dot>
 
   <subsection|<verbatim|AccountNonceApi_account_nonce>>
 
@@ -1069,6 +1095,7 @@
     <associate|sect-rte-grandpa-auth|<tuple|A.2.25|109>>
     <associate|sect-rte-validate-transaction|<tuple|A.2.10|109>>
     <associate|sect-runtime-entries|<tuple|A|107>>
+    <associate|sect-sessionkeys_generate_session_keys|<tuple|A.2.35|?>>
     <associate|snippet-runtime-enteries|<tuple|A.1|107>>
   </collection>
 </references>

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -571,59 +571,59 @@
 
   <subsection|<verbatim|OffchainWorkerApi_offchain_worker>>
 
-  \;
+  \ <todo|future-reserved>
 
   <subsection|<verbatim|ParachainHost_validators>>
 
-  \;
+  <todo|future-reserved>
 
   <subsection|<verbatim|ParachainHost_validator_groups>>
 
-  \;
+  <todo|future-reserved>
 
   <subsection|<verbatim|ParachainHost_availability_cores>>
 
-  \;
+  <todo|future-reserved>
 
   <subsection|<verbatim|ParachainHost_persisted_validation_data>>
 
-  \;
+  <todo|future-reserved>
 
   <subsection|<verbatim|ParachainHost_check_validation_outputs>>
 
-  \;
+  <todo|future-reserved>
 
   <subsection|<verbatim|ParachainHost_session_index_for_child>>
 
-  \;
+  <todo|future-reserved>
 
   <subsection|<verbatim|ParachainHost_session_info>>
 
-  \;
+  <todo|future-reserved>
 
   <subsection|<verbatim|ParachainHost_validation_code>>
 
-  \;
+  <todo|future-reserved>
 
   <subsection|<verbatim|ParachainHost_historical_validation_code>>
 
-  \;
+  <todo|future-reserved>
 
   <subsection|<verbatim|ParachainHost_candidate_pending_availability>>
 
-  \;
+  <todo|future-reserved>
 
   <subsection|<verbatim|ParachainHost_candidate_events>>
 
-  \;
+  <todo|future-reserved>
 
   <subsection|<verbatim|ParachainHost_dmq_contents>>
 
-  \;
+  <todo|future-reserved>
 
   <subsection|<verbatim|ParachainHost_inbound_hrmp_channel_contents>>
 
-  \;
+  <todo|future-reserved>
 
   <subsection|<verbatim|GrandpaApi_grandpa_authorities>><label|sect-rte-grandpa-auth>
 
@@ -635,7 +635,28 @@
 
   <subsection|<verbatim|GrandpaApi_submit_report_equivocation_unsigned_extrinsic>>
 
+  Submits a report about an observed equivocation as defined in Definition
+  <reference|defn-equivocation>.
+
   \;
+
+  <strong|Arguments>:
+
+  <\itemize-dot>
+    <item>The equivocation proof. <todo|reference that type>
+
+    <item>An opaque byte slice used to represent the key ownership proof.
+  </itemize-dot>
+
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>A SCALE encoded <verbatim|Option> as defined in Definition
+    <reference|defn-option-type> containing an empty <verbatim|Some> value on
+    success or <verbatim|None> on failure.
+  </itemize-dot>
 
   <subsection|<verbatim|GrandpaApi_generate_key_ownership_proof>>
 
@@ -686,10 +707,6 @@
   </big-table>
 
   <subsection|<verbatim|BabeApi_current_epoch_start>>
-
-  \;
-
-  <subsection|<verbatim|BabeApi_current_epoch>>
 
   \;
 
@@ -814,8 +831,6 @@
     <associate|auto-54|<tuple|A.2.37|?>>
     <associate|auto-55|<tuple|A.2.38|?>>
     <associate|auto-56|<tuple|A.2.39|?>>
-    <associate|auto-57|<tuple|A.2.40|?>>
-    <associate|auto-58|<tuple|A.2.41|?>>
     <associate|auto-6|<tuple|A.1|108>>
     <associate|auto-7|<tuple|A.2.2|108>>
     <associate|auto-8|<tuple|A.2.3|108>>
@@ -839,7 +854,6 @@
     <associate|sect-rte-babeapi-epoch|<tuple|A.2.28|109>>
     <associate|sect-rte-core-execute-block|<tuple|A.2.2|?>>
     <associate|sect-rte-grandpa-auth|<tuple|A.2.25|109>>
-    <associate|sect-rte-hash-and-length|<tuple|A.2.5|109>>
     <associate|sect-rte-validate-transaction|<tuple|A.2.10|109>>
     <associate|sect-runtime-entries|<tuple|A|107>>
     <associate|snippet-runtime-enteries|<tuple|A.1|107>>
@@ -859,62 +873,62 @@
       function.>|<pageref|auto-6>>
 
       <tuple|normal|<\surround|<hidden-binding|<tuple>|A.2>|>
-        The tuple provided by <with|font-series|<quote|bold>|math-font-series|<quote|bold>|BabeApi_configuration>.
+        Possible values of varying data type
+        <with|font-series|<quote|bold>|math-font-series|<quote|bold>|ApplyExtrinsicResult>.
       </surround>|<pageref|auto-11>>
 
       <tuple|normal|<\surround|<hidden-binding|<tuple>|A.3>|>
-        The tuple provided by <with|font-family|<quote|tt>|language|<quote|verbatim>|TaggedTransactionQueue_transaction_validity>
+        Possible values of varying data type
+        <with|font-series|<quote|bold>|math-font-series|<quote|bold>|DispatchOutcome>.
+      </surround>|<pageref|auto-12>>
 
-        in the case the transaction is judged to be valid.
-      </surround>|<pageref|auto-14>>
-
-      <tuple|normal|<surround|<hidden-binding|<tuple>|A.4>||Type variation
-      for the return value of <with|font-family|<quote|tt>|language|<quote|verbatim>|TaggedTransactionQueue_transaction_validity>.>|<pageref|auto-15>>
+      <tuple|normal|<\surround|<hidden-binding|<tuple>|A.4>|>
+        Possible values of varying data type
+        <with|font-series|<quote|bold>|math-font-series|<quote|bold>|DispatchError>.
+      </surround>|<pageref|auto-13>>
 
       <tuple|normal|<\surround|<hidden-binding|<tuple>|A.5>|>
-        Type variant whichs gets appended to Id 0 of
-        <with|font-series|<quote|bold>|math-font-series|<quote|bold>|TransactionValidityError>.
-      </surround>|<pageref|auto-16>>
+        Possible values of varying data type
+        <with|font-series|<quote|bold>|math-font-series|<quote|bold>|CustomModuleError>.
+      </surround>|<pageref|auto-14>>
 
       <tuple|normal|<\surround|<hidden-binding|<tuple>|A.6>|>
-        Type variant whichs gets appended to Id 1 of
+        Possible values of varying data type
         <with|font-series|<quote|bold>|math-font-series|<quote|bold>|TransactionValidityError>.
-      </surround>|<pageref|auto-17>>
+      </surround>|<pageref|auto-15>>
 
       <tuple|normal|<\surround|<hidden-binding|<tuple>|A.7>|>
         Possible values of varying data type
-        <with|font-series|<quote|bold>|math-font-series|<quote|bold>|ApplyExtrinsicResult>.
-      </surround>|<pageref|auto-19>>
+        <with|font-series|<quote|bold>|math-font-series|<quote|bold>|InvalidTransaction>.
+      </surround>|<pageref|auto-16>>
 
       <tuple|normal|<\surround|<hidden-binding|<tuple>|A.8>|>
         Possible values of varying data type
-        <with|font-series|<quote|bold>|math-font-series|<quote|bold>|DispatchOutcome>.
-      </surround>|<pageref|auto-20>>
+        <with|font-series|<quote|bold>|math-font-series|<quote|bold>|UnknownTransaction>.
+      </surround>|<pageref|auto-17>>
 
       <tuple|normal|<\surround|<hidden-binding|<tuple>|A.9>|>
-        Possible values of varying data type
-        <with|font-series|<quote|bold>|math-font-series|<quote|bold>|DispatchError>.
-      </surround>|<pageref|auto-21>>
+        The tuple provided by <with|font-family|<quote|tt>|language|<quote|verbatim>|TaggedTransactionQueue_transaction_validity>
 
-      <tuple|normal|<\surround|<hidden-binding|<tuple>|A.10>|>
-        Possible values of varying data type
-        <with|font-series|<quote|bold>|math-font-series|<quote|bold>|CustomModuleError>.
-      </surround>|<pageref|auto-22>>
-
-      <tuple|normal|<\surround|<hidden-binding|<tuple>|A.11>|>
-        Possible values of varying data type
-        <with|font-series|<quote|bold>|math-font-series|<quote|bold>|TransactionValidityError>.
+        in the case the transaction is judged to be valid.
       </surround>|<pageref|auto-23>>
 
+      <tuple|normal|<surround|<hidden-binding|<tuple>|A.10>||Type variation
+      for the return value of <with|font-family|<quote|tt>|language|<quote|verbatim>|TaggedTransactionQueue_transaction_validity>.>|<pageref|auto-24>>
+
+      <tuple|normal|<\surround|<hidden-binding|<tuple>|A.11>|>
+        Type variant whichs gets appended to Id 0 of
+        <with|font-series|<quote|bold>|math-font-series|<quote|bold>|TransactionValidityError>.
+      </surround>|<pageref|auto-25>>
+
       <tuple|normal|<\surround|<hidden-binding|<tuple>|A.12>|>
-        Possible values of varying data type
-        <with|font-series|<quote|bold>|math-font-series|<quote|bold>|InvalidTransaction>.
-      </surround>|<pageref|auto-24>>
+        Type variant whichs gets appended to Id 1 of
+        <with|font-series|<quote|bold>|math-font-series|<quote|bold>|TransactionValidityError>.
+      </surround>|<pageref|auto-26>>
 
       <tuple|normal|<\surround|<hidden-binding|<tuple>|A.13>|>
-        Possible values of varying data type
-        <with|font-series|<quote|bold>|math-font-series|<quote|bold>|UnknownTransaction>.
-      </surround>|<pageref|auto-25>>
+        The tuple provided by <with|font-series|<quote|bold>|math-font-series|<quote|bold>|BabeApi_configuration>.
+      </surround>|<pageref|auto-45>>
     </associate>
     <\associate|toc>
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|Appendix
@@ -941,33 +955,149 @@
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-8>>
 
-      <with|par-left|<quote|1tab>|A.2.4<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|hash_and_length>
+      <with|par-left|<quote|1tab>|A.2.4<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|Metadata_metadatabb>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-9>>
 
-      <with|par-left|<quote|1tab>|A.2.5<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|BabeApi_configuration>
+      <with|par-left|<quote|1tab>|A.2.5<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|BlockBuilder_apply_extrinsic>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-10>>
 
-      <with|par-left|<quote|1tab>|A.2.6<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|GrandpaApi_grandpa_authorities>
-      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-12>>
-
-      <with|par-left|<quote|1tab>|A.2.7<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|TaggedTransactionQueue_validate_transaction>
-      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-13>>
-
-      <with|par-left|<quote|1tab>|A.2.8<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|BlockBuilder_apply_extrinsic>
+      <with|par-left|<quote|1tab>|A.2.6<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|BlockBuilder_finalize_block>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-18>>
 
-      <with|par-left|<quote|1tab>|A.2.9<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|BlockBuilder_inherent_extrinsics>
+      <with|par-left|<quote|1tab>|A.2.7<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|BlockBuilder_inherent_extrinsics>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-26>>
+      <no-break><pageref|auto-19>>
 
-      <with|par-left|<quote|1tab>|A.2.10<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|BlockBuilder_finalize_block>
+      <with|par-left|<quote|1tab>|A.2.8<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|BlockBuilder_check_inherents>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-20>>
+
+      <with|par-left|<quote|1tab>|A.2.9<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|BlockBuilder_random_seed>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-21>>
+
+      <with|par-left|<quote|1tab>|A.2.10<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|TaggedTransactionQueue_validate_transaction>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-22>>
+
+      <with|par-left|<quote|1tab>|A.2.11<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|OffchainWorkerApi_offchain_worker>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-27>>
+
+      <with|par-left|<quote|1tab>|A.2.12<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ParachainHost_validators>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-28>>
+
+      <with|par-left|<quote|1tab>|A.2.13<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ParachainHost_validator_groups>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-29>>
+
+      <with|par-left|<quote|1tab>|A.2.14<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ParachainHost_availability_cores>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-30>>
+
+      <with|par-left|<quote|1tab>|A.2.15<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ParachainHost_persisted_validation_data>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-31>>
+
+      <with|par-left|<quote|1tab>|A.2.16<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ParachainHost_check_validation_outputs>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-32>>
+
+      <with|par-left|<quote|1tab>|A.2.17<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ParachainHost_session_index_for_child>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-33>>
+
+      <with|par-left|<quote|1tab>|A.2.18<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ParachainHost_session_info>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-34>>
+
+      <with|par-left|<quote|1tab>|A.2.19<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ParachainHost_validation_code>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-35>>
+
+      <with|par-left|<quote|1tab>|A.2.20<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ParachainHost_historical_validation_code>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-36>>
+
+      <with|par-left|<quote|1tab>|A.2.21<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ParachainHost_candidate_pending_availability>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-37>>
+
+      <with|par-left|<quote|1tab>|A.2.22<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ParachainHost_candidate_events>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-38>>
+
+      <with|par-left|<quote|1tab>|A.2.23<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ParachainHost_dmq_contents>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-39>>
+
+      <with|par-left|<quote|1tab>|A.2.24<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|ParachainHost_inbound_hrmp_channel_contents>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-40>>
+
+      <with|par-left|<quote|1tab>|A.2.25<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|GrandpaApi_grandpa_authorities>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-41>>
+
+      <with|par-left|<quote|1tab>|A.2.26<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|GrandpaApi_submit_report_equivocation_unsigned_extrinsic>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-42>>
+
+      <with|par-left|<quote|1tab>|A.2.27<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|GrandpaApi_generate_key_ownership_proof>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-43>>
+
+      <with|par-left|<quote|1tab>|A.2.28<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|BabeApi_configuration>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-44>>
+
+      <with|par-left|<quote|1tab>|A.2.29<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|BabeApi_current_epoch_start>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-46>>
+
+      <with|par-left|<quote|1tab>|A.2.30<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|BabeApi_current_epoch>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-47>>
+
+      <with|par-left|<quote|1tab>|A.2.31<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|BabeApi_next_epoch>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-48>>
+
+      <with|par-left|<quote|1tab>|A.2.32<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|BabeApi_generate_key_ownership_proof>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-49>>
+
+      <with|par-left|<quote|1tab>|A.2.33<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|BabeApi_submit_report_equivocation_unsigned_extrinsic>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-50>>
+
+      <with|par-left|<quote|1tab>|A.2.34<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|AuthorityDiscoveryApi_authorities>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-51>>
+
+      <with|par-left|<quote|1tab>|A.2.35<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|SessionKeys_generate_session_keys>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-52>>
+
+      <with|par-left|<quote|1tab>|A.2.36<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|SessionKeys_decode_session_keys>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-53>>
+
+      <with|par-left|<quote|1tab>|A.2.37<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|AccountNonceApi_account_nonce>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-54>>
+
+      <with|par-left|<quote|1tab>|A.2.38<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|TransactionPaymentApi_query_info>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-55>>
+
+      <with|par-left|<quote|1tab>|A.2.39<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|TransactionPaymentApi_query_fee_details>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-56>>
     </associate>
   </collection>
 </auxiliary>

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -254,203 +254,6 @@
     form.
   </itemize-dot>
 
-  <subsection|<verbatim|hash_and_length>><label|sect-rte-hash-and-length>
-
-  An auxilarry function which returns hash and encoding length of an
-  extrinsics.
-
-  \;
-
-  <strong|Arguments>:
-
-  <\itemize>
-    <item>A blob of an extrinsic.
-  </itemize>
-
-  <verbatim|>
-
-  <strong|Return>:
-
-  <\itemize-dot>
-    <item>Pair of Blake2Hash of the blob as element of
-    <math|\<bbb-B\><rsub|32>> and its length as 64 bit integer.
-  </itemize-dot>
-
-  <subsection|<verbatim|BabeApi_configuration>><label|sect-rte-babeapi-epoch>
-
-  This entry is called to obtain the current configuration of BABE consensus
-  protocol.
-
-  \;
-
-  <strong|Arguments>:
-
-  <\itemize>
-    <item>None
-  </itemize>
-
-  \;
-
-  <strong|Return>:
-
-  A tuple containing configuration data used by the Babe consensus engine.
-
-  <\big-table|<tabular|<tformat|<cwith|1|1|1|-1|cell-tborder|1ln>|<cwith|1|1|1|1|cell-lborder|0ln>|<cwith|1|1|3|3|cell-rborder|0ln>|<cwith|18|18|1|-1|cell-bborder|1ln>|<cwith|2|-1|1|1|cell-lborder|0ln>|<cwith|2|-1|3|3|cell-rborder|0ln>|<cwith|2|2|1|-1|cell-tborder|1ln>|<cwith|1|1|1|-1|cell-bborder|1ln>|<cwith|2|4|1|1|cell-lborder|0ln>|<cwith|2|4|3|3|cell-rborder|0ln>|<cwith|5|5|1|-1|cell-tborder|1ln>|<cwith|4|4|1|-1|cell-bborder|1ln>|<cwith|5|6|1|1|cell-lborder|0ln>|<cwith|5|6|3|3|cell-rborder|0ln>|<cwith|7|7|1|-1|cell-tborder|1ln>|<cwith|6|6|1|-1|cell-bborder|1ln>|<cwith|7|10|1|1|cell-lborder|0ln>|<cwith|7|10|3|3|cell-rborder|0ln>|<cwith|11|11|1|-1|cell-tborder|1ln>|<cwith|10|10|1|-1|cell-bborder|1ln>|<cwith|11|15|1|1|cell-lborder|0ln>|<cwith|11|15|3|3|cell-rborder|0ln>|<cwith|16|16|1|-1|cell-tborder|1ln>|<cwith|15|15|1|-1|cell-bborder|1ln>|<cwith|16|16|1|-1|cell-bborder|1ln>|<cwith|17|17|1|-1|cell-tborder|1ln>|<cwith|16|16|1|1|cell-lborder|0ln>|<cwith|16|16|3|3|cell-rborder|0ln>|<table|<row|<cell|<strong|Name>>|<cell|<strong|Description>>|<cell|<strong|Type>>>|<row|<cell|SlotDuration>|<cell|The
-  slot duration in milliseconds. Currently, only the value
-  provided>|<cell|Unsigned 64bit>>|<row|<cell|>|<cell|by this type at genesis
-  will be used. Dynamic slot duration may
-  be>|<cell|integer>>|<row|<cell|>|<cell|supported in the
-  future.>|<cell|>>|<row|<cell|EpochLength>|<cell|The duration of epochs in
-  slots.>|<cell|Unsigned 64bit>>|<row|<cell|>|<cell|>|<cell|integer>>|<row|<cell|Constant>|<cell|A
-  constant value that is used in the threshold calculation
-  formula>|<cell|Tuple containing>>|<row|<cell|>|<cell|as defined in
-  definition <reference|defn-babe-constant>.>|<cell|two
-  unsigned>>|<row|<cell|>|<cell|>|<cell|64bit
-  integers>>|<row|<cell|>|<cell|>|<cell|>>|<row|<cell|Genesis>|<cell|The
-  authority list for the genesis epoch as defined in Definition
-  <reference|defn-authority-list>. >|<cell|Array of
-  tuples>>|<row|<cell|Authorities>|<cell|>|<cell|containing a
-  256-bit>>|<row|<cell|>|<cell|>|<cell|byte array and
-  a>>|<row|<cell|>|<cell|>|<cell|unsigned
-  64bit>>|<row|<cell|>|<cell|>|<cell|integer>>|<row|<cell|Randomness>|<cell|The
-  randomness for the genesis epoch>|<cell|32-byte
-  array>>|<row|<cell|SecondarySlot>|<cell|Whether this chain should run with
-  secondary slots and wether>|<cell|8bit enum>>|<row|<cell|>|<cell|they are
-  assigned in a round-robin manner or via a second VRF.>|<cell|>>>>>>
-    The tuple provided by <strong|BabeApi_configuration>.
-  </big-table>
-
-  <subsection|<verbatim|GrandpaApi_grandpa_authorities>><label|sect-rte-grandpa-auth>
-
-  This entry fetches the list of GRANDPA authorities according to the genesis
-  block and is used to initialize authority list defined in Definition
-  <reference|defn-authority-list>, at genisis. Any future authority changes
-  get tracked via Runtiem-to-consensus engine messages as described in
-  Section <reference|sect-consensus-message-digest>.
-
-  <subsection|<verbatim|TaggedTransactionQueue_validate_transaction>><label|sect-rte-validate-transaction>
-
-  This entry is invoked against extrinsics submitted through the transaction
-  network message <reference|sect-msg-transactions> and indicates if the
-  submitted blob represents a valid extrinsics applied to the specified
-  block. This function gets called internally when executing blocks with the
-  <verbatim|Core_execute_block> runtime function as described in section
-  <reference|sect-rte-core-execute-block>.
-
-  \;
-
-  <strong|Arguments>:
-
-  <\itemize>
-    <item>UTX: A byte array that contains the transaction.
-  </itemize>
-
-  \;
-
-  <strong|Return>:
-
-  This function returns a <verbatim|Result> as defined in Definition
-  <reference|defn-result-type> which contains the type <em|ValidTransaction>
-  as defined in Definition <reference|defn-valid-transaction> on success and
-  the type <em|TransactionValidityError> as defined in Definition
-  <reference|defn-transaction-validity-error> on failure.
-
-  <\definition>
-    <label|defn-valid-transaction><strong|ValidTransaction> is a tuple which
-    contains information concerning a valid transaction.
-
-    \;
-
-    <\small-table|<tabular|<tformat|<cwith|4|4|1|-1|cell-tborder|1ln>|<cwith|3|3|1|-1|cell-bborder|1ln>|<cwith|4|4|1|-1|cell-bborder|0ln>|<cwith|5|5|1|-1|cell-tborder|0ln>|<cwith|6|6|1|-1|cell-tborder|1ln>|<cwith|5|5|1|-1|cell-bborder|1ln>|<cwith|6|6|1|-1|cell-bborder|0ln>|<cwith|7|7|1|-1|cell-tborder|0ln>|<cwith|9|9|1|-1|cell-tborder|1ln>|<cwith|8|8|1|-1|cell-bborder|1ln>|<cwith|9|9|1|-1|cell-bborder|0ln>|<cwith|10|10|1|-1|cell-tborder|0ln>|<cwith|11|11|1|-1|cell-tborder|1ln>|<cwith|10|10|1|-1|cell-bborder|1ln>|<cwith|11|11|1|-1|cell-bborder|0ln>|<cwith|12|12|1|-1|cell-tborder|0ln>|<cwith|1|-1|1|1|cell-rborder|0ln>|<cwith|1|-1|2|2|cell-lborder|0ln>|<cwith|1|-1|3|3|cell-lborder|0ln>|<cwith|1|-1|2|2|cell-rborder|0ln>|<twith|table-rborder|1ln>|<twith|table-lborder|0ln>|<twith|table-tborder|0ln>|<cwith|1|1|2|2|cell-lborder|0ln>|<cwith|1|1|1|1|cell-rborder|0ln>|<cwith|1|1|3|3|cell-lborder|0ln>|<cwith|1|1|2|2|cell-rborder|0ln>|<cwith|12|12|1|1|cell-tborder|0ln>|<cwith|11|11|1|1|cell-bborder|0ln>|<cwith|12|12|2|2|cell-tborder|0ln>|<cwith|11|11|2|2|cell-bborder|0ln>|<cwith|12|12|2|2|cell-lborder|0ln>|<cwith|12|12|1|1|cell-rborder|0ln>|<cwith|12|12|3|3|cell-tborder|0ln>|<cwith|11|11|3|3|cell-bborder|0ln>|<cwith|2|-1|3|3|cell-lborder|0ln>|<cwith|2|-1|2|2|cell-rborder|0ln>|<cwith|1|1|1|-1|cell-bborder|1ln>|<cwith|2|2|1|-1|cell-tborder|1ln>|<cwith|1|1|1|-1|cell-tborder|1ln>|<cwith|12|12|1|-1|cell-bborder|1ln>|<cwith|1|-1|1|1|cell-lborder|0ln>|<cwith|1|-1|3|3|cell-rborder|0ln>|<table|<row|<cell|<strong|Name>>|<cell|<strong|Description>>|<cell|<strong|Type>>>|<row|<cell|Priority>|<cell|Determines
-    the ordering of two transactions that have>|<cell|Unsigned
-    64bit>>|<row|<cell|>|<cell|all their dependencies (required tags)
-    satisfied.>|<cell|integer>>|<row|<cell|Requires>|<cell|List of tags
-    specifying extrinsics which should be applied >|<cell|Array
-    containing>>|<row|<cell|>|<cell|before the current exrinsics can be
-    applied.>|<cell|inner arrays>>|<row|<cell|Provides>|<cell|Informs Runtime
-    of the extrinsics depending on the tags in>|<cell|Array
-    containing>>|<row|<cell|>|<cell|the list that can be applied after
-    current extrinsics are being applied.>|<cell|inner
-    arrays>>|<row|<cell|>|<cell|Describes the minimum number of blocks for
-    the validity to be correct>|<cell|>>|<row|<cell|Longevity>|<cell|After
-    this period, the transaction should be removed from the >|<cell|Unsigned
-    64bit>>|<row|<cell|>|<cell|pool or revalidated.>|<cell|integer>>|<row|<cell|Propagate>|<cell|A
-    flag indicating if the transaction should be propagated to
-    >|<cell|Boolean>>|<row|<cell|>|<cell|other peers.>|<cell|>>>>>>
-      The tuple provided by <verbatim|TaggedTransactionQueue_transaction_validity>
-
-      in the case the transaction is judged to be valid.
-    </small-table>
-  </definition>
-
-  Note that if <em|Propagate> is set to <verbatim|false> the transaction will
-  still be considered for including in blocks that are authored on the
-  current node, but will never be sent to other peers.
-
-  <\definition>
-    <label|defn-transaction-validity-error><strong|TransactionValidityError>
-    is a varying data type as defined in Definition
-    <reference|defn-varrying-data-type>, where following values are possible:
-
-    \;
-
-    <small-table|<tabular|<tformat|<cwith|1|1|1|-1|cell-bborder|1ln>|<cwith|2|2|1|-1|cell-tborder|1ln>|<cwith|1|1|2|2|cell-rborder|0ln>|<cwith|1|1|3|3|cell-bborder|1ln>|<cwith|2|2|3|3|cell-tborder|1ln>|<cwith|1|1|1|-1|cell-tborder|1ln>|<cwith|3|3|1|-1|cell-bborder|1ln>|<cwith|1|-1|1|1|cell-lborder|0ln>|<cwith|1|-1|3|3|cell-rborder|0ln>|<table|<row|<cell|<strong|<strong|>Id>>|<cell|<strong|Descri<strong|>ption>>|<cell|<strong|Appended>>>|<row|<cell|0>|<cell|The
-    transaction is invalid.>|<cell|InvalidTransaction
-    (<reference|defn-invalid-transaction>)>>|<row|<cell|1>|<cell|The
-    transaction validity can't be determined.>|<cell|UnknownTransaction
-    (<reference|defn-unknown-transaction>)>>>>>|Type variation for the return
-    value of <verbatim|TaggedTransactionQueue_transaction_validity>.>
-
-    <\definition>
-      <label|defn-invalid-transaction><strong|InvalidTransaction> is a
-      varying data type as defined in Definition
-      <reference|defn-varrying-data-type> which can get appended to
-      TransactionValidityError and describes the invalid transaction in more
-      precise detail. The following values are possible:
-
-      <\big-table|<tabular|<tformat|<cwith|1|1|2|2|cell-lborder|0ln>|<cwith|1|1|1|1|cell-rborder|0ln>|<cwith|1|1|3|3|cell-lborder|0ln>|<cwith|1|1|2|2|cell-rborder|0ln>|<cwith|1|1|1|-1|cell-tborder|1ln>|<cwith|1|-1|1|1|cell-lborder|0ln>|<cwith|1|-1|3|3|cell-rborder|0ln>|<cwith|2|2|1|-1|cell-tborder|1ln>|<cwith|1|1|1|-1|cell-bborder|1ln>|<cwith|9|9|1|-1|cell-bborder|1ln>|<cwith|2|-1|1|1|cell-lborder|0ln>|<cwith|2|-1|3|3|cell-rborder|0ln>|<table|<row|<cell|<strong|Id>>|<cell|<strong|Description>>|<cell|<strong|Appended>>>|<row|<cell|0>|<cell|Call:
-      The call of the transaction is not expected>|<cell|>>|<row|<cell|1>|<cell|Payment:
-      Inability to pay some fees (e.g. balance too
-      low)>|<cell|>>|<row|<cell|2>|<cell|Future: Transaction not yet valid
-      (e.g. nonce too high)>|<cell|>>|<row|<cell|3>|<cell|Stale: Transaction
-      is outdated (e.g. nonce too low)>|<cell|>>|<row|<cell|4>|<cell|BadProof:
-      Bad transaction proof (e.g. bad signature)>|<cell|>>|<row|<cell|5>|<cell|AncientBirthBlock:
-      Transaction birth block is ancient.>|<cell|>>|<row|<cell|6>|<cell|ExhaustsResources:
-      Transaction would exhaus the resources of the current
-      block>|<cell|>>|<row|<cell|7>|<cell|Custom: Any other custom message
-      not covered by this type. >|<cell|one byte>>>>>>
-        Type variant whichs gets appended to Id 0 of
-        <strong|TransactionValidityError>.
-      </big-table>
-    </definition>
-
-    <\definition>
-      <label|defn-unknown-transaction><strong|UnknownTransacion> is a varying
-      data type as defined in Definition <reference|defn-varrying-data-type>
-      which can get appended to TransactionValidityError and describes the
-      unknown transaction validity in more precise detail. The following
-      values are possible:
-
-      <\big-table|<tabular|<tformat|<cwith|1|1|3|3|cell-bborder|1ln>|<cwith|2|2|3|3|cell-tborder|1ln>|<cwith|1|1|2|2|cell-bborder|1ln>|<cwith|2|2|2|2|cell-tborder|1ln>|<cwith|1|1|2|2|cell-rborder|0ln>|<cwith|1|1|3|3|cell-lborder|0ln>|<cwith|1|1|1|1|cell-bborder|1ln>|<cwith|2|2|1|1|cell-tborder|1ln>|<cwith|1|1|1|1|cell-rborder|0ln>|<cwith|1|1|2|2|cell-lborder|0ln>|<cwith|1|1|1|-1|cell-tborder|1ln>|<cwith|4|4|1|-1|cell-bborder|1ln>|<cwith|1|-1|1|1|cell-lborder|0ln>|<cwith|1|-1|3|3|cell-rborder|0ln>|<table|<row|<cell|<strong|Id>>|<cell|<strong|Description>>|<cell|<strong|Appended>>>|<row|<cell|0>|<cell|CannotLookup:
-      Could not lookup some info that is required for the
-      transaction>|<cell|>>|<row|<cell|1>|<cell|NoUnsignedValidator: No
-      validator found for the given unsigned
-      transaction.>|<cell|>>|<row|<cell|2>|<cell|Custom: Any other custom
-      message not covered by this type>|<cell|one byte>>>>>>
-        Type variant whichs gets appended to Id 1 of
-        <strong|TransactionValidityError>.
-      </big-table>
-    </definition>
-
-    \;
-  </definition>
-
-  Note that when this function gets called by the Polkadot host in order to
-  validate a transaction received from peers, Polkadot host usually
-  disregards and rewinds state changes resulting for such a call.
-
-  \;
-
   <subsection|<verbatim|BlockBuilder_apply_extrinsic>>
   <label|sect-rte-apply-extrinsic>
 
@@ -602,7 +405,12 @@
     </big-table>
   </definition>
 
-  \;
+  <subsection|<verbatim|BlockBuilder_finalize_block>><label|defn-rt-blockbuilder-finalize-block>
+
+  Finalize the block - it is up to the caller to ensure that all header
+  fields are valid except for the state root. State changes resulting from
+  calling this function are usually meant to persist upon successful
+  execution of the function and appending of the block to the chain.
 
   <subsection|<verbatim|BlockBuilder_inherent_extrinsics>>
 
@@ -632,12 +440,306 @@
     array.
   </itemize-dot>
 
-  <subsection|<verbatim|BlockBuilder_finalize_block>><label|defn-rt-blockbuilder-finalize-block>
+  <subsection|<verbatim|BlockBuilder_check_inherents>>
 
-  Finalize the block - it is up to the caller to ensure that all header
-  fields are valid except for the state root. State changes resulting from
-  calling this function are usually meant to persist upon successful
-  execution of the function and appending of the block to the chain
+  \;
+
+  <subsection|<verbatim|BlockBuilder_random_seed>>
+
+  \;
+
+  <subsection|<verbatim|TaggedTransactionQueue_validate_transaction>><label|sect-rte-validate-transaction>
+
+  This entry is invoked against extrinsics submitted through the transaction
+  network message <reference|sect-msg-transactions> and indicates if the
+  submitted blob represents a valid extrinsics applied to the specified
+  block. This function gets called internally when executing blocks with the
+  <verbatim|Core_execute_block> runtime function as described in section
+  <reference|sect-rte-core-execute-block>.
+
+  \;
+
+  <strong|Arguments>:
+
+  <\itemize>
+    <item>UTX: A byte array that contains the transaction.
+  </itemize>
+
+  \;
+
+  <strong|Return>:
+
+  This function returns a <verbatim|Result> as defined in Definition
+  <reference|defn-result-type> which contains the type <em|ValidTransaction>
+  as defined in Definition <reference|defn-valid-transaction> on success and
+  the type <em|TransactionValidityError> as defined in Definition
+  <reference|defn-transaction-validity-error> on failure.
+
+  <\definition>
+    <label|defn-valid-transaction><strong|ValidTransaction> is a tuple which
+    contains information concerning a valid transaction.
+
+    \;
+
+    <\small-table|<tabular|<tformat|<cwith|4|4|1|-1|cell-tborder|1ln>|<cwith|3|3|1|-1|cell-bborder|1ln>|<cwith|4|4|1|-1|cell-bborder|0ln>|<cwith|5|5|1|-1|cell-tborder|0ln>|<cwith|6|6|1|-1|cell-tborder|1ln>|<cwith|5|5|1|-1|cell-bborder|1ln>|<cwith|6|6|1|-1|cell-bborder|0ln>|<cwith|7|7|1|-1|cell-tborder|0ln>|<cwith|9|9|1|-1|cell-tborder|1ln>|<cwith|8|8|1|-1|cell-bborder|1ln>|<cwith|9|9|1|-1|cell-bborder|0ln>|<cwith|10|10|1|-1|cell-tborder|0ln>|<cwith|11|11|1|-1|cell-tborder|1ln>|<cwith|10|10|1|-1|cell-bborder|1ln>|<cwith|11|11|1|-1|cell-bborder|0ln>|<cwith|12|12|1|-1|cell-tborder|0ln>|<cwith|1|-1|1|1|cell-rborder|0ln>|<cwith|1|-1|2|2|cell-lborder|0ln>|<cwith|1|-1|3|3|cell-lborder|0ln>|<cwith|1|-1|2|2|cell-rborder|0ln>|<twith|table-rborder|1ln>|<twith|table-lborder|0ln>|<twith|table-tborder|0ln>|<cwith|1|1|2|2|cell-lborder|0ln>|<cwith|1|1|1|1|cell-rborder|0ln>|<cwith|1|1|3|3|cell-lborder|0ln>|<cwith|1|1|2|2|cell-rborder|0ln>|<cwith|12|12|1|1|cell-tborder|0ln>|<cwith|11|11|1|1|cell-bborder|0ln>|<cwith|12|12|2|2|cell-tborder|0ln>|<cwith|11|11|2|2|cell-bborder|0ln>|<cwith|12|12|2|2|cell-lborder|0ln>|<cwith|12|12|1|1|cell-rborder|0ln>|<cwith|12|12|3|3|cell-tborder|0ln>|<cwith|11|11|3|3|cell-bborder|0ln>|<cwith|2|-1|3|3|cell-lborder|0ln>|<cwith|2|-1|2|2|cell-rborder|0ln>|<cwith|1|1|1|-1|cell-bborder|1ln>|<cwith|2|2|1|-1|cell-tborder|1ln>|<cwith|1|1|1|-1|cell-tborder|1ln>|<cwith|12|12|1|-1|cell-bborder|1ln>|<cwith|1|-1|1|1|cell-lborder|0ln>|<cwith|1|-1|3|3|cell-rborder|0ln>|<table|<row|<cell|<strong|Name>>|<cell|<strong|Description>>|<cell|<strong|Type>>>|<row|<cell|Priority>|<cell|Determines
+    the ordering of two transactions that have>|<cell|Unsigned
+    64bit>>|<row|<cell|>|<cell|all their dependencies (required tags)
+    satisfied.>|<cell|integer>>|<row|<cell|Requires>|<cell|List of tags
+    specifying extrinsics which should be applied >|<cell|Array
+    containing>>|<row|<cell|>|<cell|before the current exrinsics can be
+    applied.>|<cell|inner arrays>>|<row|<cell|Provides>|<cell|Informs Runtime
+    of the extrinsics depending on the tags in>|<cell|Array
+    containing>>|<row|<cell|>|<cell|the list that can be applied after
+    current extrinsics are being applied.>|<cell|inner
+    arrays>>|<row|<cell|>|<cell|Describes the minimum number of blocks for
+    the validity to be correct>|<cell|>>|<row|<cell|Longevity>|<cell|After
+    this period, the transaction should be removed from the >|<cell|Unsigned
+    64bit>>|<row|<cell|>|<cell|pool or revalidated.>|<cell|integer>>|<row|<cell|Propagate>|<cell|A
+    flag indicating if the transaction should be propagated to
+    >|<cell|Boolean>>|<row|<cell|>|<cell|other peers.>|<cell|>>>>>>
+      The tuple provided by <verbatim|TaggedTransactionQueue_transaction_validity>
+
+      in the case the transaction is judged to be valid.
+    </small-table>
+  </definition>
+
+  Note that if <em|Propagate> is set to <verbatim|false> the transaction will
+  still be considered for including in blocks that are authored on the
+  current node, but will never be sent to other peers.
+
+  <\definition>
+    <label|defn-transaction-validity-error><strong|TransactionValidityError>
+    is a varying data type as defined in Definition
+    <reference|defn-varrying-data-type>, where following values are possible:
+
+    \;
+
+    <small-table|<tabular|<tformat|<cwith|1|1|1|-1|cell-bborder|1ln>|<cwith|2|2|1|-1|cell-tborder|1ln>|<cwith|1|1|2|2|cell-rborder|0ln>|<cwith|1|1|3|3|cell-bborder|1ln>|<cwith|2|2|3|3|cell-tborder|1ln>|<cwith|1|1|1|-1|cell-tborder|1ln>|<cwith|3|3|1|-1|cell-bborder|1ln>|<cwith|1|-1|1|1|cell-lborder|0ln>|<cwith|1|-1|3|3|cell-rborder|0ln>|<table|<row|<cell|<strong|<strong|>Id>>|<cell|<strong|Descri<strong|>ption>>|<cell|<strong|Appended>>>|<row|<cell|0>|<cell|The
+    transaction is invalid.>|<cell|InvalidTransaction
+    (<reference|defn-invalid-transaction>)>>|<row|<cell|1>|<cell|The
+    transaction validity can't be determined.>|<cell|UnknownTransaction
+    (<reference|defn-unknown-transaction>)>>>>>|Type variation for the return
+    value of <verbatim|TaggedTransactionQueue_transaction_validity>.>
+
+    <\definition>
+      <label|defn-invalid-transaction><strong|InvalidTransaction> is a
+      varying data type as defined in Definition
+      <reference|defn-varrying-data-type> which can get appended to
+      TransactionValidityError and describes the invalid transaction in more
+      precise detail. The following values are possible:
+
+      <\big-table|<tabular|<tformat|<cwith|1|1|2|2|cell-lborder|0ln>|<cwith|1|1|1|1|cell-rborder|0ln>|<cwith|1|1|3|3|cell-lborder|0ln>|<cwith|1|1|2|2|cell-rborder|0ln>|<cwith|1|1|1|-1|cell-tborder|1ln>|<cwith|1|-1|1|1|cell-lborder|0ln>|<cwith|1|-1|3|3|cell-rborder|0ln>|<cwith|2|2|1|-1|cell-tborder|1ln>|<cwith|1|1|1|-1|cell-bborder|1ln>|<cwith|9|9|1|-1|cell-bborder|1ln>|<cwith|2|-1|1|1|cell-lborder|0ln>|<cwith|2|-1|3|3|cell-rborder|0ln>|<table|<row|<cell|<strong|Id>>|<cell|<strong|Description>>|<cell|<strong|Appended>>>|<row|<cell|0>|<cell|Call:
+      The call of the transaction is not expected>|<cell|>>|<row|<cell|1>|<cell|Payment:
+      Inability to pay some fees (e.g. balance too
+      low)>|<cell|>>|<row|<cell|2>|<cell|Future: Transaction not yet valid
+      (e.g. nonce too high)>|<cell|>>|<row|<cell|3>|<cell|Stale: Transaction
+      is outdated (e.g. nonce too low)>|<cell|>>|<row|<cell|4>|<cell|BadProof:
+      Bad transaction proof (e.g. bad signature)>|<cell|>>|<row|<cell|5>|<cell|AncientBirthBlock:
+      Transaction birth block is ancient.>|<cell|>>|<row|<cell|6>|<cell|ExhaustsResources:
+      Transaction would exhaus the resources of the current
+      block>|<cell|>>|<row|<cell|7>|<cell|Custom: Any other custom message
+      not covered by this type. >|<cell|one byte>>>>>>
+        Type variant whichs gets appended to Id 0 of
+        <strong|TransactionValidityError>.
+      </big-table>
+    </definition>
+
+    <\definition>
+      <label|defn-unknown-transaction><strong|UnknownTransacion> is a varying
+      data type as defined in Definition <reference|defn-varrying-data-type>
+      which can get appended to TransactionValidityError and describes the
+      unknown transaction validity in more precise detail. The following
+      values are possible:
+
+      <\big-table|<tabular|<tformat|<cwith|1|1|3|3|cell-bborder|1ln>|<cwith|2|2|3|3|cell-tborder|1ln>|<cwith|1|1|2|2|cell-bborder|1ln>|<cwith|2|2|2|2|cell-tborder|1ln>|<cwith|1|1|2|2|cell-rborder|0ln>|<cwith|1|1|3|3|cell-lborder|0ln>|<cwith|1|1|1|1|cell-bborder|1ln>|<cwith|2|2|1|1|cell-tborder|1ln>|<cwith|1|1|1|1|cell-rborder|0ln>|<cwith|1|1|2|2|cell-lborder|0ln>|<cwith|1|1|1|-1|cell-tborder|1ln>|<cwith|4|4|1|-1|cell-bborder|1ln>|<cwith|1|-1|1|1|cell-lborder|0ln>|<cwith|1|-1|3|3|cell-rborder|0ln>|<table|<row|<cell|<strong|Id>>|<cell|<strong|Description>>|<cell|<strong|Appended>>>|<row|<cell|0>|<cell|CannotLookup:
+      Could not lookup some info that is required for the
+      transaction>|<cell|>>|<row|<cell|1>|<cell|NoUnsignedValidator: No
+      validator found for the given unsigned
+      transaction.>|<cell|>>|<row|<cell|2>|<cell|Custom: Any other custom
+      message not covered by this type>|<cell|one byte>>>>>>
+        Type variant whichs gets appended to Id 1 of
+        <strong|TransactionValidityError>.
+      </big-table>
+    </definition>
+
+    \;
+  </definition>
+
+  Note that when this function gets called by the Polkadot host in order to
+  validate a transaction received from peers, Polkadot host usually
+  disregards and rewinds state changes resulting for such a call.
+
+  <subsection|<verbatim|OffchainWorkerApi_offchain_worker>>
+
+  \;
+
+  <subsection|<verbatim|ParachainHost_validators>>
+
+  \;
+
+  <subsection|<verbatim|ParachainHost_validator_groups>>
+
+  \;
+
+  <subsection|<verbatim|ParachainHost_availability_cores>>
+
+  \;
+
+  <subsection|<verbatim|ParachainHost_persisted_validation_data>>
+
+  \;
+
+  <subsection|<verbatim|ParachainHost_check_validation_outputs>>
+
+  \;
+
+  <subsection|<verbatim|ParachainHost_session_index_for_child>>
+
+  \;
+
+  <subsection|<verbatim|ParachainHost_session_info>>
+
+  \;
+
+  <subsection|<verbatim|ParachainHost_validation_code>>
+
+  \;
+
+  <subsection|<verbatim|ParachainHost_historical_validation_code>>
+
+  \;
+
+  <subsection|<verbatim|ParachainHost_candidate_pending_availability>>
+
+  \;
+
+  <subsection|<verbatim|ParachainHost_candidate_events>>
+
+  \;
+
+  <subsection|<verbatim|ParachainHost_dmq_contents>>
+
+  \;
+
+  <subsection|<verbatim|ParachainHost_inbound_hrmp_channel_contents>>
+
+  \;
+
+  <subsection|<verbatim|GrandpaApi_grandpa_authorities>><label|sect-rte-grandpa-auth>
+
+  This entry fetches the list of GRANDPA authorities according to the genesis
+  block and is used to initialize authority list defined in Definition
+  <reference|defn-authority-list>, at genisis. Any future authority changes
+  get tracked via Runtiem-to-consensus engine messages as described in
+  Section <reference|sect-consensus-message-digest>.
+
+  <subsection|<verbatim|GrandpaApi_submit_report_equivocation_unsigned_extrinsic>>
+
+  \;
+
+  <subsection|<verbatim|GrandpaApi_generate_key_ownership_proof>>
+
+  \;
+
+  <subsection|<verbatim|BabeApi_configuration>><label|sect-rte-babeapi-epoch>
+
+  This entry is called to obtain the current configuration of BABE consensus
+  protocol.
+
+  \;
+
+  <strong|Arguments>:
+
+  <\itemize>
+    <item>None
+  </itemize>
+
+  \;
+
+  <strong|Return>:
+
+  A tuple containing configuration data used by the Babe consensus engine.
+
+  <\big-table|<tabular|<tformat|<cwith|1|1|1|-1|cell-tborder|1ln>|<cwith|1|1|1|1|cell-lborder|0ln>|<cwith|1|1|3|3|cell-rborder|0ln>|<cwith|18|18|1|-1|cell-bborder|1ln>|<cwith|2|-1|1|1|cell-lborder|0ln>|<cwith|2|-1|3|3|cell-rborder|0ln>|<cwith|2|2|1|-1|cell-tborder|1ln>|<cwith|1|1|1|-1|cell-bborder|1ln>|<cwith|2|4|1|1|cell-lborder|0ln>|<cwith|2|4|3|3|cell-rborder|0ln>|<cwith|5|5|1|-1|cell-tborder|1ln>|<cwith|4|4|1|-1|cell-bborder|1ln>|<cwith|5|6|1|1|cell-lborder|0ln>|<cwith|5|6|3|3|cell-rborder|0ln>|<cwith|7|7|1|-1|cell-tborder|1ln>|<cwith|6|6|1|-1|cell-bborder|1ln>|<cwith|7|10|1|1|cell-lborder|0ln>|<cwith|7|10|3|3|cell-rborder|0ln>|<cwith|11|11|1|-1|cell-tborder|1ln>|<cwith|10|10|1|-1|cell-bborder|1ln>|<cwith|11|15|1|1|cell-lborder|0ln>|<cwith|11|15|3|3|cell-rborder|0ln>|<cwith|16|16|1|-1|cell-tborder|1ln>|<cwith|15|15|1|-1|cell-bborder|1ln>|<cwith|16|16|1|-1|cell-bborder|1ln>|<cwith|17|17|1|-1|cell-tborder|1ln>|<cwith|16|16|1|1|cell-lborder|0ln>|<cwith|16|16|3|3|cell-rborder|0ln>|<table|<row|<cell|<strong|Name>>|<cell|<strong|Description>>|<cell|<strong|Type>>>|<row|<cell|SlotDuration>|<cell|The
+  slot duration in milliseconds. Currently, only the value
+  provided>|<cell|Unsigned 64bit>>|<row|<cell|>|<cell|by this type at genesis
+  will be used. Dynamic slot duration may
+  be>|<cell|integer>>|<row|<cell|>|<cell|supported in the
+  future.>|<cell|>>|<row|<cell|EpochLength>|<cell|The duration of epochs in
+  slots.>|<cell|Unsigned 64bit>>|<row|<cell|>|<cell|>|<cell|integer>>|<row|<cell|Constant>|<cell|A
+  constant value that is used in the threshold calculation
+  formula>|<cell|Tuple containing>>|<row|<cell|>|<cell|as defined in
+  definition <reference|defn-babe-constant>.>|<cell|two
+  unsigned>>|<row|<cell|>|<cell|>|<cell|64bit
+  integers>>|<row|<cell|>|<cell|>|<cell|>>|<row|<cell|Genesis>|<cell|The
+  authority list for the genesis epoch as defined in Definition
+  <reference|defn-authority-list>. >|<cell|Array of
+  tuples>>|<row|<cell|Authorities>|<cell|>|<cell|containing a
+  256-bit>>|<row|<cell|>|<cell|>|<cell|byte array and
+  a>>|<row|<cell|>|<cell|>|<cell|unsigned
+  64bit>>|<row|<cell|>|<cell|>|<cell|integer>>|<row|<cell|Randomness>|<cell|The
+  randomness for the genesis epoch>|<cell|32-byte
+  array>>|<row|<cell|SecondarySlot>|<cell|Whether this chain should run with
+  secondary slots and wether>|<cell|8bit enum>>|<row|<cell|>|<cell|they are
+  assigned in a round-robin manner or via a second VRF.>|<cell|>>>>>>
+    The tuple provided by <strong|BabeApi_configuration>.
+  </big-table>
+
+  <subsection|<verbatim|BabeApi_current_epoch_start>>
+
+  \;
+
+  <subsection|<verbatim|BabeApi_current_epoch>>
+
+  \;
+
+  <subsection|<verbatim|BabeApi_current_epoch>>
+
+  \;
+
+  <subsection|<verbatim|BabeApi_next_epoch>>
+
+  \;
+
+  <subsection|<verbatim|BabeApi_generate_key_ownership_proof>>
+
+  \;
+
+  <subsection|<verbatim|BabeApi_submit_report_equivocation_unsigned_extrinsic>>
+
+  \;
+
+  <subsection|<verbatim|AuthorityDiscoveryApi_authorities>>
+
+  \;
+
+  <subsection|<verbatim|SessionKeys_generate_session_keys>>
+
+  \;
+
+  <subsection|<verbatim|SessionKeys_decode_session_keys>>
+
+  \;
+
+  <subsection|<verbatim|AccountNonceApi_account_nonce>>
+
+  \;
+
+  <subsection|<verbatim|TransactionPaymentApi_query_info>>
+
+  \;
+
+  <subsection|<verbatim|TransactionPaymentApi_query_fee_details>>
+
+  \;
+
+  \;
+
+  \;
+
+  \;
+
+  \;
 
   <\with|par-mode|right>
     <qed>
@@ -662,53 +764,83 @@
   <\collection>
     <associate|auto-1|<tuple|A|107>>
     <associate|auto-10|<tuple|A.2.5|109>>
-    <associate|auto-11|<tuple|A.2.6|109>>
-    <associate|auto-12|<tuple|A.2|109>>
-    <associate|auto-13|<tuple|A.2.7|109>>
-    <associate|auto-14|<tuple|A.2.8|110>>
-    <associate|auto-15|<tuple|A.3|110>>
-    <associate|auto-16|<tuple|A.4|110>>
-    <associate|auto-17|<tuple|A.5|111>>
-    <associate|auto-18|<tuple|A.6|111>>
-    <associate|auto-19|<tuple|A.2.9|111>>
+    <associate|auto-11|<tuple|A.2|109>>
+    <associate|auto-12|<tuple|A.3|109>>
+    <associate|auto-13|<tuple|A.4|109>>
+    <associate|auto-14|<tuple|A.5|110>>
+    <associate|auto-15|<tuple|A.6|110>>
+    <associate|auto-16|<tuple|A.7|110>>
+    <associate|auto-17|<tuple|A.8|111>>
+    <associate|auto-18|<tuple|A.2.6|111>>
+    <associate|auto-19|<tuple|A.2.7|111>>
     <associate|auto-2|<tuple|A.1|107>>
-    <associate|auto-20|<tuple|A.7|111>>
-    <associate|auto-21|<tuple|A.8|112>>
-    <associate|auto-22|<tuple|A.9|112>>
-    <associate|auto-23|<tuple|A.10|?>>
-    <associate|auto-24|<tuple|A.11|?>>
-    <associate|auto-25|<tuple|A.12|?>>
-    <associate|auto-26|<tuple|A.13|?>>
-    <associate|auto-27|<tuple|A.2.10|?>>
-    <associate|auto-28|<tuple|A.2.11|?>>
+    <associate|auto-20|<tuple|A.2.8|111>>
+    <associate|auto-21|<tuple|A.2.9|112>>
+    <associate|auto-22|<tuple|A.2.10|112>>
+    <associate|auto-23|<tuple|A.9|?>>
+    <associate|auto-24|<tuple|A.10|?>>
+    <associate|auto-25|<tuple|A.11|?>>
+    <associate|auto-26|<tuple|A.12|?>>
+    <associate|auto-27|<tuple|A.2.11|?>>
+    <associate|auto-28|<tuple|A.2.12|?>>
+    <associate|auto-29|<tuple|A.2.13|?>>
     <associate|auto-3|<tuple|A.1|107>>
+    <associate|auto-30|<tuple|A.2.14|?>>
+    <associate|auto-31|<tuple|A.2.15|?>>
+    <associate|auto-32|<tuple|A.2.16|?>>
+    <associate|auto-33|<tuple|A.2.17|?>>
+    <associate|auto-34|<tuple|A.2.18|?>>
+    <associate|auto-35|<tuple|A.2.19|?>>
+    <associate|auto-36|<tuple|A.2.20|?>>
+    <associate|auto-37|<tuple|A.2.21|?>>
+    <associate|auto-38|<tuple|A.2.22|?>>
+    <associate|auto-39|<tuple|A.2.23|?>>
     <associate|auto-4|<tuple|A.2|107>>
+    <associate|auto-40|<tuple|A.2.24|?>>
+    <associate|auto-41|<tuple|A.2.25|?>>
+    <associate|auto-42|<tuple|A.2.26|?>>
+    <associate|auto-43|<tuple|A.2.27|?>>
+    <associate|auto-44|<tuple|A.2.28|?>>
+    <associate|auto-45|<tuple|A.13|?>>
+    <associate|auto-46|<tuple|A.2.29|?>>
+    <associate|auto-47|<tuple|A.2.30|?>>
+    <associate|auto-48|<tuple|A.2.31|?>>
+    <associate|auto-49|<tuple|A.2.32|?>>
     <associate|auto-5|<tuple|A.2.1|108>>
+    <associate|auto-50|<tuple|A.2.33|?>>
+    <associate|auto-51|<tuple|A.2.34|?>>
+    <associate|auto-52|<tuple|A.2.35|?>>
+    <associate|auto-53|<tuple|A.2.36|?>>
+    <associate|auto-54|<tuple|A.2.37|?>>
+    <associate|auto-55|<tuple|A.2.38|?>>
+    <associate|auto-56|<tuple|A.2.39|?>>
+    <associate|auto-57|<tuple|A.2.40|?>>
+    <associate|auto-58|<tuple|A.2.41|?>>
     <associate|auto-6|<tuple|A.1|108>>
     <associate|auto-7|<tuple|A.2.2|108>>
     <associate|auto-8|<tuple|A.2.3|108>>
     <associate|auto-9|<tuple|A.2.4|109>>
-    <associate|defn-invalid-transaction|<tuple|A.4|110>>
+    <associate|defn-invalid-transaction|<tuple|A.11|110>>
     <associate|defn-rt-apisvec|<tuple|A.1|?>>
-    <associate|defn-rt-blockbuilder-finalize-block|<tuple|A.2.11|112>>
+    <associate|defn-rt-blockbuilder-finalize-block|<tuple|A.2.6|112>>
     <associate|defn-rt-core-version|<tuple|A.2.1|108>>
-    <associate|defn-rte-apply-extrinsic-result|<tuple|A.6|?>>
-    <associate|defn-rte-custom-module-error|<tuple|A.9|?>>
-    <associate|defn-rte-dispatch-error|<tuple|A.8|?>>
-    <associate|defn-rte-dispatch-outcome|<tuple|A.7|?>>
-    <associate|defn-rte-invalid-transaction|<tuple|A.11|?>>
-    <associate|defn-rte-transaction-validity-error|<tuple|A.10|?>>
-    <associate|defn-rte-unknown-transaction|<tuple|A.12|?>>
-    <associate|defn-transaction-validity-error|<tuple|A.3|110>>
-    <associate|defn-unknown-transaction|<tuple|A.5|110>>
-    <associate|defn-valid-transaction|<tuple|A.2|110>>
+    <associate|defn-rte-apply-extrinsic-result|<tuple|A.2|?>>
+    <associate|defn-rte-custom-module-error|<tuple|A.5|?>>
+    <associate|defn-rte-dispatch-error|<tuple|A.4|?>>
+    <associate|defn-rte-dispatch-outcome|<tuple|A.3|?>>
+    <associate|defn-rte-invalid-transaction|<tuple|A.7|?>>
+    <associate|defn-rte-transaction-validity-error|<tuple|A.6|?>>
+    <associate|defn-rte-unknown-transaction|<tuple|A.8|?>>
+    <associate|defn-transaction-validity-error|<tuple|A.10|110>>
+    <associate|defn-unknown-transaction|<tuple|A.12|110>>
+    <associate|defn-valid-transaction|<tuple|A.9|110>>
     <associate|sect-list-of-runtime-entries|<tuple|A.1|107>>
-    <associate|sect-rte-apply-extrinsic|<tuple|A.2.9|?>>
-    <associate|sect-rte-babeapi-epoch|<tuple|A.2.6|109>>
+    <associate|sect-rte-apply-extrinsic|<tuple|A.2.5|?>>
+    <associate|sect-rte-babeapi-epoch|<tuple|A.2.28|109>>
     <associate|sect-rte-core-execute-block|<tuple|A.2.2|?>>
-    <associate|sect-rte-grandpa-auth|<tuple|A.2.7|109>>
+    <associate|sect-rte-grandpa-auth|<tuple|A.2.25|109>>
     <associate|sect-rte-hash-and-length|<tuple|A.2.5|109>>
-    <associate|sect-rte-validate-transaction|<tuple|A.2.8|109>>
+    <associate|sect-rte-validate-transaction|<tuple|A.2.10|109>>
     <associate|sect-runtime-entries|<tuple|A|107>>
     <associate|snippet-runtime-enteries|<tuple|A.1|107>>
   </collection>

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -108,6 +108,15 @@
   persisted after the call is ended. See Section
   <reference|sect-handling-runtime-state-update> for more information.
 
+  <section|JSON-RPC API for external services><label|sect-json-rpc-api>
+
+  Polkadot Host implementers are encouraged to implement an API in order for
+  external, third-party services to interact with the node. The
+  <hlink|JSON-RPC Interface for Polkadot Nodes|https://github.com/w3f/PSPs/blob/master/PSPs/drafts/psp-6.md>
+  (PSP Number 006) is a Polkadot Standard Proposal for such an API and makes
+  it easier to integrate the node with exisiting tools available in the
+  Polkadot ecosystem, such as <hlink|polkadot.js.org|https://polkadot.js.org/>.\ 
+
   <section|Argument Specification>
 
   As a wasm functions, all runtime entries have the following prototype
@@ -137,7 +146,8 @@
   <subsection|<verbatim|Core_version>><label|defn-rt-core-version>
 
   Returns the version identifiers of the Runtime. This function can be used
-  by the Polkadot Host implementation when it seems appropriate.
+  by the Polkadot Host implementation when it seems appropriate, such as for
+  the JSON-RPC API as described in Section <reference|sect-json-rpc-api>.
 
   \;
 
@@ -250,7 +260,9 @@
   <subsection|<verbatim|Metadata_metadata>>
 
   Returns native Runtime metadata in an opaque form. This function can be
-  used for logging purposes.
+  used for logging purposes. This function can be used by the Polkadot Host
+  implementation when it seems appropriate, such as for the JSON-RPC API as
+  described in Section <reference|sect-json-rpc-api>.
 
   \;
 
@@ -1094,7 +1106,9 @@
 
   <subsection|<verbatim|AccountNonceApi_account_nonce>>
 
-  Get the current nonce of an account.
+  Get the current nonce of an account. This function can be used by the
+  Polkadot Host implementation when it seems appropriate, such as for the
+  JSON-RPC API as described in Section <reference|sect-json-rpc-api>.
 
   \;
 
@@ -1118,6 +1132,12 @@
   internals of an extrinsic, but only interprets the extrinsic as some
   encoded value and accounts for its weight and length, the runtime's
   extrinsic base weight and the current fee multiplier.
+
+  \;
+
+  This function can be used by the Polkadot Host implementation when it seems
+  appropriate, such as for the JSON-RPC API as described in Section
+  <reference|sect-json-rpc-api>.
 
   \;
 
@@ -1162,7 +1182,9 @@
 
   <subsection|<verbatim|TransactionPaymentApi_query_fee_details>>
 
-  Query the detailed fee of a given extrinsic.
+  Query the detailed fee of a given extrinsic. This function can be used by
+  the Polkadot Host implementation when it seems appropriate, such as for the
+  JSON-RPC API as described in Section <reference|sect-json-rpc-api>.
 
   \;
 
@@ -1233,11 +1255,11 @@
 <\initial>
   <\collection>
     <associate|chapter-nr|8>
-    <associate|page-first|139>
+    <associate|page-first|133>
     <associate|page-height|auto>
     <associate|page-type|letter>
     <associate|page-width|auto>
-    <associate|section-nr|2<uninit>>
+    <associate|section-nr|2>
     <associate|subsection-nr|0>
   </collection>
 </initial>
@@ -1245,66 +1267,67 @@
 <\references>
   <\collection>
     <associate|auto-1|<tuple|A|107>>
-    <associate|auto-10|<tuple|A.2.5|109>>
-    <associate|auto-11|<tuple|A.2|109>>
-    <associate|auto-12|<tuple|A.3|109>>
-    <associate|auto-13|<tuple|A.4|109>>
-    <associate|auto-14|<tuple|A.5|110>>
-    <associate|auto-15|<tuple|A.6|110>>
-    <associate|auto-16|<tuple|A.7|110>>
-    <associate|auto-17|<tuple|A.8|111>>
-    <associate|auto-18|<tuple|A.2.6|111>>
-    <associate|auto-19|<tuple|A.2.7|111>>
+    <associate|auto-10|<tuple|A.3.4|109>>
+    <associate|auto-11|<tuple|A.3.5|109>>
+    <associate|auto-12|<tuple|A.2|109>>
+    <associate|auto-13|<tuple|A.3|109>>
+    <associate|auto-14|<tuple|A.4|110>>
+    <associate|auto-15|<tuple|A.5|110>>
+    <associate|auto-16|<tuple|A.6|110>>
+    <associate|auto-17|<tuple|A.7|111>>
+    <associate|auto-18|<tuple|A.8|111>>
+    <associate|auto-19|<tuple|A.3.6|111>>
     <associate|auto-2|<tuple|A.1|107>>
-    <associate|auto-20|<tuple|A.2.8|111>>
-    <associate|auto-21|<tuple|A.2.9|112>>
-    <associate|auto-22|<tuple|A.2.10|112>>
-    <associate|auto-23|<tuple|A.9|?>>
-    <associate|auto-24|<tuple|A.10|?>>
-    <associate|auto-25|<tuple|A.11|?>>
-    <associate|auto-26|<tuple|A.12|?>>
-    <associate|auto-27|<tuple|A.2.11|?>>
-    <associate|auto-28|<tuple|A.2.12|?>>
-    <associate|auto-29|<tuple|A.2.13|?>>
+    <associate|auto-20|<tuple|A.3.7|111>>
+    <associate|auto-21|<tuple|A.3.8|112>>
+    <associate|auto-22|<tuple|A.3.9|112>>
+    <associate|auto-23|<tuple|A.3.10|?>>
+    <associate|auto-24|<tuple|A.9|?>>
+    <associate|auto-25|<tuple|A.10|?>>
+    <associate|auto-26|<tuple|A.11|?>>
+    <associate|auto-27|<tuple|A.12|?>>
+    <associate|auto-28|<tuple|A.3.11|?>>
+    <associate|auto-29|<tuple|A.3.12|?>>
     <associate|auto-3|<tuple|A.1|107>>
-    <associate|auto-30|<tuple|A.2.14|?>>
-    <associate|auto-31|<tuple|A.2.15|?>>
-    <associate|auto-32|<tuple|A.2.16|?>>
-    <associate|auto-33|<tuple|A.2.17|?>>
-    <associate|auto-34|<tuple|A.2.18|?>>
-    <associate|auto-35|<tuple|A.2.19|?>>
-    <associate|auto-36|<tuple|A.2.20|?>>
-    <associate|auto-37|<tuple|A.2.21|?>>
-    <associate|auto-38|<tuple|A.2.22|?>>
-    <associate|auto-39|<tuple|A.2.23|?>>
+    <associate|auto-30|<tuple|A.3.13|?>>
+    <associate|auto-31|<tuple|A.3.14|?>>
+    <associate|auto-32|<tuple|A.3.15|?>>
+    <associate|auto-33|<tuple|A.3.16|?>>
+    <associate|auto-34|<tuple|A.3.17|?>>
+    <associate|auto-35|<tuple|A.3.18|?>>
+    <associate|auto-36|<tuple|A.3.19|?>>
+    <associate|auto-37|<tuple|A.3.20|?>>
+    <associate|auto-38|<tuple|A.3.21|?>>
+    <associate|auto-39|<tuple|A.3.22|?>>
     <associate|auto-4|<tuple|A.2|107>>
-    <associate|auto-40|<tuple|A.2.24|?>>
-    <associate|auto-41|<tuple|A.2.25|?>>
-    <associate|auto-42|<tuple|A.2.26|?>>
-    <associate|auto-43|<tuple|A.2.27|?>>
-    <associate|auto-44|<tuple|A.2.28|?>>
-    <associate|auto-45|<tuple|A.13|?>>
-    <associate|auto-46|<tuple|A.2.29|?>>
-    <associate|auto-47|<tuple|A.2.30|?>>
-    <associate|auto-48|<tuple|A.2.31|?>>
-    <associate|auto-49|<tuple|A.2.32|?>>
-    <associate|auto-5|<tuple|A.2.1|108>>
-    <associate|auto-50|<tuple|A.2.33|?>>
-    <associate|auto-51|<tuple|A.2.34|?>>
-    <associate|auto-52|<tuple|A.2.35|?>>
-    <associate|auto-53|<tuple|A.2.36|?>>
-    <associate|auto-54|<tuple|A.2.37|?>>
-    <associate|auto-55|<tuple|A.2.38|?>>
-    <associate|auto-56|<tuple|A.2.39|?>>
-    <associate|auto-57|<tuple|A.2.39|?>>
-    <associate|auto-6|<tuple|A.1|108>>
-    <associate|auto-7|<tuple|A.2.2|108>>
-    <associate|auto-8|<tuple|A.2.3|108>>
-    <associate|auto-9|<tuple|A.2.4|109>>
+    <associate|auto-40|<tuple|A.3.23|?>>
+    <associate|auto-41|<tuple|A.3.24|?>>
+    <associate|auto-42|<tuple|A.3.25|?>>
+    <associate|auto-43|<tuple|A.3.26|?>>
+    <associate|auto-44|<tuple|A.3.27|?>>
+    <associate|auto-45|<tuple|A.3.28|?>>
+    <associate|auto-46|<tuple|A.13|?>>
+    <associate|auto-47|<tuple|A.3.29|?>>
+    <associate|auto-48|<tuple|A.3.30|?>>
+    <associate|auto-49|<tuple|A.3.31|?>>
+    <associate|auto-5|<tuple|A.3|108>>
+    <associate|auto-50|<tuple|A.3.32|?>>
+    <associate|auto-51|<tuple|A.3.33|?>>
+    <associate|auto-52|<tuple|A.3.34|?>>
+    <associate|auto-53|<tuple|A.3.35|?>>
+    <associate|auto-54|<tuple|A.3.36|?>>
+    <associate|auto-55|<tuple|A.3.37|?>>
+    <associate|auto-56|<tuple|A.3.38|?>>
+    <associate|auto-57|<tuple|A.3.39|?>>
+    <associate|auto-58|<tuple|1.39|?>>
+    <associate|auto-6|<tuple|A.3.1|108>>
+    <associate|auto-7|<tuple|A.1|108>>
+    <associate|auto-8|<tuple|A.3.2|108>>
+    <associate|auto-9|<tuple|A.3.3|109>>
     <associate|defn-invalid-transaction|<tuple|A.11|110>>
     <associate|defn-rt-apisvec|<tuple|A.1|?>>
-    <associate|defn-rt-blockbuilder-finalize-block|<tuple|A.2.6|112>>
-    <associate|defn-rt-core-version|<tuple|A.2.1|108>>
+    <associate|defn-rt-blockbuilder-finalize-block|<tuple|A.3.6|112>>
+    <associate|defn-rt-core-version|<tuple|A.3.1|108>>
     <associate|defn-rte-apply-extrinsic-result|<tuple|A.2|?>>
     <associate|defn-rte-custom-module-error|<tuple|A.5|?>>
     <associate|defn-rte-dispatch-error|<tuple|A.4|?>>
@@ -1315,16 +1338,17 @@
     <associate|defn-transaction-validity-error|<tuple|A.10|110>>
     <associate|defn-unknown-transaction|<tuple|A.12|110>>
     <associate|defn-valid-transaction|<tuple|A.9|110>>
-    <associate|sect-babeapi_current_epoch|<tuple|A.2.30|?>>
-    <associate|sect-babeapi_generate_key_ownership_proof|<tuple|A.2.32|?>>
-    <associate|sect-grandpaapi_generate_key_ownership_proof|<tuple|A.2.27|?>>
-    <associate|sect-grandpaapi_submit_report_equivocation_unsigned_extrinsic|<tuple|A.2.26|?>>
+    <associate|sect-babeapi_current_epoch|<tuple|A.3.30|?>>
+    <associate|sect-babeapi_generate_key_ownership_proof|<tuple|A.3.32|?>>
+    <associate|sect-grandpaapi_generate_key_ownership_proof|<tuple|A.3.27|?>>
+    <associate|sect-grandpaapi_submit_report_equivocation_unsigned_extrinsic|<tuple|A.3.26|?>>
+    <associate|sect-json-rpc-api|<tuple|A.2|?>>
     <associate|sect-list-of-runtime-entries|<tuple|A.1|107>>
-    <associate|sect-rte-apply-extrinsic|<tuple|A.2.5|?>>
-    <associate|sect-rte-babeapi-epoch|<tuple|A.2.28|109>>
-    <associate|sect-rte-core-execute-block|<tuple|A.2.2|?>>
-    <associate|sect-rte-grandpa-auth|<tuple|A.2.25|109>>
-    <associate|sect-rte-validate-transaction|<tuple|A.2.10|109>>
+    <associate|sect-rte-apply-extrinsic|<tuple|A.3.5|?>>
+    <associate|sect-rte-babeapi-epoch|<tuple|A.3.28|109>>
+    <associate|sect-rte-core-execute-block|<tuple|A.3.2|?>>
+    <associate|sect-rte-grandpa-auth|<tuple|A.3.25|109>>
+    <associate|sect-rte-validate-transaction|<tuple|A.3.10|109>>
     <associate|sect-runtime-entries|<tuple|A|107>>
     <associate|snippet-runtime-enteries|<tuple|A.1|107>>
   </collection>

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -745,19 +745,83 @@
 
   \;
 
-  <strong|Returns>:
+  <strong|Return>:
 
   <\itemize-dot>
-    <item>A 64-bit integer representing the slot number.
+    <item>A unsigned 64-bit integer representing the slot number.
   </itemize-dot>
 
-  <subsection|<verbatim|BabeApi_current_epoch>>
+  <subsection|<verbatim|BabeApi_current_epoch>><label|sect-babeapi_current_epoch>
+
+  Produces information about the current epoch.
 
   \;
+
+  <strong|Arguments>:
+
+  <\itemize-dot>
+    <item>None
+  </itemize-dot>
+
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>A datastructure of the following format:
+
+    <\equation*>
+      <around*|(|E<rsub|i>,S<rsub|s>,d,A,r|)>
+    </equation*>
+
+    where:
+
+    <\itemize-dot>
+      <item><math|E<rsub|i>> is a unsigned 64-bit integer representing the
+      epoch index.
+
+      <item><math|S<rsub|s>> is a unsigned 64-bit integer representing the
+      starting slot of the epoch.
+
+      <item><math|d> is a unsigned 64-bit integer representing the duration
+      of the epoch.
+
+      <item><math|A> is an array of varying size containing tuple pairs of
+      the following format:
+
+      <\equation*>
+        <around*|(|A<rsub|id>,w|)>
+      </equation*>
+
+      where <math|A<rsub|id>> is the 256-bit public key of an authority and
+      <math|w> is a unsigned 64-bit integer representing the weight of an
+      authority. <todo|what does this weight indicate?>
+
+      <item><math|r> is an 256-bit array containing the randomness for the
+      epoch <todo|reference randomness>
+    </itemize-dot>
+  </itemize-dot>
 
   <subsection|<verbatim|BabeApi_next_epoch>>
 
+  Produces information about the next epoch.
+
   \;
+
+  <strong|Arguments>:
+
+  <\itemize-dot>
+    <item>None
+  </itemize-dot>
+
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>Returns the same datastructure as described in Section
+    <reference|sect-babeapi_current_epoch>.
+  </itemize-dot>
 
   <subsection|<verbatim|BabeApi_generate_key_ownership_proof>>
 
@@ -890,6 +954,7 @@
     <associate|defn-transaction-validity-error|<tuple|A.10|110>>
     <associate|defn-unknown-transaction|<tuple|A.12|110>>
     <associate|defn-valid-transaction|<tuple|A.9|110>>
+    <associate|sect-babeapi_current_epoch|<tuple|A.2.30|?>>
     <associate|sect-grandpaApi_submit_report_equivocation_unsigned_extrinsic|<tuple|A.2.26|?>>
     <associate|sect-grandpaapi_generate_key_ownership_proof|<tuple|A.2.27|?>>
     <associate|sect-grandpaapi_submit_report_equivocation_unsigned_extrinsic|<tuple|A.2.26|?>>

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -701,7 +701,10 @@
 
   <strong|Return>:
 
-  A tuple containing configuration data used by the Babe consensus engine.
+  <\itemize-dot>
+    <item>A tuple containing configuration data used by the Babe consensus
+    engine.
+  </itemize-dot>
 
   <\big-table|<tabular|<tformat|<cwith|1|1|1|-1|cell-tborder|1ln>|<cwith|1|1|1|1|cell-lborder|0ln>|<cwith|1|1|3|3|cell-rborder|0ln>|<cwith|18|18|1|-1|cell-bborder|1ln>|<cwith|2|-1|1|1|cell-lborder|0ln>|<cwith|2|-1|3|3|cell-rborder|0ln>|<cwith|2|2|1|-1|cell-tborder|1ln>|<cwith|1|1|1|-1|cell-bborder|1ln>|<cwith|2|4|1|1|cell-lborder|0ln>|<cwith|2|4|3|3|cell-rborder|0ln>|<cwith|5|5|1|-1|cell-tborder|1ln>|<cwith|4|4|1|-1|cell-bborder|1ln>|<cwith|5|6|1|1|cell-lborder|0ln>|<cwith|5|6|3|3|cell-rborder|0ln>|<cwith|7|7|1|-1|cell-tborder|1ln>|<cwith|6|6|1|-1|cell-bborder|1ln>|<cwith|7|10|1|1|cell-lborder|0ln>|<cwith|7|10|3|3|cell-rborder|0ln>|<cwith|11|11|1|-1|cell-tborder|1ln>|<cwith|10|10|1|-1|cell-bborder|1ln>|<cwith|11|15|1|1|cell-lborder|0ln>|<cwith|11|15|3|3|cell-rborder|0ln>|<cwith|16|16|1|-1|cell-tborder|1ln>|<cwith|15|15|1|-1|cell-bborder|1ln>|<cwith|16|16|1|-1|cell-bborder|1ln>|<cwith|17|17|1|-1|cell-tborder|1ln>|<cwith|16|16|1|1|cell-lborder|0ln>|<cwith|16|16|3|3|cell-rborder|0ln>|<table|<row|<cell|<strong|Name>>|<cell|<strong|Description>>|<cell|<strong|Type>>>|<row|<cell|SlotDuration>|<cell|The
   slot duration in milliseconds. Currently, only the value
@@ -730,7 +733,23 @@
 
   <subsection|<verbatim|BabeApi_current_epoch_start>>
 
+  Finds the start slot of the current epoch.
+
   \;
+
+  <strong|Arguments>:
+
+  <\itemize-dot>
+    <item>None
+  </itemize-dot>
+
+  \;
+
+  <strong|Returns>:
+
+  <\itemize-dot>
+    <item>A 64-bit integer representing the slot number.
+  </itemize-dot>
 
   <subsection|<verbatim|BabeApi_current_epoch>>
 

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -823,7 +823,7 @@
     <reference|sect-babeapi_current_epoch>.
   </itemize-dot>
 
-  <subsection|<verbatim|BabeApi_generate_key_ownership_proof>>
+  <subsection|<verbatim|BabeApi_generate_key_ownership_proof>><label|sect-babeapi_generate_key_ownership_proof>
 
   Generates a proof of the membership of a key owner in the specified block
   state. The returned value is used to report equivocations as described in
@@ -850,7 +850,28 @@
 
   <subsection|<verbatim|BabeApi_submit_report_equivocation_unsigned_extrinsic>>
 
+  Submits a report about an observed equivocation as defined in <todo|spec
+  Babe equivocations>.
+
   \;
+
+  <strong|Arguments>:
+
+  <\itemize-dot>
+    <item>The equivocation proof. <todo|reference that type>
+
+    <item>An proof of the key owner in an opaque form as described in Section
+    <reference|sect-babeapi_generate_key_ownership_proof>.
+  </itemize-dot>
+
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>A SCALE encoded <verbatim|Option> as defined in Definition
+    <reference|defn-option-type> containing an empty value on success.
+  </itemize-dot>
 
   <subsection|<verbatim|AuthorityDiscoveryApi_authorities>>
 
@@ -976,6 +997,7 @@
     <associate|defn-unknown-transaction|<tuple|A.12|110>>
     <associate|defn-valid-transaction|<tuple|A.9|110>>
     <associate|sect-babeapi_current_epoch|<tuple|A.2.30|?>>
+    <associate|sect-babeapi_generate_key_ownership_proof|<tuple|A.2.32|?>>
     <associate|sect-grandpaApi_submit_report_equivocation_unsigned_extrinsic|<tuple|A.2.26|?>>
     <associate|sect-grandpaapi_generate_key_ownership_proof|<tuple|A.2.27|?>>
     <associate|sect-grandpaapi_submit_report_equivocation_unsigned_extrinsic|<tuple|A.2.26|?>>

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -975,7 +975,23 @@
 
   <subsection|<verbatim|AccountNonceApi_account_nonce>>
 
+  Get the current nonce of an account.
+
   \;
+
+  <strong|Arguments>:
+
+  <\itemize-dot>
+    <item>The 256-bit public key of the account.
+  </itemize-dot>
+
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>A 32-bit unsigned integer indicating the nonce of the account.
+  </itemize-dot>
 
   <subsection|<verbatim|TransactionPaymentApi_query_info>>
 

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -995,7 +995,51 @@
 
   <subsection|<verbatim|TransactionPaymentApi_query_info>>
 
+  Returns information about an extrinsic. This function is not aware of the
+  internals of an extrinsic, but only interprets the extrinsic as some
+  encoded value and accounts for its weight and length, the runtime's
+  extrinsic base weight and the current fee multiplier.
+
   \;
+
+  Arguments:
+
+  <\itemize-dot>
+    <item>The raw extrinsic.
+
+    <item>The length of the extrinsics <todo|why is this needed?>
+  </itemize-dot>
+
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>A datastructure of the following format:
+
+    <\equation*>
+      <around*|(|w,c,f|)>
+    </equation*>
+
+    where:
+
+    <\itemize-dot>
+      <item><math|w> is the weight of the extrinsic.
+
+      <item><math|c> is the \Pclass\Q of the extrinsic, where class is a
+      varying datatype defined as:
+
+      <\equation*>
+        c=<choice|<tformat|<table|<row|<cell|0<space|1em>Normal
+        extrinsic>>|<row|<cell|1<space|1em>Operational
+        extrinsic>>|<row|<cell|2<space|1em>Mandatory extrinsic,which is
+        always included>>>>>
+      </equation*>
+
+      <item><math|f> is the inclusion fee of this dispatch. This does not
+      include a tip or anything else that depends on the signature.
+    </itemize-dot>
+  </itemize-dot>
 
   <subsection|<verbatim|TransactionPaymentApi_query_fee_details>>
 

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -633,7 +633,7 @@
   get tracked via Runtiem-to-consensus engine messages as described in
   Section <reference|sect-consensus-message-digest>.
 
-  <subsection|<verbatim|GrandpaApi_submit_report_equivocation_unsigned_extrinsic>>
+  <subsection|<verbatim|GrandpaApi_submit_report_equivocation_unsigned_extrinsic>><label|sect-grandpaapi_submit_report_equivocation_unsigned_extrinsic>
 
   Submits a report about an observed equivocation as defined in Definition
   <reference|defn-equivocation>.
@@ -645,7 +645,8 @@
   <\itemize-dot>
     <item>The equivocation proof. <todo|reference that type>
 
-    <item>An opaque byte slice used to represent the key ownership proof.
+    <item>An proof of the key owner in an opaque form as described in Section
+    <reference|sect-grandpaapi_generate_key_ownership_proof>.
   </itemize-dot>
 
   \;
@@ -654,13 +655,34 @@
 
   <\itemize-dot>
     <item>A SCALE encoded <verbatim|Option> as defined in Definition
-    <reference|defn-option-type> containing an empty <verbatim|Some> value on
-    success or <verbatim|None> on failure.
+    <reference|defn-option-type> containing an empty value on success.
   </itemize-dot>
 
-  <subsection|<verbatim|GrandpaApi_generate_key_ownership_proof>>
+  <subsection|<verbatim|GrandpaApi_generate_key_ownership_proof>><label|sect-grandpaapi_generate_key_ownership_proof>
+
+  Generates a proof of the membership of a key owner in the specified block
+  state. The returned value is used to report equivocations as described in
+  Section <reference|sect-grandpaapi_submit_report_equivocation_unsigned_extrinsic>.
 
   \;
+
+  <strong|Arguments>:
+
+  <\itemize-dot>
+    <item>The authority set Id as defined in Definition
+    <reference|defn-authority-set-id>.
+
+    <item>The 256-bit public key of the authority.
+  </itemize-dot>
+
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>A SCALE encoded <verbatim|Option> as defined in Definition
+    <reference|defn-option-type> containing the proof in an opaque form.
+  </itemize-dot>
 
   <subsection|<verbatim|BabeApi_configuration>><label|sect-rte-babeapi-epoch>
 
@@ -849,6 +871,9 @@
     <associate|defn-transaction-validity-error|<tuple|A.10|110>>
     <associate|defn-unknown-transaction|<tuple|A.12|110>>
     <associate|defn-valid-transaction|<tuple|A.9|110>>
+    <associate|sect-grandpaApi_submit_report_equivocation_unsigned_extrinsic|<tuple|A.2.26|?>>
+    <associate|sect-grandpaapi_generate_key_ownership_proof|<tuple|A.2.27|?>>
+    <associate|sect-grandpaapi_submit_report_equivocation_unsigned_extrinsic|<tuple|A.2.26|?>>
     <associate|sect-list-of-runtime-entries|<tuple|A.1|107>>
     <associate|sect-rte-apply-extrinsic|<tuple|A.2.5|?>>
     <associate|sect-rte-babeapi-epoch|<tuple|A.2.28|109>>

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -275,7 +275,9 @@
 
   <\itemize-dot>
     <item>Returns the varying datatype <strong|<em|ApplyExtrinsicResult>> as
-    defined in Definition <reference|defn-rte-apply-extrinsic-result>.
+    defined in Definition <reference|defn-rte-apply-extrinsic-result>. This
+    structure let's the block builder know whether an extrinsic should be
+    included into the block or rejected.
 
     \;
   </itemize-dot>
@@ -286,6 +288,16 @@
     <reference|defn-result-type>. This structure can contain multiple nested
     structures, indicating either module dispatch outcomes or transaction
     invalidity errors.
+
+    \;
+
+    <strong|NOTE>: When applying an extrinsic returns a
+    <strong|DispatchOutcome> (<reference|defn-rte-dispatch-outcome>), the
+    extrinsic is always included into the block, even if the outcome is a
+    dispatch error. Dispatch errors do not invalidate the block and all state
+    changes are persisted. When applying an extrinsics returns
+    <strong|TransactionValidityError> (<reference|defn-rte-transaction-validity-error>),
+    the extrinsic must rejected.
 
     <\big-table|<tabular|<tformat|<cwith|2|2|1|-1|cell-bborder|1ln>|<cwith|3|3|1|-1|cell-tborder|1ln>|<cwith|2|2|1|1|cell-lborder|0ln>|<cwith|2|2|3|3|cell-rborder|0ln>|<cwith|1|1|1|-1|cell-tborder|0ln>|<cwith|1|1|1|-1|cell-bborder|1ln>|<cwith|2|2|1|-1|cell-tborder|1ln>|<cwith|1|1|1|1|cell-lborder|0ln>|<cwith|1|1|3|3|cell-rborder|0ln>|<cwith|4|4|1|-1|cell-tborder|0ln>|<cwith|3|3|1|-1|cell-bborder|0ln>|<cwith|4|4|1|-1|cell-bborder|1ln>|<cwith|4|4|1|1|cell-lborder|0ln>|<cwith|4|4|3|3|cell-rborder|0ln>|<table|<row|<cell|<strong|Id>>|<cell|<strong|Description>>|<cell|<strong|Type>>>|<row|<cell|0>|<cell|Outcome
     of dispatching the extrinsic.>|<cell|DispatchOutcome
@@ -1295,7 +1307,6 @@
     <associate|sect-rte-grandpa-auth|<tuple|A.2.25|109>>
     <associate|sect-rte-validate-transaction|<tuple|A.2.10|109>>
     <associate|sect-runtime-entries|<tuple|A|107>>
-    <associate|sect-sessionkeys_generate_session_keys|<tuple|A.2.35|?>>
     <associate|snippet-runtime-enteries|<tuple|A.1|107>>
   </collection>
 </references>
@@ -1395,7 +1406,7 @@
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-8>>
 
-      <with|par-left|<quote|1tab>|A.2.4<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|Metadata_metadatabb>
+      <with|par-left|<quote|1tab>|A.2.4<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|Metadata_metadata>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-9>>
 

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -266,7 +266,7 @@
   <strong|Arguments>:
 
   <\itemize>
-    <item>An extrinisic.
+    <item>A byte array of varying size containing the extrinsic.
   </itemize>
 
   \;

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -633,6 +633,31 @@
   get tracked via Runtiem-to-consensus engine messages as described in
   Section <reference|sect-consensus-message-digest>.
 
+  \;
+
+  <strong|Arguments>:
+
+  <\itemize-dot>
+    <item>None.
+  </itemize-dot>
+
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>An array of variying size containg tuple pairs of the following
+    format:
+
+    <\equation*>
+      <around*|(|A<rsub|id>,w|)>
+    </equation*>
+
+    where <math|A<rsub|id>> is the 256-bit public key of an authority and
+    <math|w> is a unsigned 64-bit integer representing the weight of an
+    authority. <todo|what does this weight indicate?>
+  </itemize-dot>
+
   <subsection|<verbatim|GrandpaApi_submit_report_equivocation_unsigned_extrinsic>><label|sect-grandpaapi_submit_report_equivocation_unsigned_extrinsic>
 
   Submits a report about an observed equivocation as defined in Definition
@@ -694,7 +719,7 @@
   <strong|Arguments>:
 
   <\itemize>
-    <item>None
+    <item>None.
   </itemize>
 
   \;
@@ -740,7 +765,7 @@
   <strong|Arguments>:
 
   <\itemize-dot>
-    <item>None
+    <item>None.
   </itemize-dot>
 
   \;
@@ -760,7 +785,7 @@
   <strong|Arguments>:
 
   <\itemize-dot>
-    <item>None
+    <item>None.
   </itemize-dot>
 
   \;
@@ -811,7 +836,7 @@
   <strong|Arguments>:
 
   <\itemize-dot>
-    <item>None
+    <item>None.
   </itemize-dot>
 
   \;
@@ -998,7 +1023,6 @@
     <associate|defn-valid-transaction|<tuple|A.9|110>>
     <associate|sect-babeapi_current_epoch|<tuple|A.2.30|?>>
     <associate|sect-babeapi_generate_key_ownership_proof|<tuple|A.2.32|?>>
-    <associate|sect-grandpaApi_submit_report_equivocation_unsigned_extrinsic|<tuple|A.2.26|?>>
     <associate|sect-grandpaapi_generate_key_ownership_proof|<tuple|A.2.27|?>>
     <associate|sect-grandpaapi_submit_report_equivocation_unsigned_extrinsic|<tuple|A.2.26|?>>
     <associate|sect-list-of-runtime-entries|<tuple|A.1|107>>

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -197,9 +197,9 @@
   <strong|Arguments>:
 
   <\itemize>
-    <item>The entry accepts a block, represented as a tuple consisting of a
-    block header as described in section <reference|defn-block-header> and
-    the block body as described in section <reference|defn-block-body>.
+    <item>A block represented as a tuple consisting of a block header as
+    described in section <reference|defn-block-header> and the block body as
+    described in section <reference|defn-block-body>.
   </itemize>
 
   \;
@@ -233,7 +233,7 @@
     <item>None.
   </itemize-dot>
 
-  <subsection|<verbatim|Metadata_metadatabb>>
+  <subsection|<verbatim|Metadata_metadata>>
 
   Returns native Runtime metadata in an opaque form.
 
@@ -250,8 +250,7 @@
   <strong|Return>:
 
   <\itemize-dot>
-    <item>A byte slice of unknown length containing the metadata in an opaque
-    form.
+    <item>A array of varying size containing the metadata in an opaque form.
   </itemize-dot>
 
   <subsection|<verbatim|BlockBuilder_apply_extrinsic>>
@@ -442,11 +441,66 @@
 
   <subsection|<verbatim|BlockBuilder_check_inherents>>
 
+  Checks whether the provided inherent is valid.
+
   \;
+
+  <strong|Arguments>:
+
+  <\itemize-dot>
+    <item>A block represented as a tuple consisting of a block header as
+    described in section <reference|defn-block-header> and the block body as
+    described in section <reference|defn-block-body>.
+
+    <item>A <name|Inherents-Data> structure as defined in
+    <reference|defn-inherent-data>.
+  </itemize-dot>
+
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>A datastructure of the following format:
+
+    <\equation*>
+      <around*|(|o,f<rsub|e>,e|)>
+    </equation*>
+
+    where
+
+    <\itemize-dot>
+      <item><math|o> is a boolean indicating whether the check was
+      successful.
+
+      <item><math|f<rsub|e>> is a boolean indicating whether a fatal error
+      was encountered.
+
+      <item><math|e> is a <name|Inherents-Data> structure as defined in
+      <reference|defn-inherent-data> containing any errors created by this
+      Runtime function.
+    </itemize-dot>
+  </itemize-dot>
 
   <subsection|<verbatim|BlockBuilder_random_seed>>
 
+  Generates a random seed.
+
   \;
+
+  <strong|Arguments>:
+
+  <\itemize-dot>
+    <item>None.
+  </itemize-dot>
+
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>A 32-byte array containing the random seed.
+  </itemize-dot>
 
   <subsection|<verbatim|TaggedTransactionQueue_validate_transaction>><label|sect-rte-validate-transaction>
 
@@ -571,7 +625,24 @@
 
   <subsection|<verbatim|OffchainWorkerApi_offchain_worker>>
 
-  \ <todo|future-reserved>
+  Starts an offchain worker and generates extrinsics. <todo|when is this
+  called?>
+
+  \;
+
+  <strong|Arguments>:
+
+  <\itemize-dot>
+    <item>A block header
+  </itemize-dot>
+
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>None.
+  </itemize-dot>
 
   <subsection|<verbatim|ParachainHost_validators>>
 
@@ -796,16 +867,16 @@
     <item>A datastructure of the following format:
 
     <\equation*>
-      <around*|(|E<rsub|i>,S<rsub|s>,d,A,r|)>
+      <around*|(|e<rsub|i>,s<rsub|s>,d,A,r|)>
     </equation*>
 
     where:
 
     <\itemize-dot>
-      <item><math|E<rsub|i>> is a unsigned 64-bit integer representing the
+      <item><math|e<rsub|i>> is a unsigned 64-bit integer representing the
       epoch index.
 
-      <item><math|S<rsub|s>> is a unsigned 64-bit integer representing the
+      <item><math|s<rsub|s>> is a unsigned 64-bit integer representing the
       starting slot of the epoch.
 
       <item><math|d> is a unsigned 64-bit integer representing the duration
@@ -823,7 +894,7 @@
       authority. <todo|what does this weight indicate?>
 
       <item><math|r> is an 256-bit array containing the randomness for the
-      epoch <todo|reference randomness>
+      epoch as defined in Definition <reference|defn-epoch-randomness>.
     </itemize-dot>
   </itemize-dot>
 
@@ -852,14 +923,14 @@
 
   Generates a proof of the membership of a key owner in the specified block
   state. The returned value is used to report equivocations as described in
-  <todo|did we mention equivocation regarding Babe anywhere?>.
+  <todo|spec Babe equivocation>.
 
   \;
 
   <strong|Arguments>:
 
   <\itemize-dot>
-    <item>The usigned 64-bit integer representing the slot number.
+    <item>The unsigned 64-bit integer indicating the slot number.
 
     <item>The 256-bit public key of the authority.
   </itemize-dot>
@@ -1080,11 +1151,10 @@
       where
 
       <\itemize-dot>
-        <item><math|f<rsub|b>> is the minimum amount a user pays for a
-        transaction.
+        <item><math|f<rsub|b>> is the minimum required fee for an extrinsic.
 
         <item><math|f<rsub|l>> is the length fee, the amount paid for the
-        encoded length (in bytes) of the transaction.
+        encoded length (in bytes) of the extrinsic.
 
         <item><math|f<rsub|a>> is the \Padjusted weight fee\Q, which is a
         multiplication of the fee multiplier and the weight fee. The fee

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -921,7 +921,27 @@
 
   <subsection|<verbatim|SessionKeys_generate_session_keys>>
 
+  Generates a set of session keys with an optional seed. The keys should be
+  stored within the keystore exposed by the Host Api. The seed needs to be
+  valid UTF8 encoded.
+
   \;
+
+  <strong|Arguments>:
+
+  <\itemize-dot>
+    <item>A SCALE encoded <verbatim|Option> as defined in Definition
+    <reference|defn-option-type> containing an array of varying size
+    representing the seed.
+  </itemize-dot>
+
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>An array of varying size containg the session keys.
+  </itemize-dot>
 
   <subsection|<verbatim|SessionKeys_decode_session_keys>>
 

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -900,7 +900,24 @@
 
   <subsection|<verbatim|AuthorityDiscoveryApi_authorities>>
 
+  A function which helps to discover authorities.
+
   \;
+
+  <strong|Arguments>:
+
+  <\itemize-dot>
+    <item>None.
+  </itemize-dot>
+
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>An array of varying size containing 256-bit pulic keys of
+    authorities.
+  </itemize-dot>
 
   <subsection|<verbatim|SessionKeys_generate_session_keys>>
 

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -17,72 +17,83 @@
 
   <\small-figure>
     <\cpp-code>
-      \ \ (export "Core_version" (func $Core_version))
+      \ \ (export "Core_version")
 
-      \ \ (export "Core_execute_block" (func $Core_execute_block))
+      \ \ (export "Core_execute_block")
 
-      \ \ (export "Core_initialize_block" (func $Core_initialize_block))
+      \ \ (export "Core_initialize_block")
 
-      \ \ (export "Metadata_metadata" (func $Metadata_metadata))
+      \ \ (export "Metadata_metadata")
 
-      \ \ (export "BlockBuilder_apply_extrinsic" (func
-      $BlockBuilder_apply_extrinsic))
+      \ \ (export "BlockBuilder_apply_extrinsic")
 
-      \ \ (export "BlockBuilder_finalize_block" (func
-      $BlockBuilder_finalize_block))
+      \ \ (export "BlockBuilder_finalize_block")
 
-      \ \ (export "BlockBuilder_inherent_extrinsics"\ 
+      \ \ (export "BlockBuilder_inherent_extrinsics")
 
-      \ \ \ \ \ \ \ \ \ \ (func $BlockBuilder_inherent_extrinsics))
+      \ \ (export "BlockBuilder_check_inherents")
 
-      \ \ (export "BlockBuilder_check_inherents" (func
-      $BlockBuilder_check_inherents))
+      \ \ (export "BlockBuilder_random_seed")
 
-      \ \ (export "BlockBuilder_random_seed" (func
-      $BlockBuilder_random_seed))
+      \ \ (export "TaggedTransactionQueue_validate_transaction")
 
-      \ \ (export "TaggedTransactionQueue_validate_transaction"\ 
+      \ \ (export "OffchainWorkerApi_offchain_worker")
 
-      \ \ \ \ \ \ \ \ \ \ (func $TaggedTransactionQueue_validate_transaction))
+      \ \ (export "ParachainHost_validators")
 
-      \ \ (export "OffchainWorkerApi_offchain_worker"\ 
+      \ \ (export "ParachainHost_validator_groups")
 
-      \ \ \ \ \ \ \ \ \ \ (func $OffchainWorkerApi_offchain_worker))
+      \ \ (export "ParachainHost_availability_cores")
 
-      \ \ (export "ParachainHost_validators" (func
-      $ParachainHost_validators))
+      \ \ (export "ParachainHost_persisted_validation_data")
 
-      \ \ (export "ParachainHost_duty_roster" (func
-      $ParachainHost_duty_roster))
+      \ \ (export "ParachainHost_check_validation_outputs")
 
-      \ \ (export "ParachainHost_active_parachains"\ 
+      \ \ (export "ParachainHost_session_index_for_child")
 
-      \ \ \ \ \ \ \ \ \ \ (func $ParachainHost_active_parachains))
+      \ \ (export "ParachainHost_session_info")
 
-      \ \ (export "ParachainHost_parachain_status" (func
-      $ParachainHost_parachain_status))
+      \ \ (export "ParachainHost_validation_code")
 
-      \ \ (export "ParachainHost_parachain_code" (func
-      $ParachainHost_parachain_code))
+      \ \ (export "ParachainHost_historical_validation_code")
 
-      \ \ (export "ParachainHost_ingress" (func $ParachainHost_ingress))
+      \ \ (export "ParachainHost_candidate_pending_availability")
 
-      \ \ (export "GrandpaApi_grandpa_pending_change"\ 
+      \ \ (export "ParachainHost_candidate_events")
 
-      \ \ \ \ \ \ \ \ \ \ (func $GrandpaApi_grandpa_pending_change))
+      \ \ (export "ParachainHost_dmq_contents")
 
-      \ \ (export "GrandpaApi_grandpa_forced_change"\ 
+      \ \ (export "ParachainHost_inbound_hrmp_channels_contents")
 
-      \ \ \ \ \ \ \ \ \ \ (func $GrandpaApi_grandpa_forced_change))
+      \ \ (export "GrandpaApi_authorities")
 
-      \ \ (export "GrandpaApi_grandpa_authorities" (func
-      $GrandpaApi_grandpa_authorities))
+      \ \ (export "GrandpaApi_submit_report_equivocation_unsigned_extrinsic")
 
-      \ \ (export "BabeApi_configuration" (func $BabeApi_configuration))
+      \ \ (export "GrandpaApi_generate_key_ownership_proof")
 
-      \ \ (export "SessionKeys_generate_session_keys"\ 
+      \ \ (export "BabeApi_configuration")
 
-      \ \ \ \ \ \ \ \ \ \ (func $SessionKeys_generate_session_keys))
+      \ \ (export "BabeApi_current_epoch_start")
+
+      \ \ (export "BabeApi_current_epoch")
+
+      \ \ (export "BabeApi_next_epoch")
+
+      \ \ (export "BabeApi_generate_key_ownership_proof")
+
+      \ \ (export "BabeApi_submit_report_equivocation_unsigned_extrinsic")
+
+      \ \ (export "AuthorityDiscoveryApi_authorities")
+
+      \ \ (export "SessionKeys_generate_session_keys")
+
+      \ \ (export "SessionKeys_decode_session_keys")
+
+      \ \ (export "AccountNonceApi_account_nonce")
+
+      \ \ (export "TransactionPaymentApi_query_info")
+
+      \ \ (export "TransactionPaymentApi_query_fee_details")
 
       \;
     </cpp-code>
@@ -222,7 +233,7 @@
     <item>None.
   </itemize-dot>
 
-  <subsection|<verbatim|Metadata_metadata>>
+  <subsection|<verbatim|Metadata_metadatabb>>
 
   Returns native Runtime metadata in an opaque form.
 

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -136,36 +136,51 @@
 
   <subsection|<verbatim|Core_version>><label|defn-rt-core-version>
 
-  This entry receives no argument; it returns the version data encoded in ABI
-  format described in Section <reference|sect-runtime-return-value>
-  containing the following information:
+  Returns the version identifiers of the Runtime. This function can be used
+  by the Polkadot Host implementation when it seems appropriate.
 
-  <verbatim|>
+  \;
 
-  <\with|par-mode|center>
-    <small-table|<tabular|<tformat|<cwith|1|8|1|1|cell-halign|l>|<cwith|1|8|1|1|cell-lborder|0ln>|<cwith|1|8|2|2|cell-halign|l>|<cwith|1|8|3|3|cell-halign|l>|<cwith|1|8|3|3|cell-rborder|0ln>|<cwith|1|8|1|3|cell-valign|c>|<cwith|1|1|1|3|cell-tborder|1ln>|<cwith|1|1|1|3|cell-bborder|1ln>|<cwith|8|8|1|3|cell-bborder|1ln>|<cwith|2|-1|1|1|font-base-size|8>|<cwith|2|-1|2|-1|font-base-size|8>|<table|<row|<cell|Name>|<cell|Type>|<cell|Description>>|<row|<cell|<verbatim|spec_name>>|<cell|String>|<cell|Runtime
-    identifier>>|<row|<cell|<verbatim|impl_name>>|<cell|String>|<cell|the
-    name of the implementation (e.g. C++)>>|<row|<cell|<verbatim|authoring_version>>|<cell|UINT32>|<cell|the
-    version of the authorship interface>>|<row|<cell|<verbatim|spec_version>>|<cell|UINT32>|<cell|the
-    version of the Runtime specification>>|<row|<cell|<verbatim|impl_version>>|<cell|UINT32>|<cell|the
-    v<verbatim|>ersion of the Runtime implementation>>|<row|<cell|<verbatim|apis>>|<cell|ApisVec
-    (<reference|defn-rt-apisvec>)>|<cell|List of supported APIs along with
-    their version>>|<row|<cell|<verbatim|transaction_version>>|<cell|UINT32>|<cell|the
-    version of the transaction format>>>>>|Detail of the version data type
-    returns from runtime <verbatim|version> function.>
-  </with>
+  <strong|Arguments>:
 
-  <\definition>
-    <label|defn-rt-apisvec><strong|ApisVec> is a specialised type for the
-    <verbatim|Core_version> (<reference|defn-rt-core-version>) function
-    entry. It represents an array of tuples, where the first value of the
-    tuple is an array of 8-bytes indicating the API name. The second value of
-    the tuple is the version number of the corresponding API.
+  <\itemize-dot>
+    <item>None
+  </itemize-dot>
 
-    <\eqnarray*>
-      <tformat|<table|<row|<cell|ApiVec>|<cell|\<assign\>>|<cell|<around*|(|T<rsub|0>,\<ldots\>,T<rsub|n>|)>>>|<row|<cell|T>|<cell|\<assign\>>|<cell|<around*|(|<around*|(|b<rsub|0>,\<ldots\>,b<rsub|7>|)>,UINT32|)>>>>>
-    </eqnarray*>
-  </definition>
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>A datastructure of the following format:
+
+    \;
+
+    <\with|par-mode|center>
+      <small-table|<tabular|<tformat|<cwith|1|8|1|1|cell-halign|l>|<cwith|1|8|1|1|cell-lborder|0ln>|<cwith|1|8|2|2|cell-halign|l>|<cwith|1|8|3|3|cell-halign|l>|<cwith|1|8|3|3|cell-rborder|0ln>|<cwith|1|8|1|3|cell-valign|c>|<cwith|1|1|1|3|cell-tborder|1ln>|<cwith|1|1|1|3|cell-bborder|1ln>|<cwith|8|8|1|3|cell-bborder|1ln>|<cwith|2|-1|1|1|font-base-size|8>|<cwith|2|-1|2|-1|font-base-size|8>|<table|<row|<cell|Name>|<cell|Type>|<cell|Description>>|<row|<cell|<verbatim|spec_name>>|<cell|String>|<cell|Runtime
+      identifier>>|<row|<cell|<verbatim|impl_name>>|<cell|String>|<cell|the
+      name of the implementation (e.g. C++)>>|<row|<cell|<verbatim|authoring_version>>|<cell|UINT32>|<cell|the
+      version of the authorship interface>>|<row|<cell|<verbatim|spec_version>>|<cell|UINT32>|<cell|the
+      version of the Runtime specification>>|<row|<cell|<verbatim|impl_version>>|<cell|UINT32>|<cell|the
+      v<verbatim|>ersion of the Runtime implementation>>|<row|<cell|<verbatim|apis>>|<cell|ApisVec
+      (<reference|defn-rt-apisvec>)>|<cell|List of supported APIs along with
+      their version>>|<row|<cell|<verbatim|transaction_version>>|<cell|UINT32>|<cell|the
+      version of the transaction format>>>>>|Detail of the version data type
+      returns from runtime <verbatim|version> function.>
+    </with>
+
+    <\definition>
+      <label|defn-rt-apisvec><strong|ApisVec> is a specialised type for the
+      <verbatim|Core_version> (<reference|defn-rt-core-version>) function
+      entry. It represents an array of tuples, where the first value of the
+      tuple is an array of 8-bytes indicating the API name. The second value
+      of the tuple is the version number of the corresponding API.
+
+      <\eqnarray*>
+        <tformat|<table|<row|<cell|ApiVec>|<cell|\<assign\>>|<cell|<around*|(|T<rsub|0>,\<ldots\>,T<rsub|n>|)>>>|<row|<cell|T>|<cell|\<assign\>>|<cell|<around*|(|<around*|(|b<rsub|0>,\<ldots\>,b<rsub|7>|)>,UINT32|)>>>>>
+      </eqnarray*>
+    </definition>
+  </itemize-dot>
 
   <subsection|<verbatim|Core_execute_block>><label|sect-rte-core-execute-block>
 
@@ -234,7 +249,8 @@
 
   <subsection|<verbatim|Metadata_metadata>>
 
-  Returns native Runtime metadata in an opaque form.
+  Returns native Runtime metadata in an opaque form. This function can be
+  used for logging purposes.
 
   \;
 
@@ -470,7 +486,9 @@
 
   <subsection|<verbatim|BlockBuilder_check_inherents>>
 
-  Checks whether the provided inherent is valid.
+  Checks whether the provided inherent is valid. This function can be used by
+  the Polkadot Host implementation when verifying the validaity of an
+  inherent seems appropriate, such as during a block building process.
 
   \;
 
@@ -513,7 +531,8 @@
 
   <subsection|<verbatim|BlockBuilder_random_seed>>
 
-  Generates a random seed.
+  Generates a random seed. <todo|there is currently no requirement for having
+  to call this function.>
 
   \;
 
@@ -1277,6 +1296,7 @@
     <associate|auto-54|<tuple|A.2.37|?>>
     <associate|auto-55|<tuple|A.2.38|?>>
     <associate|auto-56|<tuple|A.2.39|?>>
+    <associate|auto-57|<tuple|A.2.39|?>>
     <associate|auto-6|<tuple|A.1|108>>
     <associate|auto-7|<tuple|A.2.2|108>>
     <associate|auto-8|<tuple|A.2.3|108>>

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -1,8 +1,8 @@
-<TeXmacs|1.99.11>
+<TeXmacs|1.99.16>
 
 <project|host-spec.tm>
 
-<style|<tuple|book|old-dots>>
+<style|<tuple|book|old-dots|old-lengths>>
 
 <\body>
   <appendix|Runtime Entries><label|sect-runtime-entries>
@@ -220,6 +220,27 @@
 
   <\itemize-dot>
     <item>None.
+  </itemize-dot>
+
+  <subsection|<verbatim|Metadata_metadata>>
+
+  Returns native Runtime metadata in an opaque form.
+
+  \;
+
+  <strong|Arguments>:
+
+  <\itemize-dot>
+    <item>None.
+  </itemize-dot>
+
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>A byte slice of unknown length containing the metadata in an opaque
+    form.
   </itemize-dot>
 
   <subsection|<verbatim|hash_and_length>><label|sect-rte-hash-and-length>
@@ -616,11 +637,13 @@
 
 <\initial>
   <\collection>
-    <associate|chapter-nr|6>
-    <associate|page-first|113>
+    <associate|chapter-nr|8>
+    <associate|page-first|139>
     <associate|page-height|auto>
     <associate|page-type|letter>
     <associate|page-width|auto>
+    <associate|section-nr|2<uninit>>
+    <associate|subsection-nr|0>
   </collection>
 </initial>
 
@@ -628,24 +651,25 @@
   <\collection>
     <associate|auto-1|<tuple|A|107>>
     <associate|auto-10|<tuple|A.2.5|109>>
-    <associate|auto-11|<tuple|A.2|109>>
-    <associate|auto-12|<tuple|A.2.6|109>>
+    <associate|auto-11|<tuple|A.2.6|109>>
+    <associate|auto-12|<tuple|A.2|109>>
     <associate|auto-13|<tuple|A.2.7|109>>
-    <associate|auto-14|<tuple|A.3|110>>
-    <associate|auto-15|<tuple|A.4|110>>
-    <associate|auto-16|<tuple|A.5|110>>
-    <associate|auto-17|<tuple|A.6|111>>
-    <associate|auto-18|<tuple|A.2.8|111>>
-    <associate|auto-19|<tuple|A.7|111>>
+    <associate|auto-14|<tuple|A.2.8|110>>
+    <associate|auto-15|<tuple|A.3|110>>
+    <associate|auto-16|<tuple|A.4|110>>
+    <associate|auto-17|<tuple|A.5|111>>
+    <associate|auto-18|<tuple|A.6|111>>
+    <associate|auto-19|<tuple|A.2.9|111>>
     <associate|auto-2|<tuple|A.1|107>>
-    <associate|auto-20|<tuple|A.8|111>>
-    <associate|auto-21|<tuple|A.9|112>>
-    <associate|auto-22|<tuple|A.10|112>>
-    <associate|auto-23|<tuple|A.11|?>>
-    <associate|auto-24|<tuple|A.12|?>>
-    <associate|auto-25|<tuple|A.13|?>>
-    <associate|auto-26|<tuple|A.2.9|?>>
+    <associate|auto-20|<tuple|A.7|111>>
+    <associate|auto-21|<tuple|A.8|112>>
+    <associate|auto-22|<tuple|A.9|112>>
+    <associate|auto-23|<tuple|A.10|?>>
+    <associate|auto-24|<tuple|A.11|?>>
+    <associate|auto-25|<tuple|A.12|?>>
+    <associate|auto-26|<tuple|A.13|?>>
     <associate|auto-27|<tuple|A.2.10|?>>
+    <associate|auto-28|<tuple|A.2.11|?>>
     <associate|auto-3|<tuple|A.1|107>>
     <associate|auto-4|<tuple|A.2|107>>
     <associate|auto-5|<tuple|A.2.1|108>>
@@ -655,7 +679,7 @@
     <associate|auto-9|<tuple|A.2.4|109>>
     <associate|defn-invalid-transaction|<tuple|A.4|110>>
     <associate|defn-rt-apisvec|<tuple|A.1|?>>
-    <associate|defn-rt-blockbuilder-finalize-block|<tuple|A.2.10|112>>
+    <associate|defn-rt-blockbuilder-finalize-block|<tuple|A.2.11|112>>
     <associate|defn-rt-core-version|<tuple|A.2.1|108>>
     <associate|defn-rte-apply-extrinsic-result|<tuple|A.6|?>>
     <associate|defn-rte-custom-module-error|<tuple|A.9|?>>
@@ -668,11 +692,12 @@
     <associate|defn-unknown-transaction|<tuple|A.5|110>>
     <associate|defn-valid-transaction|<tuple|A.2|110>>
     <associate|sect-list-of-runtime-entries|<tuple|A.1|107>>
-    <associate|sect-rte-babeapi-epoch|<tuple|A.2.5|109>>
+    <associate|sect-rte-apply-extrinsic|<tuple|A.2.9|?>>
+    <associate|sect-rte-babeapi-epoch|<tuple|A.2.6|109>>
     <associate|sect-rte-core-execute-block|<tuple|A.2.2|?>>
-    <associate|sect-rte-grandpa-auth|<tuple|A.2.6|109>>
-    <associate|sect-rte-hash-and-length|<tuple|A.2.4|109>>
-    <associate|sect-rte-validate-transaction|<tuple|A.2.7|109>>
+    <associate|sect-rte-grandpa-auth|<tuple|A.2.7|109>>
+    <associate|sect-rte-hash-and-length|<tuple|A.2.5|109>>
+    <associate|sect-rte-validate-transaction|<tuple|A.2.8|109>>
     <associate|sect-runtime-entries|<tuple|A|107>>
     <associate|snippet-runtime-enteries|<tuple|A.1|107>>
   </collection>

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -995,19 +995,19 @@
 
   <subsection|<verbatim|TransactionPaymentApi_query_info>>
 
-  Returns information about an extrinsic. This function is not aware of the
+  Returns information of a given extrinsic. This function is not aware of the
   internals of an extrinsic, but only interprets the extrinsic as some
   encoded value and accounts for its weight and length, the runtime's
   extrinsic base weight and the current fee multiplier.
 
   \;
 
-  Arguments:
+  <strong|Arguments>:
 
   <\itemize-dot>
-    <item>The raw extrinsic.
+    <item>An array of varying size containing the extrinsic.
 
-    <item>The length of the extrinsics <todo|why is this needed?>
+    <item>The length of the extrinsic. <todo|why is this needed?>
   </itemize-dot>
 
   \;
@@ -1036,12 +1036,64 @@
         always included>>>>>
       </equation*>
 
-      <item><math|f> is the inclusion fee of this dispatch. This does not
+      <item><math|f> is the inclusion fee of the extrinsic. This does not
       include a tip or anything else that depends on the signature.
     </itemize-dot>
   </itemize-dot>
 
   <subsection|<verbatim|TransactionPaymentApi_query_fee_details>>
+
+  Query the detailed fee of a given extrinsic.
+
+  \;
+
+  <strong|Arguments>:
+
+  <\itemize-dot>
+    <item>An array of varying size containing the extrinsic.
+
+    <item>The length of the extrinsic.
+  </itemize-dot>
+
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>A datastructure of the following format:
+
+    <\equation*>
+      <around*|(|f,t|)>
+    </equation*>
+
+    where
+
+    <\itemize-dot>
+      <item><math|f> is a SCALE encoded <verbatim|Option> as defined in
+      Definition <reference|defn-option-type> containing the following
+      datastructure:
+
+      <\equation*>
+        <around*|(|f<rsub|b>,f<rsub|l>,f<rsub|a>|)>
+      </equation*>
+
+      where
+
+      <\itemize-dot>
+        <item><math|f<rsub|b>> is the minimum amount a user pays for a
+        transaction.
+
+        <item><math|f<rsub|l>> is the length fee, the amount paid for the
+        encoded length (in bytes) of the transaction.
+
+        <item><math|f<rsub|a>> is the \Padjusted weight fee\Q, which is a
+        multiplication of the fee multiplier and the weight fee. The fee
+        multiplier varies depending on the usage of the network.
+      </itemize-dot>
+
+      <item><math|t> is the tip for the block author.
+    </itemize-dot>
+  </itemize-dot>
 
   \;
 

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -220,7 +220,7 @@
   <strong|Arguments>:
 
   <\itemize>
-    <item>The block header of the new block as defined in
+    <item>The header of the new block as defined in
     <reference|defn-block-header>. The values <math|H<rsub|r>,H<rsub|e> and
     H<rsub|d>> are left empty.
   </itemize>
@@ -250,7 +250,8 @@
   <strong|Return>:
 
   <\itemize-dot>
-    <item>A array of varying size containing the metadata in an opaque form.
+    <item>A byte array of varying size containing the metadata in an opaque
+    form.
   </itemize-dot>
 
   <subsection|<verbatim|BlockBuilder_apply_extrinsic>>
@@ -411,6 +412,23 @@
   calling this function are usually meant to persist upon successful
   execution of the function and appending of the block to the chain.
 
+  \;
+
+  <strong|Arguments>:
+
+  <\itemize-dot>
+    <item>None.
+  </itemize-dot>
+
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>The header of the new block as defined in
+    <reference|defn-block-header>.
+  </itemize-dot>
+
   <subsection|<verbatim|BlockBuilder_inherent_extrinsics>>
 
   Generates the inherent extrinsics, which are explained in more detail in
@@ -435,8 +453,8 @@
   <strong|Return>:
 
   <\itemize-dot>
-    <item>An array of extrinisic where each extrinsic is a variable byte
-    array.
+    <item>A byte array of varying size containing extrinisics. Each extrinsic
+    is a byte array of varying size.
   </itemize-dot>
 
   <subsection|<verbatim|BlockBuilder_check_inherents>>
@@ -633,7 +651,7 @@
   <strong|Arguments>:
 
   <\itemize-dot>
-    <item>A block header
+    <item>The block header as defined in <reference|defn-block-header>.
   </itemize-dot>
 
   \;
@@ -844,7 +862,7 @@
   <strong|Return>:
 
   <\itemize-dot>
-    <item>A unsigned 64-bit integer representing the slot number.
+    <item>A unsigned 64-bit integer indicating the slot number.
   </itemize-dot>
 
   <subsection|<verbatim|BabeApi_current_epoch>><label|sect-babeapi_current_epoch>
@@ -986,7 +1004,7 @@
   <strong|Return>:
 
   <\itemize-dot>
-    <item>An array of varying size containing 256-bit pulic keys of
+    <item>A byte array of varying size containing 256-bit pulic keys of the
     authorities.
   </itemize-dot>
 
@@ -1011,7 +1029,7 @@
   <strong|Return>:
 
   <\itemize-dot>
-    <item>An array of varying size containg the encoded session keys.
+    <item>A byte array of varying size containg the encoded session keys.
   </itemize-dot>
 
   <subsection|<verbatim|SessionKeys_decode_session_keys>>
@@ -1033,7 +1051,7 @@
   <strong|Return>:
 
   <\itemize-dot>
-    <item>An array of varying size containg tuple pairs of the following
+    <item>An array of varying size containing tuple pairs of the following
     format:
 
     <\equation*>
@@ -1076,7 +1094,7 @@
   <strong|Arguments>:
 
   <\itemize-dot>
-    <item>An array of varying size containing the extrinsic.
+    <item>A byte array of varying size containing the extrinsic.
 
     <item>The length of the extrinsic. <todo|why is this needed?>
   </itemize-dot>
@@ -1121,7 +1139,7 @@
   <strong|Arguments>:
 
   <\itemize-dot>
-    <item>An array of varying size containing the extrinsic.
+    <item>A byte array of varying size containing the extrinsic.
 
     <item>The length of the extrinsic.
   </itemize-dot>

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -125,15 +125,14 @@
 
   where <verbatim|data> points to the SCALE encoded paramaters sent to the
   function and <verbatim|len> is the length of the data. <verbatim|result>
-  points to the SCALE encoded data the function returns (See Sections
-  <reference|sect-runtime-send-args-to-runtime-enteries> and
-  <reference|sect-runtime-return-value>).
+  points to the SCALE encoded data the function returns. In this section, we
+  describe the function of each of the entries alongside with the details of
+  the arguments and the return values for each one of these enteries.
 
   \;
 
-  In this section, we describe the function of each of the entries alongside
-  with the details of the arguments and the return values for each one of
-  these enteries.
+  See Section <reference|sect-code-executor> for more information about the
+  behavior of the Wasm Runtime.
 
   <subsection|<verbatim|Core_version>><label|defn-rt-core-version>
 

--- a/host-spec/ag-runtimeentries.tm
+++ b/host-spec/ag-runtimeentries.tm
@@ -825,7 +825,28 @@
 
   <subsection|<verbatim|BabeApi_generate_key_ownership_proof>>
 
+  Generates a proof of the membership of a key owner in the specified block
+  state. The returned value is used to report equivocations as described in
+  <todo|did we mention equivocation regarding Babe anywhere?>.
+
   \;
+
+  <strong|Arguments>:
+
+  <\itemize-dot>
+    <item>The usigned 64-bit integer representing the slot number.
+
+    <item>The 256-bit public key of the authority.
+  </itemize-dot>
+
+  \;
+
+  <strong|Return>:
+
+  <\itemize-dot>
+    <item>A SCALE encoded <verbatim|Option> as defined in Definition
+    <reference|defn-option-type> containing the proof in an opaque form.
+  </itemize-dot>
 
   <subsection|<verbatim|BabeApi_submit_report_equivocation_unsigned_extrinsic>>
 

--- a/host-spec/c03-transition.tm
+++ b/host-spec/c03-transition.tm
@@ -1,4 +1,4 @@
-<TeXmacs|1.99.14>
+<TeXmacs|1.99.16>
 
 <project|host-spec.tm>
 
@@ -596,7 +596,7 @@
     <item><strong|<samp|authority Ids>>: This is the list of the Ids of
     authorities, which have voted for the block to be stored and<verbatim|>
     is formally referred to as <math|A<around|(|B|)>>. An authority Id is
-    32bit.
+    256-bit.
   </itemize>
 
   <subsubsection|Block Body><label|sect-block-body>
@@ -999,8 +999,8 @@
 <\initial>
   <\collection>
     <associate|chapter-nr|2>
-    <associate|page-first|21>
-    <associate|section-nr|2<uninit>>
+    <associate|page-first|23>
+    <associate|section-nr|2>
     <associate|subsection-nr|1>
   </collection>
 </initial>
@@ -1016,9 +1016,9 @@
     <associate|auto-11|<tuple|3.2.2|23>>
     <associate|auto-12|<tuple|3.2.2.1|23>>
     <associate|auto-13|<tuple|3.2.3|24>>
-    <associate|auto-14|<tuple|3.2.3|24>>
-    <associate|auto-15|<tuple|3.2.3|24>>
-    <associate|auto-16|<tuple|3.2.3|24>>
+    <associate|auto-14|<tuple|Transaction Message|24>>
+    <associate|auto-15|<tuple|transaction pool|24>>
+    <associate|auto-16|<tuple|transaction queue|24>>
     <associate|auto-17|<tuple|3.2.3.1|25>>
     <associate|auto-18|<tuple|3.1|25>>
     <associate|auto-19|<tuple|3.3|25>>

--- a/host-spec/c03-transition.tm
+++ b/host-spec/c03-transition.tm
@@ -104,7 +104,7 @@
   storage API (see Section <reference|sect-re-api>) to insert a new Wasm blob
   into runtime storage slot to upgrade the runtime.
 
-  <subsection|Code Executor>
+  <subsection|Code Executor><label|sect-code-executor>
 
   The Polkadot Host provides a Wasm Virtual Machine (VM) to run the Runtime.
   The Wasm VM exposes the Polkadot Host API to the Runtime, which, on its
@@ -999,8 +999,8 @@
 <\initial>
   <\collection>
     <associate|chapter-nr|2>
-    <associate|page-first|23>
-    <associate|section-nr|2>
+    <associate|page-first|21>
+    <associate|section-nr|2<uninit>>
     <associate|subsection-nr|1>
   </collection>
 </initial>
@@ -1061,6 +1061,7 @@
     <associate|sect-changes-trie-block-pairs|<tuple|3.3.4.2|29>>
     <associate|sect-changes-trie-child-trie-pair|<tuple|3.3.4.3|30>>
     <associate|sect-changes-trie-extrinsics-pairs|<tuple|3.3.4.1|29>>
+    <associate|sect-code-executor|<tuple|3.1.2|?>>
     <associate|sect-entries-into-runtime|<tuple|3.1|21>>
     <associate|sect-extrinsics|<tuple|3.2|23>>
     <associate|sect-handling-runtime-state-update|<tuple|3.1.2.4|23>>

--- a/host-spec/c06-consensus.tm
+++ b/host-spec/c06-consensus.tm
@@ -1,4 +1,4 @@
-<TeXmacs|1.99.17>
+<TeXmacs|1.99.16>
 
 <project|host-spec.tm>
 
@@ -1037,11 +1037,11 @@
   counts votes.
 
   <\definition>
-    Voter <math|v> <strong|equivocates> if they broadcast two or more valid
-    votes to blocks during one voting sub-round. In such a situation, we say
-    that <math|v> is an <strong|equivocator> and any vote
-    <math|V<rsub|v><rsup|r,stage><around*|(|B|)>> cast by <math|v> in that
-    sub-round is an <strong|equivocatory vote>, and
+    <label|defn-equivocation>Voter <math|v> <strong|equivocates> if they
+    broadcast two or more valid votes to blocks during one voting sub-round.
+    In such a situation, we say that <math|v> is an <strong|equivocator> and
+    any vote <math|V<rsub|v><rsup|r,stage><around*|(|B|)>> cast by <math|v>
+    in that sub-round is an <strong|equivocatory vote>, and
 
     <\equation*>
       \<cal-E\><rsup|r,stage>
@@ -2207,6 +2207,7 @@
     <associate|defn-epoch-randomness|<tuple|6.21|?>>
     <associate|defn-epoch-slot|<tuple|6.6|39>>
     <associate|defn-epoch-subchain|<tuple|6.9|39>>
+    <associate|defn-equivocation|<tuple|6.27|?>>
     <associate|defn-finalized-block|<tuple|6.42|49>>
     <associate|defn-gossip-message|<tuple|6.34|45>>
     <associate|defn-grandpa-catchup-request-msg|<tuple|6.39|46>>


### PR DESCRIPTION
Fixes #328 .

There are still some open points that need to be added: 

- ~~The Grandpa equivocation report format.~~ tracked in  https://github.com/w3f/polkadot-spec/issues/369
- ~~Spec of Babe equivocations (which is not mentioned at all right now).~~ tracked in  https://github.com/w3f/polkadot-spec/issues/369
- ~~ParachainHost APIs. Currently, the Polkadot master branch just returns empty values. This will probably be submitted in a separate PR.~~ tracked in https://github.com/w3f/polkadot-spec/issues/371


**Printscreen**
![ag-runtimeentries](https://user-images.githubusercontent.com/42901763/105414562-f21ee600-5c37-11eb-8578-7250932410e9.png)
