### PR TITLE
host-spec: add html release

### DIFF
--- a/.github/workflows/gh-pages.deb.yml
+++ b/.github/workflows/gh-pages.deb.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published]
 
+concurrency: gh-pages
+
 jobs:
   pages:
     name: deb-release-pages

--- a/.github/workflows/gh-pages.deb.yml
+++ b/.github/workflows/gh-pages.deb.yml
@@ -14,26 +14,26 @@ jobs:
     - uses: actions/checkout@v2
       with:
         ref: gh-pages
-    - name: Wait for host spec
+    - name: Wait for host spec pdf
       uses: lewagon/wait-on-check-action@v1.1.1
       with:
         ref: ${{ github.sha }}
-        check-name: deb-build-spec-host
+        check-name: deb-build-spec-host-pdf
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Download host spec
+    - name: Download host spec pdf
       uses: marcofaggian/action-download-multiple-artifacts@v3.0.8
       with:
         names: polkadot-host-spec.pdf
         workflow: deb-spec-host
         commit: ${{ github.sha }}
         event: ${{ github.event_name }}
-    - name: Wait for runtime spec
+    - name: Wait for runtime spec pdf
       uses: lewagon/wait-on-check-action@v1.1.1
       with:
         ref: ${{ github.sha }}
         check-name: deb-build-spec-runtime
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Download runtime spec
+    - name: Download runtime spec pdf
       uses: marcofaggian/action-download-multiple-artifacts@v3.0.8
       with:
         names: polkadot-runtime-spec.pdf

--- a/.github/workflows/host-spec.deb.yml
+++ b/.github/workflows/host-spec.deb.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    name: deb-build-spec-${{ matrix.format }}
+    name: deb-build-spec-host-${{ matrix.format }}
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/host-spec.deb.yml
+++ b/.github/workflows/host-spec.deb.yml
@@ -34,9 +34,10 @@ jobs:
         sudo apt-key add .github/apt-texmacs.asc
         sudo add-apt-repository "deb http://ftp.texmacs.org/TeXmacs/tmftp/repos/apt/ focal universe"
     - name: Install deb dependencies
-      uses: awalsh128/cache-apt-pkgs-action@v1
+      uses: FlorianFranzen/cache-apt-pkgs-action@v1.1
       with:
         packages: xvfb texmacs plantuml
+        version: "v1.1"
     - name: Install TeXmacs packages
       run: |
         mkdir -p ~/.TeXmacs/packages

--- a/.github/workflows/host-spec.deb.yml
+++ b/.github/workflows/host-spec.deb.yml
@@ -22,9 +22,10 @@ jobs:
       run: |
         sudo apt-key add .github/apt-texmacs.asc
         sudo add-apt-repository "deb http://ftp.texmacs.org/TeXmacs/tmftp/repos/apt/ focal universe"
-        sudo apt-get update
-        sudo apt-get install -y xvfb texmacs plantuml
-    - name: Install TeXmacs pacakges
+    - uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: xvfb texmacs plantuml
+    - name: Install TeXmacs packages
       run: |
         mkdir -p ~/.TeXmacs/packages
         cd ~/.TeXmacs/packages
@@ -63,9 +64,10 @@ jobs:
       run: |
         sudo apt-key add .github/apt-texmacs.asc
         sudo add-apt-repository "deb http://ftp.texmacs.org/TeXmacs/tmftp/repos/apt/ focal universe"
-        sudo apt-get update
-        sudo apt-get install -y xvfb texmacs plantuml
-    - name: Install TeXmacs pacakges
+    - uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: xvfb texmacs plantuml
+    - name: Install TeXmacs packages
       run: |
         mkdir -p ~/.TeXmacs/packages
         cd ~/.TeXmacs/packages

--- a/.github/workflows/host-spec.deb.yml
+++ b/.github/workflows/host-spec.deb.yml
@@ -29,15 +29,12 @@ jobs:
           mime: application/xml
     steps:
     - uses: actions/checkout@v2
