### PR TITLE
Last-Completed-Round

### DIFF
--- a/host-spec/c06-consensus.tm
+++ b/host-spec/c06-consensus.tm
@@ -1294,16 +1294,26 @@
   each round of voting is assigned a unique sequential round number
   <math|r<rsub|v>>, it needs to determine and set its round counter <math|r>
   equal to the voting round <math|r<rsub|n>> currently undergoing in the
-  network. Algorithm <reference|algo-initiate-grandpa> mandates the
-  initialization procedure for GRANDPA protocol for a joining validator.
+  network.
+
+  The process of joining a new voter set verses rejoining the current voter
+  set after possible event of network disconnect are different from each
+  other as being explained in this chapter.
+
+  <subsubsection|Voter Set Changes>
+
+  A GRANDPA voter node which is initiating GRANDPA protocol as part of
+  joining a new authority set is required to execute Algorithm
+  <reference|algo-initiate-grandpa>. Algorithm
+  <reference|algo-initiate-grandpa> mandates the initialization procedure for
+  GRANDPA protocol. Note that GRANDPA round number reset to 0 for every
+  authority set change.
 
   <\algorithm>
     <label|algo-initiate-grandpa><name|Initiate-Grandpa>(
 
-    <math|r<rsub|last>>: <math|>last round number (See the following),
-
-    ,<math|B<rsub|last>>: the last block which has been finalized on the
-    chain (see Definition <reference|defn-finalized-block>)
+    <math|B<rsub|last>>: the last block which has been finalized on the chain
+    (see Definition <reference|defn-finalized-block>)
 
     )
   <|algorithm>
@@ -1313,25 +1323,19 @@
       </state>
 
       <\state>
-        <name|Last-Completed-Round><math|\<leftarrow\>0>
-      </state>
-
-      <\state>
-        <\IF>
-          <math|r<rsub|last>=0>
-        </IF>
-      </state>
-
-      <\state>
         <name|Best-Final-Candidate(0)><math|\<leftarrow\>B<rsub|last>>
       </state>
 
       <\state>
-        <name|GRANDPA-GHOST>(<math|0>)<math|\<leftarrow\>B<rsub|last>><END>
+        <name|GRANDPA-GHOST>(<math|0>)<math|\<leftarrow\>B<rsub|last>>
       </state>
 
       <\state>
-        <math|r<rsub|n>\<leftarrow\>r<rsub|last+1>>
+        <name|Last-Completed-Round><math|\<leftarrow\>0>
+      </state>
+
+      <\state>
+        <math|r<rsub|n>\<leftarrow\>1>
       </state>
 
       <\state>
@@ -1340,23 +1344,23 @@
     </algorithmic>
   </algorithm>
 
-  <math|r<rsub|last>> is equal to the latest round the voter has observed
-  that other voters are voting on. The voter obtains this information through
-  various gossiped messages including those mentioned in Definition
-  <reference|defn-finalized-block>.
-
-  <math|r<rsub|last>> is set to 0 if the GRANDPA node is initiating the
-  GRANDPA voting process as a part of a new authority set. This is because
-  the GRANDPA round number reset to 0 for every authority set change.
-
-  <subsubsection|Voter Set Changes>
-
   Voter set changes are signalled by Runtime via a consensus engine message
   as described in Section <reference|sect-consensus-message-digest>. When
   Authorities process such messages they must not vote on any block with a
   higher number than the block at which the change is supposed to happen. The
   new authority set should reinitiate GRANDPA protocol by executing Algorithm
   <reference|algo-initiate-grandpa>.
+
+  <subsubsection|Rejoining the Same Voter Set>
+
+  When a voter node rejoins the network after a possible disconnect from the
+  reset of the voter set and there has been no change to the voter set, they
+  must continue performing GRANDPA protocol at their latest state they have
+  last observed before getting disconnected from the network, essentially
+  ignoring any possible progress in GRANDPA finalization. It is through the
+  process described in Section <reference|sect-grandpa-catchup> which they
+  eventually gets updated about the current GRANDPA round and are able to
+  synchronize their state with the rest of the voting set.
 
   <subsection|Voting Process in Round <math|r>>
 

--- a/host-spec/c06-consensus.tm
+++ b/host-spec/c06-consensus.tm
@@ -1296,18 +1296,18 @@
   equal to the voting round <math|r<rsub|n>> currently undergoing in the
   network.
 
-  The process of joining a new voter set verses rejoining the current voter
-  set after possible event of network disconnect are different from each
-  other as being explained in this chapter.
+  The process of joining a new voter set is different from the one of
+  rejoining the current voter set after a network disconnect. The details of
+  this distinction are described further in this section.
 
   <subsubsection|Voter Set Changes>
 
-  A GRANDPA voter node which is initiating GRANDPA protocol as part of
+  A GRANDPA voter node that is initiating the GRANDPA protocol as part of
   joining a new authority set is required to execute Algorithm
   <reference|algo-initiate-grandpa>. Algorithm
   <reference|algo-initiate-grandpa> mandates the initialization procedure for
