### PR TITLE
testsuite: Test more then just default wasm backend

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -145,7 +145,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fixture: [ host-api, scale-codec, state-trie ]
+        fixture: [ scale-codec, state-trie ]
     name: "[test-${{ matrix.fixture }}] substrate"
     runs-on: ubuntu-20.04
     steps:
@@ -158,6 +158,25 @@ jobs:
     - run: chmod +x test/bin/substrate-adapter
     - name: Run test fixture
       run: test/runtests.jl substrate ${{ matrix.fixture }}
+
+  test-substrate-hostapi:
+    needs: build-adapter-substrate
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [ wasmi, wasmtime ]
+    name: "[test-host-api] substrate ${{ matrix.environment }}"
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - uses: actions/download-artifact@v2.0.8
+      with:
+        name: substrate-adapter
+        path: test/bin
+    - run: chmod +x test/bin/substrate-adapter
+    - name: Run test fixture
+      run: test/runtests.jl substrate host-api ${{ matrix.environment }}
 
 
   test-kagome:
@@ -231,7 +250,11 @@ jobs:
 
   test-gossamer-hostapi:
     needs: [ build-adapter-gossamer, build-runtime-hostapi]
-    name: "[test-host-api] gossamer"
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [ wasmer ]
+    name: "[test-host-api] gossamer ${{ matrix.environment }}"
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout repository
@@ -249,4 +272,4 @@ jobs:
         mkdir -p test/lib
         mv test/bin/libwasmer.so test/lib/
     - name: Run test fixture
-      run: test/runtests.jl gossamer host-api
+      run: test/runtests.jl gossamer host-api ${{ matrix.environment }}

--- a/test/adapters/gossamer/go.sum
+++ b/test/adapters/gossamer/go.sum
@@ -119,6 +119,7 @@ github.com/dop251/goja v0.0.0-20200219165308-d1232e640a87/go.mod h1:Mw6PkjjMXWbT
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -135,6 +136,7 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
+github.com/go-interpreter/wagon v0.6.0 h1:BBxDxjiJiHgw9EdkYXAWs8NHhwnazZ5P2EWBW5hFNWw=
 github.com/go-interpreter/wagon v0.6.0/go.mod h1:5+b/MBYkclRZngKF5s6qrgWxSLgE9F5dFdO1hAueZLc=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
@@ -547,6 +549,7 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pborman/uuid v0.0.0-20170112150404-1b00554d8222/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/perlin-network/life v0.0.0-20191203030451-05c0e0f7eaea h1:okKoivlkNRRLqXraEtatHfEhW+D71QTwkaj+4n4M2Xc=
 github.com/perlin-network/life v0.0.0-20191203030451-05c0e0f7eaea/go.mod h1:3KEU5Dm8MAYWZqity880wOFJ9PhQjyKVZGwAEfc5Q4E=
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
 github.com/phuslu/iploc v1.0.20200807/go.mod h1:Q/0VX0txvbxekt4NhWIi3Q3eyZ139lHhnlzvDxyXhuc=
@@ -601,12 +604,14 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
+github.com/twitchyliquid64/golang-asm v0.0.0-20190126203739-365674df15fc h1:RTUQlKzoZZVG3umWNzOYeFecQLIh+dbxXvJp1zPQJTI=
 github.com/twitchyliquid64/golang-asm v0.0.0-20190126203739-365674df15fc/go.mod h1:NoCfSFWosfqMqmmD7hApkirIK9ozpHjxRnRxs1l413A=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
+github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/wasmerio/go-ext-wasm v0.3.2-0.20200326095750-0a32be6068ec h1:VElCeVyfCWNmCv6UisKQrr+P2/JRG0uf4/FIdCB4pL0=
 github.com/wasmerio/go-ext-wasm v0.3.2-0.20200326095750-0a32be6068ec/go.mod h1:VGyarTzasuS7k5KhSIGpM3tciSZlkP31Mp9VJTHMMeI=
@@ -741,6 +746,7 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1N
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.6.0 h1:Tfd7cKwKbFRsI8RMAD3oqqw7JPFRrvFlOsfbgVkjOOw=
 google.golang.org/appengine v1.6.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/test/adapters/gossamer/host_api/allocator.go
