### PR TITLE
gossamer-adapter: Implement crypto testsuite

### DIFF
--- a/test/adapters/gossamer/host_api/crypto.go
+++ b/test/adapters/gossamer/host_api/crypto.go
@@ -19,6 +19,7 @@ package host_api
 
 import (
 	"fmt"
+	"bytes"
 
 	"github.com/ChainSafe/gossamer/lib/common/optional"
 	"github.com/ChainSafe/gossamer/lib/runtime"
@@ -51,6 +52,23 @@ func crypto_generate(r runtime.Instance, suite string, seed string) ([]byte, err
 	return pk, nil
 }
 
+// Helper function to call rtm_ext_crypto_<suite>_public_keys_version_1
+func crypto_public_keys(r runtime.Instance, suite string) ([]byte, error) {
+	// Encode input
+	id_enc, err := scale.Encode(DUMY_KEY_ID)
+	if err != nil {
+		return nil, AdapterError{"Encoding key id failed", err}
+	}
+
+	// Request all know public keys
+	keys, err := r.Exec("rtm_ext_crypto_" + suite + "_public_keys_version_1", id_enc)
+	if err != nil {
+		return nil, AdapterError{"Execution failed", err}
+	}
+
+	return keys, nil
+}
+
 // -- Tests --
 
 // Test for ext_crypto_<suite>_generate_version_1
@@ -66,3 +84,43 @@ func test_crypto_generate(r runtime.Instance, suite string, seed string) error {
 	return nil
 }
 
+// Test for ext_crypto_<suite>_public_keys_version_1
+func test_crypto_public_keys(r runtime.Instance, suite string, seed1 string, seed2 string) error {
+	// Generate two new keys
+	pk1, err := crypto_generate(r, suite, seed1)
+	if err != nil {
+		return err
+	}
+
+	pk2, err := crypto_generate(r, suite, seed2)
+	if err != nil {
+		return err
+	}
+
+	// Retrieve all public keys
+	keys, err := crypto_public_keys(r, suite)
+	if err != nil {
+		return err
+	}
+
+	// Check result
+	if len(keys) != 65 || keys[0] != 8 {
+		return newTestFailure("Pubkeys size missmatch")
+	}
+
+	key1 := keys[1:33]
+	key2 := keys[33:65]
+
+	if !bytes.Equal(pk1, key1) && !bytes.Equal(pk1, key2) {
+		return newTestFailure("Keystore does not include pubkey 1")
+	}
+
+	if !bytes.Equal(pk2, key1) && !bytes.Equal(pk2, key2) {
+		return newTestFailure("Keystore does not include pubkey 2")
+	}
+
+	fmt.Printf("1. Public key: %x\n", key1)
+	fmt.Printf("2. Public key: %x\n", key2)
+
+	return nil
+}

--- a/test/adapters/gossamer/host_api/crypto.go
+++ b/test/adapters/gossamer/host_api/crypto.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2019 Web3 Technologies Foundation
+
+// This file is part of Polkadot Host Test Suite
+
+// Polkadot Host Test Suite is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot Host Tests is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+
+package host_api
+
+import (
+	"fmt"
+
+	"github.com/ChainSafe/gossamer/lib/common/optional"
+	"github.com/ChainSafe/gossamer/lib/runtime"
+	"github.com/ChainSafe/gossamer/lib/scale"
+)
+
+// -- Helpers --
+
+const DUMY_KEY_ID int32 = 0x64756d79 // DUMY
+
+// Helper function to call rtm_ext_crypto_<suite>_generate_version_1
+func crypto_generate(r runtime.Instance, suite string, seed string) ([]byte, error) {
+	// Encode inputs
+	id_enc, err := scale.Encode(DUMY_KEY_ID)
+	if err != nil {
+		return nil, AdapterError{"Encoding key id failed", err}
+	}
+
+	seed_enc, err := scale.Encode(optional.NewBytes(true, []byte(seed)))
+	if err != nil {
+		return nil, AdapterError{"Encoding seed failed", err}
+	}
+
+	// Generate new public key
+	pk, err := r.Exec("rtm_ext_crypto_" + suite + "_generate_version_1", append(id_enc, seed_enc...))
+	if err != nil {
+		return nil, AdapterError{"Execution failed", err}
+	}
+
+	return pk, nil
+}
+
+// -- Tests --
+
+// Test for ext_crypto_<suite>_generate_version_1
+func test_crypto_generate(r runtime.Instance, suite string, seed string) error {
+	// Generate new key and print result
+	pk, err := crypto_generate(r, suite, seed)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%x\n", pk)
+
+	return nil
+}
+

--- a/test/adapters/gossamer/host_api/crypto.go
+++ b/test/adapters/gossamer/host_api/crypto.go
@@ -128,6 +128,10 @@ func test_crypto_generate(r runtime.Instance, suite string, seed string) error {
 		return err
 	}
 
+	if len(pk) != 32 {
+		return fmt.Errorf("Public key has incorrect size: %d", len(pk))
+	}
+
 	fmt.Printf("%x\n", pk)
 
 	return nil
@@ -191,6 +195,10 @@ func test_crypto_sign(r runtime.Instance, suite string, seed string, msg string)
 	// Check and print result
 	if !sig.Exists() {
 		return newTestFailure("No signature received")
+	}
+
+	if len(sig.Value()) != 64 {
+		return fmt.Errorf("Signature has incorrect size: %d", len(sig.Value()))
 	}
 
 	fmt.Println("Message: ", msg)

--- a/test/adapters/gossamer/host_api/crypto.go
+++ b/test/adapters/gossamer/host_api/crypto.go
@@ -28,7 +28,7 @@ import (
 
 // -- Helpers --
 
-const DUMY_KEY_ID int32 = 0x64756d79 // DUMY
+const DUMY_KEY_ID int32 = 0x796d7564 // DUMY (in ASCII, reversed to achieve same encoding as 4-byte static array)
 
 // Helper function to call rtm_ext_crypto_<suite>_generate_version_1
 func crypto_generate(r runtime.Instance, suite string, seed string) ([]byte, error) {

--- a/test/adapters/gossamer/host_api/crypto.go
+++ b/test/adapters/gossamer/host_api/crypto.go
@@ -91,11 +91,7 @@ func crypto_sign(r runtime.Instance, suite string, pubkey []byte, msg string) (*
 	}
 
 	// Decode and return result
-	sig_opt, err := scale.Decode(sig_enc, &optional.Bytes{})
-	if err != nil {
-		return nil, AdapterError{"Decoding signature failed", err}
-	}
-	return sig_opt.(*optional.Bytes), nil
+	return optional.NewBytes(sig_enc[0] != 0, sig_enc[1:]), nil
 }
 
 // Helper function to call rtm_ext_crypto_<suite>_verify_version_1

--- a/test/adapters/gossamer/host_api/crypto.go
+++ b/test/adapters/gossamer/host_api/crypto.go
@@ -38,7 +38,7 @@ func crypto_generate(r runtime.Instance, suite string, seed string) ([]byte, err
 		return nil, AdapterError{"Encoding key id failed", err}
 	}
 
-	seed_enc, err := scale.Encode(optional.NewBytes(true, []byte(seed)))
+	seed_enc, err := optional.NewBytes(true, []byte(seed)).Encode()
 	if err != nil {
 		return nil, AdapterError{"Encoding seed failed", err}
 	}

--- a/test/adapters/gossamer/host_api/host_api.go
+++ b/test/adapters/gossamer/host_api/host_api.go
@@ -190,14 +190,16 @@ func executeHostApiTest(function string, inputs []string, environment, runtimePa
 		return test_crypto_generate(rtm, "ed25519", inputs[0])
 	case "ext_crypto_ed25519_sign_version_1":
 		return test_crypto_sign(rtm, "ed25519", inputs[0], inputs[1])
-	//case "ext_crypto_ed25519_verify_version_1":
+	case "ext_crypto_ed25519_verify_version_1":
+		return test_crypto_verify(rtm, "ed25519", inputs[0], inputs[1])
 	case "ext_crypto_sr25519_public_keys_version_1":
 		return test_crypto_public_keys(rtm, "sr25519", inputs[0], inputs[1])
 	case "ext_crypto_sr25519_generate_version_1":
 		return test_crypto_generate(rtm, "sr25519", inputs[0])
 	case "ext_crypto_sr25519_sign_version_1":
 		return test_crypto_sign(rtm, "sr25519", inputs[0], inputs[1])
-	//case "ext_crypto_sr25519_verify_version_1":
+	case "ext_crypto_sr25519_verify_version_1":
+		return test_crypto_verify(rtm, "sr25519", inputs[0], inputs[1])
 
 	// test hashing api
 	case "ext_hashing_blake2_128_version_1",

--- a/test/adapters/gossamer/host_api/host_api.go
+++ b/test/adapters/gossamer/host_api/host_api.go
@@ -185,11 +185,13 @@ func executeHostApiTest(function string, inputs []string, environment, runtimePa
 
 	// test crypto api
 	//case "ext_crypto_ed25519_public_keys_version_1":
-	//case "ext_crypto_ed25519_generate_version_1":
+	case "ext_crypto_ed25519_generate_version_1":
+		return test_crypto_generate(rtm, "ed25519", inputs[0])
 	//case "ext_crypto_ed25519_sign_version_1":
 	//case "ext_crypto_ed25519_verify_version_1":
 	//case "ext_crypto_sr25519_public_keys_version_1":
-	//case "ext_crypto_sr25519_generate_version_1":
+	case "ext_crypto_sr25519_generate_version_1":
+		return test_crypto_generate(rtm, "sr25519", inputs[0])
 	//case "ext_crypto_sr25519_sign_version_1":
 	//case "ext_crypto_sr25519_verify_version_1":
 

--- a/test/adapters/gossamer/host_api/host_api.go
+++ b/test/adapters/gossamer/host_api/host_api.go
@@ -188,13 +188,15 @@ func executeHostApiTest(function string, inputs []string, environment, runtimePa
 		return test_crypto_public_keys(rtm, "ed25519", inputs[0], inputs[1])
 	case "ext_crypto_ed25519_generate_version_1":
 		return test_crypto_generate(rtm, "ed25519", inputs[0])
-	//case "ext_crypto_ed25519_sign_version_1":
+	case "ext_crypto_ed25519_sign_version_1":
+		return test_crypto_sign(rtm, "ed25519", inputs[0], inputs[1])
 	//case "ext_crypto_ed25519_verify_version_1":
 	case "ext_crypto_sr25519_public_keys_version_1":
 		return test_crypto_public_keys(rtm, "sr25519", inputs[0], inputs[1])
 	case "ext_crypto_sr25519_generate_version_1":
 		return test_crypto_generate(rtm, "sr25519", inputs[0])
-	//case "ext_crypto_sr25519_sign_version_1":
+	case "ext_crypto_sr25519_sign_version_1":
+		return test_crypto_sign(rtm, "sr25519", inputs[0], inputs[1])
 	//case "ext_crypto_sr25519_verify_version_1":
 
 	// test hashing api

--- a/test/adapters/gossamer/host_api/host_api.go
+++ b/test/adapters/gossamer/host_api/host_api.go
@@ -184,12 +184,14 @@ func executeHostApiTest(function string, inputs []string, environment, runtimePa
 	//case "ext_default_child_storage_next_key_version_1":
 
 	// test crypto api
-	//case "ext_crypto_ed25519_public_keys_version_1":
+	case "ext_crypto_ed25519_public_keys_version_1":
+		return test_crypto_public_keys(rtm, "ed25519", inputs[0], inputs[1])
 	case "ext_crypto_ed25519_generate_version_1":
 		return test_crypto_generate(rtm, "ed25519", inputs[0])
 	//case "ext_crypto_ed25519_sign_version_1":
 	//case "ext_crypto_ed25519_verify_version_1":
-	//case "ext_crypto_sr25519_public_keys_version_1":
+	case "ext_crypto_sr25519_public_keys_version_1":
+		return test_crypto_public_keys(rtm, "sr25519", inputs[0], inputs[1])
 	case "ext_crypto_sr25519_generate_version_1":
 		return test_crypto_generate(rtm, "sr25519", inputs[0])
 	//case "ext_crypto_sr25519_sign_version_1":


### PR DESCRIPTION
This implements the crypto testsuite for gossamer.

Upstream fixes to make this pass:
 - ChainSafe/gossamer#1279
 - ChainSafe/gossamer#1280
 - ChainSafe/gossamer#1450
 - ChainSafe/gossamer#1451
 - ChainSafe/gossamer#1418

Unresolved issue that will need to be followed separately:
 - Disabled verification of version 1 of sr25519 (ChainSafe/gossamer#1393)