-  GRANDPA protocol. Note that GRANDPA round number reset to 0 for every
-  authority set change.
+  the GRANDPA protocol. Note that the GRANDPA round number resets to 0 for
+  every authority set change.
 
   <\algorithm>
     <label|algo-initiate-grandpa><name|Initiate-Grandpa>(
@@ -1353,14 +1353,15 @@
 
   <subsubsection|Rejoining the Same Voter Set>
 
-  When a voter node rejoins the network after a possible disconnect from the
-  reset of the voter set and there has been no change to the voter set, they
-  must continue performing GRANDPA protocol at their latest state they have
-  last observed before getting disconnected from the network, essentially
-  ignoring any possible progress in GRANDPA finalization. It is through the
-  process described in Section <reference|sect-grandpa-catchup> which they
-  eventually gets updated about the current GRANDPA round and are able to
-  synchronize their state with the rest of the voting set.
+  When a voter node rejoins the network after a disconnect from the voter set
+  and with the condition that there has been no change to the voter set at
+  the time of the disconnect, the node must continue performing the GRANDPA
+  protocol at the same state as before getting disconnected from the network,
+  ignoring any possible progress in GRANDPA finalization. Following
+  reconnection, the node eventually gets updated to the current GRANDPA round
+  and synchronizes its state with the rest of the voting set through the
+  process called Catchup, described in Section
+  <reference|sect-grandpa-catchup>.\ 
 
   <subsection|Voting Process in Round <math|r>>
 

--- a/host-spec/c06-consensus.tm
+++ b/host-spec/c06-consensus.tm
@@ -1097,9 +1097,9 @@
   <\definition>
     <label|defn-grandpa-justification>The <strong|justification> for block B
     in round <math|r>, <math|<with|font-series|bold|J<rsup|r,stage><around*|(|B|)>>>
-    <glossary-explain|<math|J<rsup|r,stage><around*|(|B|)>>|The justification for pre-commiting or comming to block
-    <math|B> in round <math|r> of finality protocol|>, is a vector of pairs of
-    the type:
+    <glossary-explain|<math|J<rsup|r,stage><around*|(|B|)>>|The justification
+    for pre-commiting or comming to block <math|B> in round <math|r> of
+    finality protocol|>, is a vector of pairs of the type:
 
     <\equation*>
       <around*|(|V<around*|(|B<rprime|'>|)>,Sign<rsup|r,stage><rsub|v<rsub|i>><around*|(|B<rprime|'>|)>,v<rsub|id>|)>
@@ -1119,13 +1119,13 @@
     In all cases, <math|Sign<rsup|r,stage><rsub|v<rsub|i>><around*|(|B<rprime|'>|)>>
     <glossary-explain|<math|Sign<rsup|r,stage><rsub|v<rsub|i>><around*|(|B|)>>|The
     signature of voter <math|v> on their voteto block B, broadcasted during
-    the specified stage of finality round <math|r>>, as defined in Definition 
+    the specified stage of finality round <math|r>>, as defined in Definition
     <reference|defn-sign-round-vote>, is the signature of voter
     <math|v<rsub|i>\<in\>\<bbb-V\><rsub|B>> broadcasted during either the
-    pre-vote (stage = pv) or the pre-commit (stage = pc)
-    sub-round of round r. A <strong|valid justification> must only contain
-    up-to-one valid vote from each voter and must not contain more than two
-    equivocatory votes from each voter.
+    pre-vote (stage = pv) or the pre-commit (stage = pc) sub-round of round
+    r. A <strong|valid justification> must only contain up-to-one valid vote
+    from each voter and must not contain more than two equivocatory votes
+    from each voter.
   </definition>
 
   <\definition>
@@ -1313,6 +1313,10 @@
       </state>
 
       <\state>
+        <name|Last-Completed-Round><math|\<leftarrow\>0>
+      </state>
+
+      <\state>
         <\IF>
           <math|r<rsub|last>=0>
         </IF>
@@ -1428,6 +1432,10 @@
         completable <strong|and> <name|Finalizable>(<math|r-1>)
 
         <space|2em><strong|and> \ <name|Last-Finalized-Block><math|\<geqslant\>><name|Best-Final-Candidate>(<math|r>-1))
+      </state>
+
+      <\state>
+        <name|Last-Completed-Round><math|\<leftarrow\>r>
       </state>
 
       <\state>
@@ -1926,8 +1934,9 @@
 
     <item><math|\<bbb-P\>> is the set of immediate peers of node <math|v>.
 
-    <item><name|Last-Completed-Round> is <todo|define:
-    https://github.com/w3f/polkadot-spec/issues/161>
+    <item><name|Last-Completed-Round> is initiated in Algorithm
+    <reference|algo-initiate-grandpa> and gets updated in Algorithm
+    <reference|algo-grandpa-round> respectively.
 
     <item><math|M<rsub|v,i><rsup|Cat-s><around*|(|id<rsub|\<bbb-V\>>,r|)>> is
     the catch-up response defined in Definition


### PR DESCRIPTION
 is defined in algo-initiate-grandpa, updated in algo-grandpa-round and clarified in process-catchup. needs review and closes #161 again!