### PR TITLE
gossamer-adapter: test host-api with life backend

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -253,7 +253,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [ wasmer ]
+        environment: [ wasmer, life ]
     name: "[test-host-api] gossamer ${{ matrix.environment }}"
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
This enables the host-api fixture for gossamer's life wasm environement/backend as a continuation of #408.

Currently the life backend still calls the `Version()` runtime api on initialization, but ChainSafe promised to fix that soon.