### PR TITLE
host-spec: TeXmacs cleanup and improvements

### DIFF
--- a/host-spec/Makefile
+++ b/host-spec/Makefile
@@ -9,7 +9,7 @@ GENERATED  := figures/c07-overview.eps
 SOURCES    := host-spec.tm $(CHAPTERS) $(APPENDICES) $(FIGURES) $(GENERATED)
 
 
-.PHONY: build pdf tex diff temp update clean
+.PHONY: build pdf tex diff temp update deaux clean
 
 build: pdf
 
@@ -51,6 +51,20 @@ polkadot-host-spec.diff.pdf: $(SOURCES) $(REVDIR) host-spec.scm
 
 update: $(SOURCES) host-spec.scm
 	xvfb-run texmacs -b host-spec.scm -x "(update-all \"$$PWD/$<\" \"$(TMPDIR)\")" --quit
+
+
+define DEAUX_SED_REGEXP
+	s@<\\$1|\([^>]*\)>.*</$1>@<$1|\1|>@g
+endef
+
+DETOC := $(call DEAUX_SED_REGEXP,table-of-contents)
+DEGLY := $(call DEAUX_SED_REGEXP,the-glossary)
+DEBIB := $(call DEAUX_SED_REGEXP,bibliography)
+DEIDX := $(call DEAUX_SED_REGEXP,the-index)
+
+deaux:
+	sed -e '1h;2,$$H;$$!d;g' -e '$(DETOC)' -e '$(DEGLY)' -e '$(DEBIB)' -e '$(DEIDX)' -i host-spec.tm
+
 
 clean:
 	rm -rf $(REVDIR) $(GENERATED) polkadot-host-spec.pdf polkadot-host-spec.tex polkadot-host-spec.diff.pdf

--- a/host-spec/aa-cryptoalgorithms.tm
+++ b/host-spec/aa-cryptoalgorithms.tm
@@ -144,3 +144,16 @@
   \;
 
 </body>
+
+<\initial>
+  <\collection>
+    <associate|appendix-nr|0>
+    <associate|save-aux|false>
+  </collection>
+</initial>
+
+<references|<\collection>
+</collection>>
+
+<auxiliary|<\collection>
+</collection>>

--- a/host-spec/aa-cryptoalgorithms.tm
+++ b/host-spec/aa-cryptoalgorithms.tm
@@ -1,8 +1,8 @@
-<TeXmacs|1.99.12>
+<TeXmacs|1.99.18>
 
 <project|host-spec.tm>
 
-<style|book>
+<style|<tuple|tmbook|algorithmacs-style>>
 
 <\body>
   <appendix|Cryptographic Algorithms>

--- a/host-spec/ab-encodings.tm
+++ b/host-spec/ab-encodings.tm
@@ -249,3 +249,16 @@
   \;
 
 </body>
+
+<\initial>
+  <\collection>
+    <associate|appendix-nr|1>
+    <associate|save-aux|false>
+  </collection>
+</initial>
+
+<references|<\collection>
+</collection>>
+
+<auxiliary|<\collection>
+</collection>>

--- a/host-spec/ab-encodings.tm
+++ b/host-spec/ab-encodings.tm
@@ -1,8 +1,8 @@
-<TeXmacs|1.99.16>
+<TeXmacs|1.99.18>
 
 <project|host-spec.tm>
 
-<style|<tuple|book|old-dots|old-lengths>>
+<style|<tuple|tmbook|algorithmacs-style>>
 
 <\body>
   <appendix|Auxiliary Encodings><label|sect-encoding>

--- a/host-spec/ac-genesis.tm
+++ b/host-spec/ac-genesis.tm
@@ -1,8 +1,8 @@
-<TeXmacs|1.99.16>
+<TeXmacs|1.99.18>
 
 <project|host-spec.tm>
 
-<style|<tuple|book|old-lengths>>
+<style|<tuple|tmbook|algorithmacs-style>>
 
 <\body>
   <appendix|Genesis State Specification><label|sect-genesis-block>

--- a/host-spec/ac-genesis.tm
+++ b/host-spec/ac-genesis.tm
@@ -54,3 +54,16 @@
   \;
 
 </body>
+
+<\initial>
+  <\collection>
+    <associate|appendix-nr|2>
+    <associate|save-aux|false>
+  </collection>
+</initial>
+
+<references|<\collection>
+</collection>>
+
+<auxiliary|<\collection>
+</collection>>

--- a/host-spec/ad-hostapi.tm
+++ b/host-spec/ad-hostapi.tm
@@ -1,8 +1,8 @@
-<TeXmacs|1.99.17>
+<TeXmacs|1.99.18>
 
 <project|host-spec.tm>
 
-<style|<tuple|book|old-dots|old-lengths>>
+<style|<tuple|tmbook|algorithmacs-style>>
 
 <\body>
   <appendix|Polkadot Host API><label|sect-host-api>