-    - name: Setup additional apt repos
+    - name: Install dependencies
       run: |
         sudo apt-key add .github/apt-texmacs.asc
         sudo add-apt-repository "deb http://ftp.texmacs.org/TeXmacs/tmftp/repos/apt/ focal universe"
-    - name: Install deb dependencies
-      uses: FlorianFranzen/cache-apt-pkgs-action@v1.1
-      with:
-        packages: xvfb texmacs plantuml
-        version: "v1.1"
+        sudo apt-get update
+        sudo apt-get install -y xvfb texmacs plantuml
     - name: Install TeXmacs packages
       run: |
         mkdir -p ~/.TeXmacs/packages
@@ -77,9 +74,8 @@ jobs:
       run: |
         sudo apt-key add .github/apt-texmacs.asc
         sudo add-apt-repository "deb http://ftp.texmacs.org/TeXmacs/tmftp/repos/apt/ focal universe"
-    - uses: awalsh128/cache-apt-pkgs-action@v1
-      with:
-        packages: xvfb texmacs plantuml
+        sudo apt-get update
+        sudo apt-get install -y xvfb texmacs plantuml
     - name: Install TeXmacs packages
       run: |
         mkdir -p ~/.TeXmacs/packages

--- a/.github/workflows/host-spec.deb.yml
+++ b/.github/workflows/host-spec.deb.yml
@@ -14,15 +14,27 @@ on:
 
 jobs:
   build:
-    name: deb-build-spec-host
+    name: deb-build-spec-${{ matrix.format }}
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+        - format: html.tar.gz
+          mime: application/gzip
+        - format: pdf
+          mime: application/pdf
+        - format: tex
+          mime: application/x-latex
+        - format: tmml
+          mime: application/xml
     steps:
     - uses: actions/checkout@v2
-    - name: Install dependencies
+    - name: Setup additional apt repos
       run: |
         sudo apt-key add .github/apt-texmacs.asc
         sudo add-apt-repository "deb http://ftp.texmacs.org/TeXmacs/tmftp/repos/apt/ focal universe"
-    - uses: awalsh128/cache-apt-pkgs-action@v1
+    - name: Install deb dependencies
+      uses: awalsh128/cache-apt-pkgs-action@v1
       with:
         packages: xvfb texmacs plantuml
     - name: Install TeXmacs packages
@@ -30,22 +42,22 @@ jobs:
         mkdir -p ~/.TeXmacs/packages
         cd ~/.TeXmacs/packages
         curl -OL https://raw.githubusercontent.com/w3f/algorithmacs/master/algorithmacs-style.ts
-    - name: Build host specification
-      run: make -C host-spec
-    - name: Upload host specification
+    - name: Build ${{ matrix.format }} host specification
+      run: make -C host-spec ${{ matrix.format }}
+    - name: Upload ${{ matrix.format }} host specification
       uses: actions/upload-artifact@v2
       with:
-        name: polkadot-host-spec.pdf
-        path: host-spec/polkadot-host-spec.pdf
+        name: polkadot-host-spec.${{ matrix.format }}
+        path: host-spec/polkadot-host-spec.${{ matrix.format }}
     - name: Release host specification
       uses: actions/upload-release-asset@v1
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: host-spec/polkadot-host-spec.pdf
-        asset_name: polkadot-host-spec_${{ github.event.release.tag_name }}.pdf
-        asset_content_type: application/pdf
+        asset_path: host-spec/polkadot-host-spec.${{ matrix.format }}
+        asset_name: polkadot-host-spec_${{ github.event.release.tag_name }}.${{ matrix.format }}
+        asset_content_type: ${{ matrix.mime }}
       if: github.event_name == 'release'
 
   diff:

--- a/.github/workflows/host-spec.nix.yml
+++ b/.github/workflows/host-spec.nix.yml
@@ -11,7 +11,10 @@ on:
 
 jobs:
   build:
-    name: nix-build-spec-host
+    strategy:
+      matrix:
+        format: [ "html-tar-gz", "pdf", "tex", "tmml" ]
+    name: nix-build-spec-host-${{ matrix.format }}
     runs-on: ubuntu-20.04
     steps:
     - uses: cachix/install-nix-action@v15
@@ -20,5 +23,4 @@ jobs:
         name: polkadot-spec
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - name: Build runtime specification
-      run: nix build github:${{ github.repository }}/${{ github.sha }}#host-spec
-
+      run: nix build github:${{ github.repository }}/${{ github.sha }}#host-spec-${{ matrix.format }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 [![License](https://img.shields.io/github/license/w3f/polkadot-spec.svg)](https://github.com/w3f/polkadot-spec/blob/main/LICENSE)
 [![Latest Release](https://img.shields.io/github/release/w3f/polkadot-spec.svg)](https://github.com/w3f/polkadot-spec/releases/latest)
-[![Continues Integration](https://github.com/w3f/polkadot-spec/workflows/Specification%20Publication/badge.svg)](https://github.com/w3f/polkadot-spec/actions?query=workflow%3A%22Specification+Publication%22)
+[![Host Spec (Ubuntu)](https://github.com/w3f/polkadot-spec/actions/workflows/host-spec.deb.yml/badge.svg)](https://github.com/w3f/polkadot-spec/actions/workflows/host-spec.deb.yml)
+[![Runtime Spec (Ubuntu)](https://github.com/w3f/polkadot-spec/actions/workflows/runtime-spec.deb.yml/badge.svg)](https://github.com/w3f/polkadot-spec/actions/workflows/runtime-spec.deb.yml)
+
+[![Cachix Cache](https://img.shields.io/badge/cachix-w3fpkgs-blue.svg)](https://w3fpkgs.cachix.org)
+[![Host Spec (Flake)](https://github.com/w3f/polkadot-spec/actions/workflows/host-spec.nix.yml/badge.svg)](https://github.com/w3f/polkadot-spec/actions/workflows/host-spec.nix.yml)
+[![Runtime Spec (Flake)](https://github.com/w3f/polkadot-spec/actions/workflows/runtime-spec.nix.yml/badge.svg)](https://github.com/w3f/polkadot-spec/actions/workflows/runtime-spec.nix.yml)
 
 Polkadot is a replicated sharded state machine designed to resolve the scalability and interoperability among blockchains. This repository serves as the point of reference for Polkadot Protocol. In this repo you will find:
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,12 @@
 {
   description = "Polkadot Protocol Specification";
 
+  nixConfig = {
+    extra-experimental-features = "nix-command flakes";
+    extra-substituters = "https://polkadot-spec.cachix.org";
+    extra-trusted-public-keys = "polkadot-spec.cachix.org-1:tQiTEmNIdQ+aEV0zrfdrCn8bQZo/spEMAFGH8YEidQU=";
+  };
+
   inputs = {
     # Nix base libraries
     utils.url = "github:numtide/flake-utils";

--- a/flake.nix
+++ b/flake.nix
@@ -22,14 +22,15 @@
 
         algorithmacs = pkgs.callPackage ./.nix/algorithmacs.nix {};
 
+        host-spec-pkgs = pkgs.callPackage ./.nix/host-spec.nix { inherit src version algorithmacs; };
+
         texlive-spec = pkgs.callPackage ./.nix/texlive.nix {
           extraTexPackages = {
             inherit (pkgs.texlive) latexmk algorithms algorithmicx luacode;
           };
         };
       in {
-        packages = {
-          host-spec    = pkgs.callPackage ./.nix/host-spec.nix { inherit src version algorithmacs; };
+        packages = host-spec-pkgs // {
           runtime-spec = pkgs.callPackage ./.nix/runtime-spec.nix { inherit src version texlive-spec; };
         };
 

--- a/host-spec/Makefile
+++ b/host-spec/Makefile
@@ -9,7 +9,7 @@ GENERATED  := figures/c07-overview.eps
 SOURCES    := host-spec.tm $(CHAPTERS) $(APPENDICES) $(FIGURES) $(GENERATED)
 
 
-.PHONY: build pdf tex diff temp update deaux clean
+.PHONY: build pdf tex html html.tar.gz diff temp update deaux clean
 
 build: pdf
 
@@ -18,9 +18,11 @@ pdf: polkadot-host-spec.pdf
 
 tex: polkadot-host-spec.tex
 
-diff: polkadot-host-spec.diff.pdf
-
 html: html/index.html
+
+html.tar.gz: polkadot-host-spec.html.tar.gz
+
+diff: polkadot-host-spec.diff.pdf
 
 temp: $(GENERATED)
 
@@ -35,6 +37,9 @@ polkadot-host-spec.pdf: $(SOURCES) host-spec.scm
 polkadot-host-spec.tex: $(SOURCES) host-spec.scm
 	xvfb-run texmacs -b host-spec.scm -x "(convert-expanded \"$$PWD/$<\" \"$$PWD/$@\")" --quit
 
+
+polkadot-host-spec.html.tar.gz: html/index.html
+	tar -cvf $@ html/
 
 html/index.html: $(SOURCES) host-spec.scm
 	mkdir -p html

--- a/host-spec/Makefile
+++ b/host-spec/Makefile
@@ -20,6 +20,8 @@ tex: polkadot-host-spec.tex
 
 diff: polkadot-host-spec.diff.pdf
 
+html: html/index.html
+
 temp: $(GENERATED)
 
 
@@ -32,6 +34,11 @@ polkadot-host-spec.pdf: $(SOURCES) host-spec.scm
 
 polkadot-host-spec.tex: $(SOURCES) host-spec.scm
 	xvfb-run texmacs -b host-spec.scm -x "(convert-expanded \"$$PWD/$<\" \"$$PWD/$@\")" --quit
+
+
+html/index.html: $(SOURCES) host-spec.scm
+	mkdir -p html
+	xvfb-run texmacs -b host-spec.scm -x "(convert-updated-expanded \"$$PWD/$<\" \"$$PWD/$@\" \"$(TMPDIR)\")" --quit
 
 
 REV     ?= HEAD
@@ -67,5 +74,5 @@ deaux:
 
 
 clean:
-	rm -rf $(REVDIR) $(GENERATED) polkadot-host-spec.pdf polkadot-host-spec.tex polkadot-host-spec.diff.pdf
+	rm -rf $(REVDIR) $(GENERATED) html polkadot-host-spec.pdf polkadot-host-spec.tex polkadot-host-spec.diff.pdf
 

--- a/host-spec/Makefile
+++ b/host-spec/Makefile
@@ -37,7 +37,7 @@ polkadot-host-spec.pdf: $(SOURCES) host-spec.scm
 	xvfb-run texmacs -b host-spec.scm -x "(convert-updated \"$$PWD/$<\" \"$$PWD/$@\")" --quit
 
 polkadot-host-spec.tex: $(SOURCES) host-spec.scm
-	xvfb-run texmacs -b host-spec.scm -x "(convert-expanded \"$$PWD/$<\" \"$$PWD/$@\")" --quit
+	xvfb-run texmacs -b host-spec.scm -x "(convert-updated-expanded \"$$PWD/$<\" \"$$PWD/$@\" \"$(TMPDIR)\")" --quit
 
 
 polkadot-host-spec.html.tar.gz: html/index.html

--- a/host-spec/Makefile
+++ b/host-spec/Makefile
@@ -22,6 +22,8 @@ html: html/index.html
 
 html.tar.gz: polkadot-host-spec.html.tar.gz
 
+tmml: polkadot-host-spec.tmml
+
 diff: polkadot-host-spec.diff.pdf
 
 temp: $(GENERATED)
@@ -43,6 +45,10 @@ polkadot-host-spec.html.tar.gz: html/index.html
 
 html/index.html: $(SOURCES) host-spec.scm
 	mkdir -p html
+	xvfb-run texmacs -b host-spec.scm -x "(convert-updated-expanded \"$$PWD/$<\" \"$$PWD/$@\" \"$(TMPDIR)\")" --quit
+
+
+polkadot-host-spec.tmml: $(SOURCES) host-spec.scm
 	xvfb-run texmacs -b host-spec.scm -x "(convert-updated-expanded \"$$PWD/$<\" \"$$PWD/$@\" \"$(TMPDIR)\")" --quit
 
 
@@ -79,5 +85,5 @@ deaux:
 
 
 clean:
-	rm -rf $(REVDIR) $(GENERATED) html polkadot-host-spec.pdf polkadot-host-spec.tex polkadot-host-spec.diff.pdf
+	rm -rf $(REVDIR) $(GENERATED) html polkadot-host-spec.html.tar.gz polkadot-host-spec.pdf polkadot-host-spec.tex polkadot-host-spec.tmml polkadot-host-spec.diff.pdf
 

--- a/host-spec/Makefile
+++ b/host-spec/Makefile
@@ -61,7 +61,7 @@ REVDIR := $(TMPDIR)/host-spec-$(GITHASH)
 $(REVDIR):
 	mkdir -p $@
 	git archive --format=tar $(GITHASH) | (cd $@ && tar xf -)
-	# Will require next release: make -C $(REVDIR) temp
+	make -C $(REVDIR) temp || true
 
 polkadot-host-spec.diff.pdf: $(SOURCES) $(REVDIR) host-spec.scm
 	xvfb-run texmacs -b host-spec.scm  -x "(compare-versions-updated-expanded \"$(REVDIR)/host-spec.tm\" \"$$PWD/host-spec.tm\" \"$(TMPDIR)\") (export-buffer \"$$PWD/$@\")" -q

--- a/host-spec/Makefile
+++ b/host-spec/Makefile
@@ -53,7 +53,7 @@ polkadot-host-spec.tmml: $(SOURCES) host-spec.scm
 
 
 REV     ?= HEAD
-GITHASH := $(shell git rev-parse $(REV))
+GITHASH := $(shell git rev-parse $(REV) 2> /dev/null)
 
 TMPDIR ?= /tmp
 REVDIR := $(TMPDIR)/host-spec-$(GITHASH)

--- a/host-spec/host-spec.scm
+++ b/host-spec/host-spec.scm
@@ -9,6 +9,14 @@
   (buffer-export (current-buffer) (string-append tmpdir "/load-updated.export.tmp") "pdf")
   (generate-all-aux) (inclusions-gc) (update-current-buffer))
 
+;; This function updates/rebuilds the toc, bibliography, index and glossar
+;; of the document specified and save the result in place. Requires a tempdir
+;; to which it triggers a export.
+(tm-define (update-all input tmpdir)
+  (load-updated input tmpdir)
+  (buffer-save (current-buffer)))
+
+
 ;; This is a custom compare function with the major difference
 ;; being that it updates all indices before the comparision
 ;; and also highlights differences in included files.
@@ -26,6 +34,7 @@
            (rt (stree->tree mv)))
       (tree-set (buffer-tree) rt))))
 
+
 ;; This is a custom convert function that expands all includes
 ;; before conversion.
 (tm-define (convert-expanded input output)
@@ -41,9 +50,9 @@
   (generate-all-aux) (inclusions-gc) (update-current-buffer)
   (export-buffer output))
 
-;; This function updates/rebuilds the toc, bibliography, index and glossar
-;; of the document specified and save the result in place. Requires a tempdir
-;; to which it triggers a export.
-(tm-define (update-all input tmpdir)
+;; This is a custom convert function that expands all includes and  updates 
+;; the toc, bibliography, index and glossar before conversion.
+(tm-define (convert-updated-expanded input output tmpdir)
   (load-updated input tmpdir)
-  (buffer-save (current-buffer)))
+  (buffer-expand-includes)
+  (export-buffer output))


### PR DESCRIPTION
This PR add HTML to the list of the supported export formats of the host-spec.

It currently lack CI support, I will add that in the next few days.