+++ b/test/adapters/gossamer/host_api/allocator.go
@@ -31,24 +31,24 @@ func test_allocator_malloc_free(r runtime.Instance, value string) error {
 	// Encode inputs
 	value_enc, err := scale.Encode([]byte(value))
 	if err != nil {
-		return AdapterError{"Encoding value failed", err}
+		return fmt.Errorf("Encoding value failed: %w", err)
 	}
 
 	// The Wasm function tests both the allocation and freeing of the buffer
 	result_enc, err := r.Exec("rtm_ext_allocator_malloc_version_1", value_enc)
 	if err != nil {
-		return AdapterError{"Execution failed", err}
+		return fmt.Errorf("Execution failed: %w", err)
 	}
 
 	// Decode and print output
 	result_dec, err := scale.Decode(result_enc, []byte{})
 	if err != nil {
-		return AdapterError{"Decoding result failed", err}
+		return fmt.Errorf("Decoding result failed: %w", err)
 	}
 	result := result_dec.([]byte)
 
 	if !bytes.Equal(result, []byte(value)) {
-		return newTestFailure("Value is different: %s", result)
+		return fmt.Errorf("Value is different: %s", result)
 	}
 
 	fmt.Printf("%s\n", result)

--- a/test/adapters/gossamer/host_api/child_storage.go
+++ b/test/adapters/gossamer/host_api/child_storage.go
@@ -30,7 +30,7 @@ import (
 // -- Helpers --
 
 // Helper function to call rtm_ext_default_child_storage_set_version_1
-func child_storage_set(r runtime.Instance, child []byte, key []byte, value []byte) error {
+func child_storage_set(r runtime.Instance, child, key, value []byte) error {
 	// Encode inputs
 	child_enc, err := scale.Encode(child)
 	if err != nil {
@@ -59,7 +59,7 @@ func child_storage_set(r runtime.Instance, child []byte, key []byte, value []byt
 }
 
 // Helper function to call rtm_ext_default_child_storage_get_version_1
-func child_storage_get(r runtime.Instance, child []byte, key []byte) (*optional.Bytes, error) {
+func child_storage_get(r runtime.Instance, child, key []byte) (*optional.Bytes, error) {
 	// Encode inputs
 	child_enc, err := scale.Encode(child)
 	if err != nil {
@@ -87,7 +87,7 @@ func child_storage_get(r runtime.Instance, child []byte, key []byte) (*optional.
 // -- Tests --
 
 // Test for rtm_ext_child_storage_set_version_1 and rtm_ext_child_storage_get_version_1
-func test_child_storage_set_get(r runtime.Instance, child1 string, child2 string, key string, value string) error {
+func test_child_storage_set_get(r runtime.Instance, child1, child2, key, value string) error {
 	// Get invalid key
 	none1, err := child_storage_get(r, []byte(child1), []byte(key))
 	if err != nil {

--- a/test/adapters/gossamer/host_api/errors.go
+++ b/test/adapters/gossamer/host_api/errors.go
@@ -17,36 +17,7 @@
 
 package host_api
 
-import "fmt"
-
 // Empty error to indicate missing implementation
 type MissingImplementation struct {}
 
 func (e MissingImplementation) Error() string { return "Not implemented" }
-
-// Simple string error to indicate test failure
-type TestFailure struct {
-	message string
-}
-
-func (e TestFailure) Error() string { return e.message }
-
-// Constructor using Sprint for message
-func newTestFailure(args ...interface{}) error {
-	message := fmt.Sprint(args...)
-	return TestFailure{message}
-}
-
-// Constructor using Sprintf for message
-func newTestFailuref(format string, args ...interface{}) error {
-	message := fmt.Sprintf(format, args...)
-	return TestFailure{message}
-}
-
-// Wrapped error to indicate adapter failure
-type AdapterError struct {
-	message string
-	wrapped error
-}
-
-func (e AdapterError) Error() string { return e.message + ": " + e.wrapped.Error() }

--- a/test/adapters/gossamer/host_api/hashing.go
+++ b/test/adapters/gossamer/host_api/hashing.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Simple wrapper to test hash function that input and output byte arrays
-func test_hashing(r runtime.Instance, name string, input string) error {
+func test_hashing(r runtime.Instance, name, input string) error {
 
 	enc, err := scale.Encode([]byte(input))
 	if err != nil {

--- a/test/adapters/gossamer/host_api/hashing.go
+++ b/test/adapters/gossamer/host_api/hashing.go
@@ -31,17 +31,17 @@ func test_hashing(r runtime.Instance, name string, input string) error {
 
 	enc, err := scale.Encode([]byte(input))
 	if err != nil {
-		return AdapterError{"Encoding failed", err}
+		return fmt.Errorf("Encoding failed: %w", err)
 	}
 
 	output, err := r.Exec("rtm_" + name, enc)
 	if err != nil {
-		return AdapterError{"Execution failed", err}
+		return fmt.Errorf("Execution failed: %w", err)
 	}
 
 	dec, err := scale.Decode(output, []byte{})
 	if err != nil {
-		return AdapterError{"Decoding failed", err}
+		return fmt.Errorf("Decoding failed: %w", err)
 	}
 
 	fmt.Printf("%x\n", dec.([]byte)[:])

--- a/test/adapters/gossamer/host_api/host_api.go
+++ b/test/adapters/gossamer/host_api/host_api.go
@@ -102,7 +102,7 @@ func ProcessHostApiCommand(args []string) {
 }
 
 // Main hostapi test executor
-func executeHostApiTest(function string, inputs []string, environment string, runtimePath string) error {
+func executeHostApiTest(function string, inputs []string, environment, runtimePath string) error {
 	// Initialize storage
 	store, err := storage.NewTrieState(nil)
 	if err != nil {

--- a/test/adapters/gossamer/host_api/host_api.go
+++ b/test/adapters/gossamer/host_api/host_api.go
@@ -106,7 +106,7 @@ func executeHostApiTest(function string, inputs []string, environment string, ru
 	// Initialize storage
 	store, err := storage.NewTrieState(nil)
 	if err != nil {
-		return AdapterError{"Failed to initialize storage", err}
+		return fmt.Errorf("Failed to initialize storage: %w", err)
 	}
 
 	store.Set([]byte(":code"), []byte{})
@@ -126,7 +126,7 @@ func executeHostApiTest(function string, inputs []string, environment string, ru
 
 		rtm, err = wasmer.NewInstanceFromFile(runtimePath, cfg)
 		if err != nil {
-			return AdapterError{"Failed to intialize wasmer environment", err}
+			return fmt.Errorf("Failed to intialize wasmer environment: %w", err)
 		}
 	case "wasmtime":
 		// ... using wasmtime
@@ -139,7 +139,7 @@ func executeHostApiTest(function string, inputs []string, environment string, ru
 
 		rtm, err = wasmtime.NewInstanceFromFile(runtimePath, cfg)
 		if err != nil {
-			return AdapterError{"Failed to intialize wasmtime environment", err}
+			return fmt.Errorf("Failed to intialize wasmtime environment: %w", err)
 		}
 	case "life":
 		// ... using life
@@ -152,13 +152,13 @@ func executeHostApiTest(function string, inputs []string, environment string, ru
 
 		code, err := ioutil.ReadFile(runtimePath)
 		if err != nil {
-			return AdapterError{"Failed to load test runtime", err}
+			return fmt.Errorf("Failed to load test runtime: %w", err)
 		}
 
 		// create runtime executor
 		rtm, err = life.NewInstance(code, cfg)
 		if err != nil {
-			return AdapterError{"Failed to intialize life environment", err}
+			return fmt.Errorf("Failed to intialize life environment: %w", err)
 		}
 	default:
 		return errors.New("Unknown runtime environment: " + environment)

--- a/test/adapters/gossamer/host_api/storage.go
+++ b/test/adapters/gossamer/host_api/storage.go
@@ -19,6 +19,7 @@ package host_api
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -34,18 +35,18 @@ func storage_set(r runtime.Instance, key []byte, value []byte) error {
 	// Encode inputs
 	key_enc, err := scale.Encode(key)
 	if err != nil {
-		return AdapterError{"Encoding key failed", err}
+		return fmt.Errorf("Encoding key failed: %w", err)
 	}
 
 	value_enc, err := scale.Encode(value)
 	if err != nil {
-		return AdapterError{"Encoding value failed", err}
+		return fmt.Errorf("Encoding value failed: %w", err)
 	}
 
 	// Set key to value
 	_, err = r.Exec("rtm_ext_storage_set_version_1", append(key_enc, value_enc...))
 	if err != nil {
-		return AdapterError{"Execution failed", err}
+		return fmt.Errorf("Execution failed: %w", err)
 	}
 
 	return nil
@@ -56,18 +57,18 @@ func storage_get(r runtime.Instance, key []byte) (*optional.Bytes, error) {
 	// Encode inputs
 	key_enc, err := scale.Encode(key)
 	if err != nil {
-		return nil, AdapterError{"Encoding key failed", err}
+		return nil, fmt.Errorf("Encoding key failed: %w", err)
 	}
 
 	// Retrieve key
 	value_enc, err := r.Exec("rtm_ext_storage_get_version_1", key_enc)
 	if err != nil {
-		return nil, AdapterError{"Execution failed", err}
+		return nil, fmt.Errorf("Execution failed: %w", err)
 	}
 
 	value_opt, err := scale.Decode(value_enc, &optional.Bytes{})
 	if err != nil {
-		return nil, AdapterError{"Decoding value failed", err}
+		return nil, fmt.Errorf("Decoding value failed: %w", err)
 	}
 	return value_opt.(*optional.Bytes), nil
 }
@@ -77,17 +78,17 @@ func storage_read(r runtime.Instance, key []byte, offset uint32, length uint32) 
 	// Encode inputs
 	key_enc, err := scale.Encode([]byte(key))
 	if err != nil {
-		return nil, AdapterError{"Encoding key failed", err}
+		return nil, fmt.Errorf("Encoding key failed: %w", err)
 	}
 
 	offset_enc, err := scale.Encode(offset)
 	if err != nil {
-		return nil, AdapterError{"Encoding offset failed", err}
+		return nil, fmt.Errorf("Encoding offset failed: %w", err)
 	}
 
 	length_enc, err := scale.Encode(length)
 	if err != nil {
-		return nil, AdapterError{"Encoding length failed", err}
+		return nil, fmt.Errorf("Encoding length failed: %w", err)
 	}
 
 	args_enc := append(append(key_enc, offset_enc...), length_enc...)
@@ -95,12 +96,12 @@ func storage_read(r runtime.Instance, key []byte, offset uint32, length uint32) 
 	// Check that key has not been set
 	value_enc, err := r.Exec("rtm_ext_storage_read_version_1", args_enc)
 	if err != nil {
-		return nil, AdapterError{"Execution failed", err}
+		return nil, fmt.Errorf("Execution failed: %w", err)
 	}
 
 	value_opt, err := scale.Decode(value_enc, &optional.Bytes{})
 	if err != nil {
-		return nil, AdapterError{"Decoding value failed", err}
+		return nil, fmt.Errorf("Decoding value failed: %w", err)
 	}
 	return value_opt.(*optional.Bytes), nil
 }
@@ -110,13 +111,13 @@ func storage_clear(r runtime.Instance, key []byte) error {
 	// Encode inputs
 	key_enc, err := scale.Encode([]byte(key))
 	if err != nil {
-		return AdapterError{"Encoding key failed", err}
+		return fmt.Errorf("Encoding key failed: %w", err)
 	}
 
 	// Clear storage key
 	_, err = r.Exec("rtm_ext_storage_clear_version_1", key_enc)
 	if err != nil {
-		return AdapterError{"Execution failed", err}
+		return fmt.Errorf("Execution failed: %w", err)
 	}
 
 	return nil
@@ -127,18 +128,18 @@ func storage_exists(r runtime.Instance, key []byte) (uint32, error) {
 	// Encode inputs
 	key_enc, err := scale.Encode(key)
 	if err != nil {
-		return 0, AdapterError{"Encoding key failed", err}
+		return 0, fmt.Errorf("Encoding key failed: %w", err)
 	}
 
 	// Retrieve status
 	exists_enc, err := r.Exec("rtm_ext_storage_exists_version_1", key_enc)
 	if err != nil {
-		return 0, AdapterError{"Execution failed", err}
+		return 0, fmt.Errorf("Execution failed: %w", err)
 	}
 
 	exists, err := scale.Decode(exists_enc, uint32(0))
 	if err != nil {
-		return 0, AdapterError{"Decoding value failed", err}
+		return 0, fmt.Errorf("Decoding value failed: %w", err)
 	}
 	return exists.(uint32), nil
 }
@@ -148,18 +149,18 @@ func storage_append(r runtime.Instance, key []byte, value []byte) error {
 	// Encode inputs
 	key_enc, err := scale.Encode(key)
 	if err != nil {
-		return AdapterError{"Encoding key failed", err}
+		return fmt.Errorf("Encoding key failed: %w", err)
 	}
 
 	value_enc, err := scale.Encode(value)
 	if err != nil {
-		return AdapterError{"Encoding value failed", err}
+		return fmt.Errorf("Encoding value failed: %w", err)
 	}
 
 	// Append value to key
 	_, err = r.Exec("rtm_ext_storage_append_version_1", append(key_enc, value_enc...))
 	if err != nil {
-		return AdapterError{"Execution failed", err}
+		return fmt.Errorf("Execution failed: %w", err)
 	}
 
 	return nil
@@ -170,12 +171,12 @@ func storage_root(r runtime.Instance) ([]byte, error) {
 	// Retrieve current root
 	root_enc, err := r.Exec("rtm_ext_storage_root_version_1", []byte{})
 	if err != nil {
-		return nil, AdapterError{"Execution failed", err}
+		return nil, fmt.Errorf("Execution failed: %w", err)
 	}
 
 	root, err := scale.Decode(root_enc, []byte{})
 	if err != nil {
-		return nil, AdapterError{"Decoding failed", err}
+		return nil, fmt.Errorf("Decoding root failed: %w", err)
 	}
 	return root.([]byte), nil
 }
@@ -185,18 +186,18 @@ func storage_next_key(r runtime.Instance, key []byte) (*optional.Bytes, error) {
 	// Encode inputs
 	key_enc, err := scale.Encode(key)
 	if err != nil {
-		return nil, AdapterError{"Encoding key failed", err}
+		return nil, fmt.Errorf("Encoding key failed: %w", err)
 	}
 
 	// Retrieve key
 	value_enc, err := r.Exec("rtm_ext_storage_next_key_version_1", key_enc)
 	if err != nil {
-		return nil, AdapterError{"Execution failed", err}
+		return nil, fmt.Errorf("Execution failed: %w", err)
 	}
 
 	value_opt, err := scale.Decode(value_enc, &optional.Bytes{})
 	if err != nil {
-		return nil, AdapterError{"Decoding next key failed", err}
+		return nil, fmt.Errorf("Decoding next key failed: %w", err)
 	}
 	return value_opt.(*optional.Bytes), nil
 }
@@ -225,7 +226,7 @@ func test_storage_set_get(r runtime.Instance, key string, value string) error {
 	}
 
 	if none.Exists() {
-		return newTestFailuref("Key already exists: %s", none.Value())
+		return fmt.Errorf("Key already exists: %s", none.Value())
 	}
 
 	// Set key to value
@@ -241,11 +242,11 @@ func test_storage_set_get(r runtime.Instance, key string, value string) error {
 	}
 
 	if !some.Exists() {
-		return newTestFailure("Key is missing")
+		return errors.New("Key is missing")
 	}
 
 	if !bytes.Equal(some.Value(), []byte(value)) {
-		return newTestFailuref("Value is different: %s", some.Value())
+		return fmt.Errorf("Value is different: %s", some.Value())
 	}
 
 	// Print result
@@ -263,7 +264,7 @@ func test_storage_read(r runtime.Instance, key string, value string, offset uint
 	}
 
 	if none.Exists() {
-		return newTestFailuref("Key already exists: %s", none.Value())
+		return fmt.Errorf("Key already exists: %s", none.Value())
 	}
 
 	// Add data to storage
@@ -279,7 +280,7 @@ func test_storage_read(r runtime.Instance, key string, value string, offset uint
 	}
 
 	if !some.Exists() {
-		return newTestFailure("Key is missing")
+		return errors.New("Key is missing")
 	}
 
 	if int(offset) < len(value) {
@@ -290,10 +291,10 @@ func test_storage_read(r runtime.Instance, key string, value string, offset uint
 		expected_value := value[offset:int(offset)+expected_length];
 
 		if !bytes.Equal(some.Value(), []byte(expected_value)) {
-			return newTestFailuref("Value is different: %s", some.Value())
+			return fmt.Errorf("Value is different: %s", some.Value())
 		}
 	} else if len(some.Value()) != 0 {
-		return newTestFailuref("Value is not empty: %s", some.Value())
+		return fmt.Errorf("Value is not empty: %s", some.Value())
 	}
 
 	fmt.Printf("%s\n", some.Value())
@@ -316,11 +317,11 @@ func test_storage_clear(r runtime.Instance, key string, value string) error {
 	}
 
 	if !some.Exists() {
-		return newTestFailure("Key is missing")
+		return errors.New("Key is missing")
 	}
 
 	if !bytes.Equal(some.Value(), []byte(value)) {
-		return newTestFailuref("Value is different: %s", some.Value())
+		return fmt.Errorf("Value is different: %s", some.Value())
 	}
 
 	// Clear data
@@ -336,7 +337,7 @@ func test_storage_clear(r runtime.Instance, key string, value string) error {
 	}
 
 	if none.Exists() {
-		return newTestFailuref("Key was not cleared: %s", none.Value())
+		return fmt.Errorf("Key was not cleared: %s", none.Value())
 	}
 
 	return nil
@@ -351,7 +352,7 @@ func test_storage_exists(r runtime.Instance, key string, value string) error {
 	}
 
 	if none != 0 {
-		return newTestFailure("Key already exists")
+		return errors.New("Key already exists")
 	}
 
 	// Insert data
@@ -367,7 +368,7 @@ func test_storage_exists(r runtime.Instance, key string, value string) error {
 	}
 
 	if some != 1 {
-		return newTestFailure("Key does not exists")
+		return errors.New("Key does not exists")
 	}
 
 	// Print result
@@ -391,12 +392,12 @@ func test_storage_clear_prefix(r runtime.Instance, prefix string, key1 string, v
 	// Clear prefix
 	prefix_enc, err := scale.Encode([]byte(prefix))
 	if err != nil {
-		return AdapterError{"Encoding prefix failed: ", err}
+		return fmt.Errorf("Encoding prefix failed: : %w", err)
 	}
 
 	_, err = r.Exec("rtm_ext_storage_clear_prefix_version_1", prefix_enc)
 	if err != nil {
-		return AdapterError{"Execution failed: ", err}
+		return fmt.Errorf("Execution failed: : %w", err)
 	}
 
 	// Check if first key was handled correctly
@@ -407,15 +408,15 @@ func test_storage_clear_prefix(r runtime.Instance, prefix string, key1 string, v
 
 	if strings.HasPrefix(key1, prefix) {
 		if result1.Exists() {
-			return newTestFailure("Key1 was not deleted")
+			return errors.New("Key1 was not deleted")
 		}
 	} else {
 		if !result1.Exists() {
-			return newTestFailure("Key1 was deleted")
+			return errors.New("Key1 was deleted")
 		}
 
 		if !bytes.Equal(result1.Value(), []byte(value1)) {
-			return newTestFailuref("Value1 is different: %s", result1.Value())
+			return fmt.Errorf("Value1 is different: %s", result1.Value())
 		}
 	}
 
@@ -427,15 +428,15 @@ func test_storage_clear_prefix(r runtime.Instance, prefix string, key1 string, v
 
 	if strings.HasPrefix(key2, prefix) {
 		if result2.Exists() {
-			return newTestFailure("Key2 was not deleted")
+			return errors.New("Key2 was not deleted")
 		}
 	} else {
 		if !result2.Exists() {
-			return newTestFailure("Key2 was deleted")
+			return errors.New("Key2 was deleted")
 		}
 
 		if !bytes.Equal(result2.Value(), []byte(value2)) {
-			return newTestFailuref("Value2 is different: %s", result2.Value())
+			return fmt.Errorf("Value2 is different: %s", result2.Value())
 		}
 	}
 
@@ -447,12 +448,12 @@ func test_storage_append(r runtime.Instance, key1 string, value1 string, key2 st
 	// Encode inputs
 	value1_enc, err := scale.Encode(value1)
 	if err != nil {
-		return AdapterError{"Encoding value1 failed", err}
+		return fmt.Errorf("Encoding value1 failed: %w", err)
 	}
 
 	value2_enc, err := scale.Encode(value2)
 	if err != nil {
-		return AdapterError{"Encoding value2 failed", err}
+		return fmt.Errorf("Encoding value2 failed: %w", err)
 	}
 
 	// Check that key1 is unset
@@ -462,7 +463,7 @@ func test_storage_append(r runtime.Instance, key1 string, value1 string, key2 st
 	}
 
 	if none1.Exists() {
-		return newTestFailuref("Key1 already exists: %s", none1.Value())
+		return fmt.Errorf("Key1 already exists: %s", none1.Value())
 	}
 
 	// Insert key1
@@ -482,7 +483,7 @@ func test_storage_append(r runtime.Instance, key1 string, value1 string, key2 st
 	}
 
 	if none2.Exists() {
-		return newTestFailuref("Key2 already exists: %s", none2.Value())
+		return fmt.Errorf("Key2 already exists: %s", none2.Value())
 	}
 
 	// Insert key2
@@ -510,17 +511,17 @@ func test_storage_append(r runtime.Instance, key1 string, value1 string, key2 st
 	}
 
 	if !some1_opt.Exists() {
-		return newTestFailure("Key1 not set")
+		return errors.New("Key1 not set")
 	}
 
 	some1_dec, err := scale.Decode(some1_opt.Value(), []string{})
 	if err != nil {
-		return AdapterError{"Decoding value failed", err}
+		return fmt.Errorf("Decoding value failed: %w", err)
 	}
 	some1 := some1_dec.([]string)
 
 	if some1[0] != value1 || some1[1] != value2 {
-		return newTestFailure("Value is different")
+		return errors.New("Value is different")
 	}
 
 	fmt.Println(strings.Join(some1, ";"))
@@ -532,17 +533,17 @@ func test_storage_append(r runtime.Instance, key1 string, value1 string, key2 st
 	}
 
 	if !some2_opt.Exists() {
-		return newTestFailure("Key2 not set")
+		return errors.New("Key2 not set")
 	}
 
 	some2_dec, err := scale.Decode(some2_opt.Value(), []string{})
 	if err != nil {
-		return AdapterError{"Decoding value failed", err}
+		return fmt.Errorf("Decoding value failed: %w", err)
 	}
 	some2 := some2_dec.([]string)
 
 	if some2[0] != value2 || some2[1] != value1 || some2[2] != value2 || some2[3] != value1 {
-		return newTestFailuref("Key2 not set: %s", some2_opt.Value())
+		return fmt.Errorf("Key2 not set: %s", some2_opt.Value())
 	}
 
 	fmt.Println(strings.Join(some2, ";"))
@@ -583,7 +584,7 @@ func test_storage_next_key(r runtime.Instance, key1 string, value1 string, key2 
 	}
 
 	if none1.Exists() {
-		return newTestFailure("Next1 is not empty")
+		return errors.New("Next1 is not empty")
 	}
 
 	none2, err := storage_next_key(r, []byte(key2))
@@ -592,7 +593,7 @@ func test_storage_next_key(r runtime.Instance, key1 string, value1 string, key2 
 	}
 
 	if none2.Exists() {
-		return newTestFailure("Next2 is not empty")
+		return errors.New("Next2 is not empty")
 	}
 
 	// Insert test data
@@ -613,18 +614,18 @@ func test_storage_next_key(r runtime.Instance, key1 string, value1 string, key2 
 
 	if strings.Compare(key1, key2) < 0 {
 		if !some1.Exists() {
-			return newTestFailure("Key2 is missing")
+			return errors.New("Key2 is missing")
 		}
 		next := some1.Value();
 
 		if !bytes.Equal(next, []byte(key2)) {
-			return newTestFailuref("Next is not key2: %s", next)
+			return fmt.Errorf("Next is not key2: %s", next)
 		}
 
 		fmt.Printf("%s\n", next);
 	} else {
 		if some1.Exists() {
-			return newTestFailure("Next is not empty")
+			return errors.New("Next is not empty")
 		}
 	}
 
@@ -636,18 +637,18 @@ func test_storage_next_key(r runtime.Instance, key1 string, value1 string, key2 
 
 	if strings.Compare(key2, key1) < 0 {
 		if !some2.Exists() {
-			return newTestFailure("Key1 is missing")
+			return errors.New("Key1 is missing")
 		}
 		next := some2.Value();
 
 		if !bytes.Equal(next, []byte(key1)) {
-			return newTestFailuref("Next is not key1: %s", next)
+			return fmt.Errorf("Next is not key1: %s", next)
 		}
 
 		fmt.Printf("%s\n", next);
 	} else {
 		if some2.Exists() {
-			return newTestFailure("Next is not empty")
+			return errors.New("Next is not empty")
 		}
 	}
 

--- a/test/adapters/gossamer/host_api/storage.go
+++ b/test/adapters/gossamer/host_api/storage.go
@@ -31,7 +31,7 @@ import (
 // -- Helpers --
 
 // Helper function to call rtm_ext_storage_set_version_1
-func storage_set(r runtime.Instance, key []byte, value []byte) error {
+func storage_set(r runtime.Instance, key, value []byte) error {
 	// Encode inputs
 	key_enc, err := scale.Encode(key)
 	if err != nil {
@@ -145,7 +145,7 @@ func storage_exists(r runtime.Instance, key []byte) (uint32, error) {
 }
 
 // Helper function to call rtm_ext_storage_append_version_1
-func storage_append(r runtime.Instance, key []byte, value []byte) error {
+func storage_append(r runtime.Instance, key, value []byte) error {
 	// Encode inputs
 	key_enc, err := scale.Encode(key)
 	if err != nil {
@@ -218,7 +218,7 @@ func test_storage_init(r runtime.Instance) error {
 }
 
 // Test for rtm_ext_storage_set_version_1 and rtm_ext_storage_get_version_1
-func test_storage_set_get(r runtime.Instance, key string, value string) error {
+func test_storage_set_get(r runtime.Instance, key, value string) error {
 	// Get invalid key
 	none, err := storage_get(r, []byte(key))
 	if err != nil {
@@ -256,7 +256,7 @@ func test_storage_set_get(r runtime.Instance, key string, value string) error {
 }
 
 // Test for rtm_ext_storage_read_version_1
-func test_storage_read(r runtime.Instance, key string, value string, offset uint32, length uint32) error {
+func test_storage_read(r runtime.Instance, key, value string, offset, length uint32) error {
 	// Check that key has not been set
 	none, err := storage_read(r, []byte(key), offset, length)
 	if err != nil {
@@ -303,7 +303,7 @@ func test_storage_read(r runtime.Instance, key string, value string, offset uint
 }
 
 // Test for rtm_ext_storage_clear_version_1
-func test_storage_clear(r runtime.Instance, key string, value string) error {
+func test_storage_clear(r runtime.Instance, key, value string) error {
 	// Insert data
 	err := storage_set(r, []byte(key), []byte(value))
 	if err != nil {
@@ -344,7 +344,7 @@ func test_storage_clear(r runtime.Instance, key string, value string) error {
 }
 
 // Test for rtm_ext_storage_exists_version_1
-func test_storage_exists(r runtime.Instance, key string, value string) error {
+func test_storage_exists(r runtime.Instance, key, value string) error {
 	// Check for no data
 	none, err := storage_exists(r, []byte(key))
 	if err != nil {
@@ -378,7 +378,7 @@ func test_storage_exists(r runtime.Instance, key string, value string) error {
 }
 
 // Test for rtm_ext_storage_clear_prefix_version_1
-func test_storage_clear_prefix(r runtime.Instance, prefix string, key1 string, value1 string, key2 string, value2 string) error {
+func test_storage_clear_prefix(r runtime.Instance, prefix, key1, value1, key2, value2 string) error {
 	// Insert data
 	err := storage_set(r, []byte(key1), []byte(value1))
 	if err != nil {
@@ -444,7 +444,7 @@ func test_storage_clear_prefix(r runtime.Instance, prefix string, key1 string, v
 }
 
 // Test for rtm_ext_storage_append_version_1
-func test_storage_append(r runtime.Instance, key1 string, value1 string, key2 string, value2 string) error {
+func test_storage_append(r runtime.Instance, key1, value1, key2, value2 string) error {
 	// Encode inputs
 	value1_enc, err := scale.Encode(value1)
 	if err != nil {
@@ -552,7 +552,7 @@ func test_storage_append(r runtime.Instance, key1 string, value1 string, key2 st
 }
 
 // Test for rtm_ext_storage_root_version_1
-func test_storage_root(r runtime.Instance, key1 string, value1 string, key2 string, value2 string) error {
+func test_storage_root(r runtime.Instance, key1, value1, key2, value2 string) error {
 	// Insert data
 	err := storage_set(r, []byte(key1), []byte(value1))
 	if err != nil {
@@ -575,7 +575,7 @@ func test_storage_root(r runtime.Instance, key1 string, value1 string, key2 stri
 }
 
 // Test for rtm_ext_storage_next_key_version_1
-func test_storage_next_key(r runtime.Instance, key1 string, value1 string, key2 string, value2 string) error {
+func test_storage_next_key(r runtime.Instance, key1, value1, key2, value2 string) error {
 
 	// No next key available
 	none1, err := storage_next_key(r, []byte(key1))

--- a/test/adapters/gossamer/host_api/trie.go
+++ b/test/adapters/gossamer/host_api/trie.go
@@ -25,7 +25,7 @@ import (
 )
 
 
-func test_trie_root(r runtime.Instance, key1 string, value1 string, key2 string, value2 string, key3 string, value3 string) error {
+func test_trie_root(r runtime.Instance, key1, value1, key2, value2, key3, value3 string) error {
 	// Construct and encode input
 	trie := []string{key1, value1, key2, value2, key3, value3}
 
@@ -55,7 +55,7 @@ func test_trie_root(r runtime.Instance, key1 string, value1 string, key2 string,
 	return nil
 }
 
-func test_trie_ordered_root(r runtime.Instance, value1 string, value2 string, value3 string) error {
+func test_trie_ordered_root(r runtime.Instance, value1, value2, value3 string) error {
 	// Construct and encode input
 	trie := []string{value1, value2, value3}
 

--- a/test/adapters/gossamer/host_api/trie.go
+++ b/test/adapters/gossamer/host_api/trie.go
@@ -31,7 +31,7 @@ func test_trie_root(r runtime.Instance, key1 string, value1 string, key2 string,
 
 	trie_enc, err := scale.Encode(trie)
 	if err != nil {
-		return AdapterError{"Encoding input failed", err}
+		return fmt.Errorf("Encoding input failed: %w", err)
 	}
 
 	// Change encoding to key-value tuples by fixing encoded list length
@@ -41,13 +41,13 @@ func test_trie_root(r runtime.Instance, key1 string, value1 string, key2 string,
 	hash_enc, err := r.Exec("rtm_ext_trie_blake2_256_root_version_1", trie_enc)
 
 	if err != nil {
-		return AdapterError{"Execution failed", err}
+		return fmt.Errorf("Execution failed: %w", err)
 	}
 
 	// Decode and print result
 	hash, err := scale.Decode(hash_enc, []byte{})
 	if err != nil {
-		return AdapterError{"Decoding value failed", err}
+		return fmt.Errorf("Decoding value failed: %w", err)
 	}
 
 	fmt.Printf("%x\n", hash.([]byte)[:])
@@ -61,20 +61,20 @@ func test_trie_ordered_root(r runtime.Instance, value1 string, value2 string, va
 
 	trie_enc, err := scale.Encode(trie)
 	if err != nil {
-		return AdapterError{"Encoding input failed", err}
+		return fmt.Errorf("Encoding input failed: %w", err)
 	}
 
 	// Compute ordered root hash
 	hash_enc, err := r.Exec("rtm_ext_trie_blake2_256_ordered_root_version_1", trie_enc)
 
 	if err != nil {
-		return AdapterError{"Execution failed", err}
+		return fmt.Errorf("Execution failed: %w", err)
 	}
 
 	// Decode and print result
 	hash, err := scale.Decode(hash_enc, []byte{})
 	if err != nil {
-		return AdapterError{"Decoding value failed", err}
+		return fmt.Errorf("Decoding value failed: %w", err)
 	}
 
 	fmt.Printf("%x\n", hash.([]byte)[:])

--- a/test/adapters/substrate/src/cli.yaml
+++ b/test/adapters/substrate/src/cli.yaml
@@ -55,5 +55,8 @@ subcommands:
               takes_value: true
               use_delimiter: true
               value_name: TEST_DATA
-          - wasmtime:
-              long: wasmtime
+          - environment:
+              long: environment
+              short: e
+              takes_value: true
+              possible_values: [ wasmi, wasmtime ]

--- a/test/adapters/substrate/src/host_api/mod.rs
+++ b/test/adapters/substrate/src/host_api/mod.rs
@@ -15,8 +15,12 @@ pub fn process_host_api_tests(subcmd_matches: &ArgMatches) {
 
         let mut rtm = utils::Runtime::new();
 
-        if subcmd_matches.is_present("wasmtime") {
-            rtm = rtm.using_wasmtime();
+        if let Some(env) = subcmd_matches.value_of("environment") {
+            match env {
+                "wasmi" => rtm = rtm.using_wasmi(),
+                "wasmtime" => rtm = rtm.using_wasmtime(),
+                _ => unreachable!(), // Clap should not allow other values
+            }
         }
 
         match func {

--- a/test/adapters/substrate/src/host_api/utils.rs
+++ b/test/adapters/substrate/src/host_api/utils.rs
@@ -73,6 +73,10 @@ impl Runtime {
             method: WasmExecutionMethod::Interpreted,
         }
     }
+    pub fn using_wasmi(mut self) -> Self {
+        self.method = WasmExecutionMethod::Interpreted;
+        self
+    }
     pub fn using_wasmtime(mut self) -> Self {
         self.method = WasmExecutionMethod::Compiled;
         self

--- a/test/helpers/SpecificationTestsuite.jl
+++ b/test/helpers/SpecificationTestsuite.jl
@@ -4,13 +4,21 @@ module SpecificationTestsuite
     include("StringHelpers.jl")
 
 
-    export ALL_IMPLEMENTATIONS, ALL_FIXTURES, Config, execute
+    export ALL_IMPLEMENTATIONS, ALL_ENVIRONMENTS, ALL_FIXTURES, Config, execute
 
-    "List of all know implementations"
+    "List of all known implementations"
     const ALL_IMPLEMENTATIONS = [
       "substrate"
       "kagome"
       "gossamer"
+    ]
+
+    "List of all known environments"
+    const ALL_ENVIRONMENTS = [
+        "wasmi"
+        "wasmtime"
+        "wasmer"
+        "life"
     ]
 
     module Config
@@ -32,6 +40,9 @@ module SpecificationTestsuite
 
         "By default all implementations are enabled."
         implementations = ALL_IMPLEMENTATIONS
+
+        "By default no special environment is selected."
+        environments = []
 
         "Path of folder containing all fixtures."
         function fixdir()::String
@@ -59,6 +70,11 @@ module SpecificationTestsuite
         "Update selected fixtures in config"
         function set_fixtures(selected::StringList)
             global fixtures = selected
+        end
+
+        "Update selected fixtures in config"
+        function set_environments(selected::StringList)
+            global environments = selected
         end
 
         "Update docker settings in config"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,12 +22,16 @@ function print_usage()
     println()
     println("FIXTURES: ")
     println(join(ALL_FIXTURES, ", "))
+    println()
+    println("ENVIRONMENTS: (host-api only)")
+    println(join(ALL_ENVIRONMENTS, ", "))
 end
 
 
 # Collect filters
 implementations = Vector{String}()
 fixtures = Vector{String}()
+environments = Vector{String}()
 
 # Process all command line arguments
 for arg in ARGS
@@ -56,6 +60,11 @@ for arg in ARGS
         continue
     end
 
+    if arg in ALL_ENVIRONMENTS
+        push!(environments, arg)
+        continue
+    end
+
     println("Unknown argument: ", arg)
     println()
     print_usage()
@@ -71,12 +80,21 @@ if !isempty(fixtures)
     Config.set_fixtures(fixtures)
 end
 
+if !isempty(environments)
+    Config.set_environments(environments)
+end
+
 # Display config
 println("CONFIGURATION:")
 println("Loglevel:        " * (Config.verbose ? "verbose"   : "info"))
 println("Binaries:        " * (Config.docker  ? "container" : "local"))
 println("Implementations: " * join(Config.implementations, ", "))
 println("Fixtures:        " * join(Config.fixtures, ", "))
+if isempty(Config.environments)
+    println("Environments:    (default)")
+else
+    println("Environments:    " * join(Config.environments, ", "))
+end
 println()
 
 # Add locally build or downloaded adapters, testers and hosts to PATH


### PR DESCRIPTION
This extends the testsuite to also allow the test of the none-default backends. This is achieved by using the optional `environment` flag the substrate and gossamer adapter now support.

While working on the `gossamer-adapter` I also added a `runtime` flag to the to simplify debugging, retired our custom error types to us the go 13 error wrapping and added support for the new life backend. 