--- a/host-spec/ad-hostapi.tm
+++ b/host-spec/ad-hostapi.tm
@@ -2440,3 +2440,16 @@
   \;
 
 </body>
+
+<\initial>
+  <\collection>
+    <associate|appendix-nr|3>
+    <associate|save-aux|false>
+  </collection>
+</initial>
+
+<references|<\collection>
+</collection>>
+
+<auxiliary|<\collection>
+</collection>>

--- a/host-spec/ae-runtimeapi.tm
+++ b/host-spec/ae-runtimeapi.tm
@@ -2,7 +2,7 @@
 
 <project|host-spec.tm>
 
-<style|<tuple|book|old-dots|old-lengths>>
+<style|<tuple|tmbook|algorithmacs-style>>
 
 <\body>
   <appendix|Polkadot Runtime API><label|sect-runtime-entries>

--- a/host-spec/ae-runtimeapi.tm
+++ b/host-spec/ae-runtimeapi.tm
@@ -1246,3 +1246,16 @@
   \;
 
 </body>
+
+<\initial>
+  <\collection>
+    <associate|appendix-nr|4>
+    <associate|save-aux|false>
+  </collection>
+</initial>
+
+<references|<\collection>
+</collection>>
+
+<auxiliary|<\collection>
+</collection>>

--- a/host-spec/c01-background.tm
+++ b/host-spec/c01-background.tm
@@ -350,3 +350,16 @@
 
   \;
 </body>
+
+<\initial>
+  <\collection>
+    <associate|chapter-nr|0>
+    <associate|save-aux|false>
+  </collection>
+</initial>
+
+<references|<\collection>
+</collection>>
+
+<auxiliary|<\collection>
+</collection>>

--- a/host-spec/c01-background.tm
+++ b/host-spec/c01-background.tm
@@ -1,8 +1,8 @@
-<TeXmacs|1.99.16>
+<TeXmacs|1.99.18>
 
 <project|host-spec.tm>
 
-<style|<tuple|book|old-lengths>>
+<style|<tuple|tmbook|algorithmacs-style>>
 
 <\body>
   <chapter|Background>

--- a/host-spec/c02-state.tm
+++ b/host-spec/c02-state.tm
@@ -543,3 +543,16 @@
 
   \;
 </body>
+
+<\initial>
+  <\collection>
+    <associate|chapter-nr|1>
+    <associate|save-aux|false>
+  </collection>
+</initial>
+
+<references|<\collection>
+</collection>>
+
+<auxiliary|<\collection>
+</collection>>

--- a/host-spec/c02-state.tm
+++ b/host-spec/c02-state.tm
@@ -1,8 +1,8 @@
-<TeXmacs|1.99.16>
+<TeXmacs|1.99.18>
 
 <project|host-spec.tm>
 
-<style|<tuple|book|old-dots|old-lengths>>
+<style|<tuple|tmbook|algorithmacs-style>>
 
 <\body>
   <chapter|State Specification><label|chap-state-spec>

--- a/host-spec/c03-transition.tm
+++ b/host-spec/c03-transition.tm
@@ -1011,3 +1011,16 @@
   \;
 
 </body>
+
+<\initial>
+  <\collection>
+    <associate|chapter-nr|2>
+    <associate|save-aux|false>
+  </collection>
+</initial>
+
+<references|<\collection>
+</collection>>
+
+<auxiliary|<\collection>
+</collection>>

--- a/host-spec/c03-transition.tm
+++ b/host-spec/c03-transition.tm
@@ -2,7 +2,7 @@
 
 <project|host-spec.tm>
 
-<style|<tuple|book|algorithmacs-style|old-dots|old-lengths>>
+<style|<tuple|tmbook|algorithmacs-style>>
 
 <\body>
   <chapter|State Transition><label|chap-state-transit>

--- a/host-spec/c04-networking.tm
+++ b/host-spec/c04-networking.tm
@@ -1,8 +1,8 @@
-<TeXmacs|1.99.19>
+<TeXmacs|1.99.18>
 
 <project|host-spec.tm>
 
-<style|<tuple|generic|std-latex|old-dots|old-lengths>>
+<style|<tuple|tmbook|algorithmacs-style>>
 
 <\body>
   <chapter|Networking><label|sect-networking>

--- a/host-spec/c04-networking.tm
+++ b/host-spec/c04-networking.tm
@@ -716,5 +716,17 @@
   </with>
 
   \;
-
 </body>
+
+<\initial>
+  <\collection>
+    <associate|chapter-nr|3>
+    <associate|save-aux|false>
+  </collection>
+</initial>
+
+<references|<\collection>
+</collection>>
+
+<auxiliary|<\collection>
+</collection>>

--- a/host-spec/c05-bootstrapping.tm
+++ b/host-spec/c05-bootstrapping.tm
@@ -65,3 +65,15 @@
 
 </body>
 
+<\initial>
+  <\collection>
+    <associate|chapter-nr|4>
+    <associate|save-aux|false>
+  </collection>
+</initial>
+
+<references|<\collection>
+</collection>>
+
+<auxiliary|<\collection>
+</collection>>

--- a/host-spec/c05-bootstrapping.tm
+++ b/host-spec/c05-bootstrapping.tm
@@ -1,8 +1,8 @@
-<TeXmacs|1.99.17>
+<TeXmacs|1.99.18>
 
 <project|host-spec.tm>
 
-<style|<tuple|book|old-lengths>>
+<style|<tuple|tmbook|algorithmacs-style>>
 
 <\body>
   <chapter|Bootstrapping><label|chap-bootstrapping>

--- a/host-spec/c06-consensus.tm
+++ b/host-spec/c06-consensus.tm
@@ -1,8 +1,8 @@
-<TeXmacs|1.99.19>
+<TeXmacs|1.99.18>
 
 <project|host-spec.tm>
 
-<style|<tuple|book|old-dots|old-lengths|algorithmacs-style>>
+<style|<tuple|tmbook|algorithmacs-style>>
 
 <\body>
   <chapter|Consensus><label|chap-consensu>

--- a/host-spec/c06-consensus.tm
+++ b/host-spec/c06-consensus.tm
@@ -1974,3 +1974,16 @@
   \;
 
 </body>
+
+<\initial>
+  <\collection>
+    <associate|chapter-nr|5>
+    <associate|save-aux|false>
+  </collection>
+</initial>
+
+<references|<\collection>
+</collection>>
+
+<auxiliary|<\collection>
+</collection>>

--- a/host-spec/c07-anv.tm
+++ b/host-spec/c07-anv.tm
@@ -1,8 +1,8 @@
-<TeXmacs|1.99.11>
+<TeXmacs|1.99.18>
 
 <project|host-spec.tm>
 
-<style|<tuple|generic|std-latex>>
+<style|<tuple|tmbook|algorithmacs-style>>
 
 <\body>
   <assign|blobB|<macro|<math|<wide|B|\<bar\>>>>><assign|PoVB|<macro|<math|PoV<rsub|B>>>><assign|paraValidSet|<macro|<math|\<cal-V\><rsub|\<rho\>>>>>

--- a/host-spec/c07-anv.tm
+++ b/host-spec/c07-anv.tm
@@ -1352,3 +1352,16 @@
   \;
 
 </body>
+
+<\initial>
+  <\collection>
+    <associate|chapter-nr|6>
+    <associate|save-aux|false>
+  </collection>
+</initial>
+
+<references|<\collection>
+</collection>>
+
+<auxiliary|<\collection>
+</collection>>

--- a/host-spec/c08-messaging.tm
+++ b/host-spec/c08-messaging.tm
@@ -548,3 +548,16 @@
   \;
 
 </body>
+
+<\initial>
+  <\collection>
+    <associate|chapter-nr|7>
+    <associate|save-aux|false>
+  </collection>
+</initial>
+
+<references|<\collection>
+</collection>>
+
+<auxiliary|<\collection>
+</collection>>

--- a/host-spec/c08-messaging.tm
+++ b/host-spec/c08-messaging.tm
@@ -1,8 +1,8 @@
-<TeXmacs|1.99.13>
+<TeXmacs|1.99.18>
 
 <project|host-spec.tm>
 
-<style|<tuple|generic|std-latex|old-dots>>
+<style|<tuple|tmbook|algorithmacs-style>>
 
 <\body>
   <chapter|Message Passing>

--- a/host-spec/host-spec.tm
+++ b/host-spec/host-spec.tm
@@ -63,6 +63,13 @@
 
 <\initial>
   <\collection>
+    <associate|save-aux|false>
     <associate|preamble|false>
   </collection>
 </initial>
+
+<references|<\collection>
+</collection>>
+
+<auxiliary|<\collection>
+</collection>>

--- a/host-spec/host-spec.tm
+++ b/host-spec/host-spec.tm
@@ -1,6 +1,6 @@
 <TeXmacs|1.99.18>
 
-<style|<tuple|tmbook|algorithmacs-style|old-dots|old-lengths>>
+<style|<tuple|tmbook|algorithmacs-style>>
 
 <\body>
   <\hide-preamble>


### PR DESCRIPTION
This PR contains the following changes:

- Use the same TeXmacs style (`tmbook` in combination with `algorithmacs`) for all files
- Provide TeXmacs with correct chapter or appendix number for each file
- Tell TeXmacs not to save auxillary information to file
- Add Makefile command (`make deaux`) to remove generated TOC, bibliography, glossary and index from spec