### PR TITLE
Spec version 2 of ECDSA functions

### DIFF
--- a/ab_host-api/child_storage.adoc
+++ b/ab_host-api/child_storage.adoc
@@ -99,7 +99,50 @@ Clears an entire child storage.
 Arguments::
 
 * `child_storage_key`: a pointer-size (<<defn-runtime-pointer>>) indicating the
-child storage key (<<defn-child-storage-type>>)..
+child storage key (<<defn-child-storage-type>>).
+
+===== Version 2 - Prototype
+
+----
+(func $ext_default_child_storage_storage_kill_version_2
+	(param $child_storage_key i64) (param $limit i64)
+	(return i32))
+----
+
+Arguments::
+
+* `child_storage_key`: a pointer-size (<<defn-runtime-pointer>>) indicating the
+child storage key (<<defn-child-storage-type>>).
+* `limit`: a pointer-size (<<defn-runtime-pointer>>) to an _Option_ type
+(<<defn-option-type>>) containing an unsigned 32-bit integer indicating the
+limit on how many keys should be deleted. No limit is applied if this is _None_.
+* `return`: a value equal to _1_ if all the keys of the child storage have been
+deleted or a value equal to _0_ if there are remaining keys.
+
+===== Version 3 - Prototype
+----
+(func $ext_default_child_storage_storage_kill_version_3
+	(param $child_storage_key i64) (param $limit i64)
+	(return i64))
+----
+
+Arguments::
+
+* `child_storage_key`: a pointer-size (<<defn-runtime-pointer>>) indicating the
+child storage key (<<defn-child-storage-type>>).
+* `limit`: a pointer-size (<<defn-runtime-pointer>>) to an _Option_ type
+(<<defn-option-type>>) containing an unsigned 32-bit integer indicating the
+limit on how many keys should be deleted. No limit is applied if this is _None_.
+* `return`: a pointer-size (<<defn-runtime-pointer>>) to the following variant, stem:[k]:
++
+[stem]
+++++
+k = {(0,-> c),(1,-> c):}
+++++
++
+where _0_ indicates that all keys of the child storage have been removed,
+followed by the number of removed keys, stem:[c]. The variant _1_ indicates that
+there are remaining keys, followed by the number of removed keys.
 
 ==== `ext_default_child_storage_exists`
 

--- a/ab_host-api/child_storage.adoc
+++ b/ab_host-api/child_storage.adoc
@@ -184,6 +184,35 @@ child storage key (<<defn-child-storage-type>>).
 * `prefix`: a pointer-size (<<defn-runtime-pointer>>) indicating the
 prefix.
 
+===== Version 2 - Prototype
+----
+(func $ext_default_child_storage_clear_prefix_version_2
+	(param $child_storage_key i64) (param $prefix i64)
+	(param $limit i64) (return i64))
+----
+
+Arguments::
+
+* `child_storage_key`: a pointer-size (<<defn-runtime-pointer>>) indicating the
+child storage key (<<defn-child-storage-type>>).
+* `prefix`: a pointer-size (<<defn-runtime-pointer>>) indicating the
+prefix.
+* `limit`: a pointer-size (<<defn-runtime-pointer>>) to an _Option_ type
+(<<defn-option-type>>) containing an unsigned 32-bit integer indicating the
+limit on how many keys should be deleted. No limit is applied if this is _None_.
+Any keys created during the current block execution do not count towards the
+limit.
+* `return`: a pointer-size (<<defn-runtime-pointer>>) to the following variant, stem:[k]:
++
+[stem]
+++++
+k = {(0,-> c),(1,-> c):}
+++++
++
+where _0_ indicates that all keys of the child storage have been removed,
+followed by the number of removed keys, stem:[c]. The variant _1_ indicates that
+there are remaining keys, followed by the number of removed keys.
+
 ==== `ext_default_child_storage_root`
 
 Commits all existing operations and computes the resulting child storage

--- a/ab_host-api/child_storage.adoc
+++ b/ab_host-api/child_storage.adoc
@@ -116,6 +116,8 @@ child storage key (<<defn-child-storage-type>>).
 * `limit`: a pointer-size (<<defn-runtime-pointer>>) to an _Option_ type
 (<<defn-option-type>>) containing an unsigned 32-bit integer indicating the
 limit on how many keys should be deleted. No limit is applied if this is _None_.
+Any keys created during the current block execution do not count towards the
+limit.
 * `return`: a value equal to _1_ if all the keys of the child storage have been
 deleted or a value equal to _0_ if there are remaining keys.
 
@@ -133,6 +135,8 @@ child storage key (<<defn-child-storage-type>>).
 * `limit`: a pointer-size (<<defn-runtime-pointer>>) to an _Option_ type
 (<<defn-option-type>>) containing an unsigned 32-bit integer indicating the
 limit on how many keys should be deleted. No limit is applied if this is _None_.
+Any keys created during the current block execution do not count towards the
+limit.
 * `return`: a pointer-size (<<defn-runtime-pointer>>) to the following variant, stem:[k]:
 +
 [stem]

--- a/ab_host-api/crypto.adoc
+++ b/ab_host-api/crypto.adoc
@@ -125,6 +125,7 @@ message that is to be verified.
 * `return`: a i32 integer value equal to _1_ if the signature is valid or a
 value equal to _0_ if otherwise.
 
+[#sect-ext-crypto-ed25519-batch-verify]
 ==== `ext_crypto_ed25519_batch_verify`
 
 Registers a ed25519 signature for batch verification. Batch verification is
@@ -244,6 +245,7 @@ message that is to be verified.
 * `return`: a i32 integer value equal to _1_ if the signature is valid or a
 value equal to _0_ if otherwise.
 
+[#sect-ext-crypto-sr25519-batch-verify]
 ==== `ext_crypto_sr25519_batch_verify`
 
 Registers a sr25519 signature for batch verification. Batch verification is
@@ -383,6 +385,7 @@ key.
 * `return`: a i32 integer value equal _1_ to if the signature is valid or a
 value equal to _0_ if otherwise.
 
+[#sect-ext-crypto-ecdsa-batch-verify]
 ==== `ext_crypto_ecdsa_batch_verify`
 
 Registers a ECDSA signature for batch verification. Batch verification is
@@ -508,11 +511,13 @@ encoded `Result` value (<<defn-result-type>>). On success it contains the
 
 Starts the verification extension. The extension is a separate background
 process and is used to parallel-verify signatures which are pushed to the batch
-with `ext_crypto_ed25519_verify` (<<sect-ext-crypto-ed25519-verify>>),
-`ext_crypto_sr25519_verify` (<<sect-ext-crypto-sr25519-verify>>) or
-`ext_crypto_ecdsa_verify` (<<sect-ext-crypto-ecdsa-verify>>). Verification will
-start immediately and the Runtime can retrieve the result when calling
-`ext_crypto_finish_batch_verify` (<<sect-ext-crypto-finish-batch-verify>>).
+with
+`ext_crypto_ed25519_batch_verify`(<<sect-ext-crypto-ed25519-batch-verify>>),
+`ext_crypto_sr25519_batch_verify` (<<sect-ext-crypto-sr25519-batch-verify>>) or
+`ext_crypto_ecdsa_batch_verify` (<<sect-ext-crypto-ecdsa-batch-verify>>).
+Verification will start immediately and the Runtime can retrieve the result when
+calling `ext_crypto_finish_batch_verify`
+(<<sect-ext-crypto-finish-batch-verify>>).
 
 ===== Version 1 - Prototype
 ----

--- a/ab_host-api/crypto.adoc
+++ b/ab_host-api/crypto.adoc
@@ -334,15 +334,7 @@ public key cannot be found in the key store.
 [#sect-ext-crypto-ecdsa-verify]
 ==== `ext_crypto_ecdsa_verify`
 
-Verifies an _ecdsa_ signature. Returns when the verification is either
-successful or batched. If no batching verification extension is registered, this
-function will fully verify the signature and return the result. If batching
-verification is registered, this function will push the data to the batch and
-return immediately. The caller can then get the result by calling
-`ext_crypto_finish_batch_verify` (<<sect-ext-crypto-finish-batch-verify>>).
-
-The verification extension is explained more in detail in
-<<sect-ext-crypto-start-batch-verify>>.
+Verifies an ECDSA signature.
 
 ===== Version 1 - Prototype
 
@@ -390,6 +382,30 @@ message that is to be verified.
 key.
 * `return`: a i32 integer value equal _1_ to if the signature is valid or a
 value equal to _0_ if otherwise.
+
+==== `ext_crypto_ecdsa_batch_verify`
+
+Registers a ECDSA signature for batch verification. Batch verification is
+enabled by calling `ext_crypto_start_batch_verify`
+(<<sect-ext-crypto-start-batch-verify>>). The result of the verification is
+returned by `ext_crypto_finish_batch_verify`
+(<<sect-ext-crypto-finish-batch-verify>>). If batch verification is not enabled,
+the signature is verified immediately.
+
+===== Version 1
+----
+(func $ext_crypto_ecdsa_batch_verify_version_1
+	(param $sig i32) (param $msg i64) (param $key i32) (return i32))
+----
+
+Arguments::
+
+* `sig`: a 32-bit pointer to the buffer containing the 64-byte signature.
+* `msg`: a pointer-size (<<defn-runtime-pointer>>) indicating the
+message that is to be verified.
+* `key`: a 32-bit pointer to the buffer containing the 256-bit public key.
+* `return`: a i32 integer value equal to _1_ if the signature is valid or
+batched or a value equal _0_ to if otherwise.
 
 ==== `ext_crypto_secp256k1_ecdsa_recover`
 

--- a/ab_host-api/crypto.adoc
+++ b/ab_host-api/crypto.adoc
@@ -212,19 +212,7 @@ This function returns _None_ if the public key cannot be found in the key store.
 [#sect-ext-crypto-sr25519-verify]
 ==== `ext_crypto_sr25519_verify`
 
-Verifies an _sr25519_ signature. Only version 1 of this function supports
-deprecated Schnorr signatures introduced by the _schnorrkel_ Rust library
-version 0.1.1 and should only be used for backward compatibility.
-
-Returns when the verification is either successful or batched. If no batching
-verification extension is registered, this function will fully verify the
-signature and return the result. If batching verification is registered, this
-function will push the data to the batch and return immediately. The caller can
-then get the result by calling `ext_crypto_finish_batch_verify`
-(<<sect-ext-crypto-finish-batch-verify>>).
-
-The verification extension is explained more in detail in
-<<sect-ext-crypto-start-batch-verify>>.
+Verifies an sr25519 signature.
 
 ===== Version 1 - Prototype
 ----
@@ -255,6 +243,30 @@ message that is to be verified.
 * `key`: a 32-bit pointer to the buffer containing the 256-bit public key.
 * `return`: a i32 integer value equal to _1_ if the signature is valid or a
 value equal to _0_ if otherwise.
+
+==== `ext_crypto_sr25519_batch_verify`
+
+Registers a sr25519 signature for batch verification. Batch verification is
+enabled by calling `ext_crypto_start_batch_verify`
+(<<sect-ext-crypto-start-batch-verify>>). The result of the verification is
+returned by `ext_crypto_finish_batch_verify`
+(<<sect-ext-crypto-finish-batch-verify>>). If batch verification is not enabled,
+the signature is verified immediately.
+
+===== Version 1
+----
+(func $ext_crypto_sr25519_batch_verify_version_1
+	(param $sig i32) (param $msg i64) (param $key i32) (return i32))
+----
+
+Arguments::
+
+* `sig`: a 32-bit pointer to the buffer containing the 64-byte signature.
+* `msg`: a pointer-size (<<defn-runtime-pointer>>) indicating the
+message that is to be verified.
+* `key`: a 32-bit pointer to the buffer containing the 256-bit public key.
+* `return`: a i32 integer value equal to _1_ if the signature is valid or
+batched or a value equal _0_ to if otherwise.
 
 ==== `ext_crypto_ecdsa_public_keys`
 

--- a/ab_host-api/crypto.adoc
+++ b/ab_host-api/crypto.adoc
@@ -211,9 +211,9 @@ then get the result by calling `ext_crypto_finish_batch_verify`
 The verification extension is explained more in detail in
 <<sect-ext-crypto-start-batch-verify>>.
 
-===== Version 2 - Prototype
+===== Version 1 - Prototype
 ----
-(func $ext_crypto_sr25519_verify_version_2
+(func $ext_crypto_sr25519_verify_version_1
 	(param $sig i32) (param $msg i64) (param $key i32) (return i32))
 ----
 
@@ -226,9 +226,9 @@ message that is to be verified.
 * `return`: a i32 integer value equal to _1_ if the signature is valid or a
 value equal to _0_ if otherwise.
 
-===== Version 1 - Prototype
+===== Version 2 - Prototype
 ----
-(func $ext_crypto_sr25519_verify_version_1
+(func $ext_crypto_sr25519_verify_version_2
 	(param $sig i32) (param $msg i64) (param $key i32) (return i32))
 ----
 
@@ -247,7 +247,7 @@ Returns all _ecdsa_ public keys for the given key id from the keystore.
 
 ===== Version 1 - Prototype
 ----
-(func $ext_crypto_ecdsa_verify_version_1
+(func $ext_crypto_ecdsa_public_key_version_1
 	(param $key_type_id i64) (return i64))
 ----
 
@@ -318,8 +318,37 @@ The verification extension is explained more in detail in
 <<sect-ext-crypto-start-batch-verify>>.
 
 ===== Version 1 - Prototype
+
+This function allows the verification of overflowing ECDSA signatures, an
+implemenation specific mechanism of the Rust
+https://github.com/paritytech/libsecp256k1[`libsecp256k1` library], specifically
+the
+https://docs.rs/libsecp256k1/0.7.0/libsecp256k1/struct.Signature.html#method.parse_overflowing[`parse_overflowing`]
+function.
+
 ----
 (func $ext_crypto_ecdsa_verify_version_1
+	(param $sig i32) (param $msg i64) (param $key i32) (return i32))
+----
+
+Arguments::
+
+* `sig`: a 32-bit pointer to the buffer containing the 65-byte signature. The
+signature is 65-bytes in size, where the first 512-bits represent the signature
+and the other 8 bits represent the recovery ID.
+* `msg`: a pointer-size (<<defn-runtime-pointer>>) indicating the
+message that is to be verified.
+* `key`: a 32-bit pointer to the buffer containing the 33-byte compressed public
+key.
+* `return`: a i32 integer value equal _1_ to if the signature is valid or a
+value equal to _0_ if otherwise.
+
+===== Version 2 - Prototype
+
+Does not allow the verification of overflowing ECDSA signatures.
+
+----
+(func $ext_crypto_ecdsa_verify_version_2
 	(param $sig i32) (param $msg i64) (param $key i32) (return i32))
 ----
 

--- a/ab_host-api/crypto.adoc
+++ b/ab_host-api/crypto.adoc
@@ -369,8 +369,35 @@ value equal to _0_ if otherwise.
 Verify and recover a _secp256k1_ ECDSA signature.
 
 ===== Version 1 - Prototype
+
+This function can handle overflowing ECDSA signatures, an
+implemenation specific mechanism of the Rust
+https://github.com/paritytech/libsecp256k1[`libsecp256k1` library], specifically
+the
+https://docs.rs/libsecp256k1/0.7.0/libsecp256k1/struct.Signature.html#method.parse_overflowing[`parse_overflowing`]
+function.
+
 ----
 (func $ext_crypto_secp256k1_ecdsa_recover_version_1
+	(param $sig i32) (param $msg i32) (return i64))
+----
+
+Arguments::
+
+* `sig`: a 32-bit pointer to the buffer containing the 65-byte signature in RSV
+format. V should be either or .
+* `msg`: a 32-bit pointer to the buffer containing the 256-bit Blake2 hash of
+the message.
+* `return`: a pointer-size (<<defn-runtime-pointer>>) indicating the SCALE
+encoded _Result_ (<<defn-result-type>>). On success it contains the 64-byte
+recovered public key or an error type (<<defn-ecdsa-verify-error>>) on failure.
+
+===== Version 2 - Prototype
+
+Does not handle overflowing ECDSA signatures.
+
+----
+(func $ext_crypto_secp256k1_ecdsa_recover_version_2
 	(param $sig i32) (param $msg i32) (return i64))
 ----
 

--- a/ab_host-api/crypto.adoc
+++ b/ab_host-api/crypto.adoc
@@ -319,7 +319,7 @@ The verification extension is explained more in detail in
 
 ===== Version 1 - Prototype
 
-This function allows the verification of overflowing ECDSA signatures, an
+This function allows the verification of non-standard, overflowing ECDSA signatures, an
 implemenation specific mechanism of the Rust
 https://github.com/paritytech/libsecp256k1[`libsecp256k1` library], specifically
 the
@@ -345,7 +345,7 @@ value equal to _0_ if otherwise.
 
 ===== Version 2 - Prototype
 
-Does not allow the verification of overflowing ECDSA signatures.
+Does not allow the verification of non-standard, overflowing ECDSA signatures.
 
 ----
 (func $ext_crypto_ecdsa_verify_version_2
@@ -370,7 +370,7 @@ Verify and recover a _secp256k1_ ECDSA signature.
 
 ===== Version 1 - Prototype
 
-This function can handle overflowing ECDSA signatures, an
+This function can handle non-standard, overflowing ECDSA signatures, an
 implemenation specific mechanism of the Rust
 https://github.com/paritytech/libsecp256k1[`libsecp256k1` library], specifically
 the
@@ -394,7 +394,7 @@ recovered public key or an error type (<<defn-ecdsa-verify-error>>) on failure.
 
 ===== Version 2 - Prototype
 
-Does not handle overflowing ECDSA signatures.
+Does not handle non-standard, overflowing ECDSA signatures.
 
 ----
 (func $ext_crypto_secp256k1_ecdsa_recover_version_2
@@ -416,8 +416,36 @@ recovered public key or an error type (<<defn-ecdsa-verify-error>>) on failure.
 Verify and recover a _secp256k1_ ECDSA signature.
 
 ===== Version 1 - Prototype
+
+This function can handle non-standard, overflowing ECDSA signatures, an
+implemenation specific mechanism of the Rust
+https://github.com/paritytech/libsecp256k1[`libsecp256k1` library], specifically
+the
+https://docs.rs/libsecp256k1/0.7.0/libsecp256k1/struct.Signature.html#method.parse_overflowing[`parse_overflowing`]
+function.
+
 ----
 (func $ext_crypto_secp256k1_ecdsa_recover_compressed_version_1
+	(param $sig i32) (param $msg i32) (return i64))
+----
+
+Arguments::
+
+* `sig`: a 32-bit pointer to the buffer containing the 65-byte signature in RSV
+format. V should be either `0/1` or `27/28`.
+* `msg`: a 32-bit pointer to the buffer containing the 256-bit Blake2 hash of
+the message.
+* `return`: a pointer-size (<<defn-runtime-pointer>>) indicating the SCALE
+encoded `Result` value (<<defn-result-type>>). On success it contains the
+33-byte recovered public key in compressed form on success or an error type
+(<<defn-ecdsa-verify-error>>) on failure.
+
+===== Version 2 - Prototype
+
+Does not handle non-standard, overflowing ECDSA signatures.
+
+----
+(func $ext_crypto_secp256k1_ecdsa_recover_compressed_version_2
 	(param $sig i32) (param $msg i32) (return i64))
 ----
 

--- a/ab_host-api/crypto.adoc
+++ b/ab_host-api/crypto.adoc
@@ -108,16 +108,7 @@ This function returns if the public key cannot be found in the key store.
 [#sect-ext-crypto-ed25519-verify]
 ==== `ext_crypto_ed25519_verify`
 
-Verifies an _ed25519_ signature. Returns when the verification is either
-successful or batched. If no batching verification extension is registered, this
-function will fully verify the signature and return the result. If batching
-verification is registered, this function will push the data to the batch and
-return immediately. The caller can then get the result by calling
-`ext_crypto_finish_batch_verify`
-(<<sect-ext-crypto-finish-batch-verify>>).
-
-The verification extension is explained more in detail in
-(<<sect-ext-crypto-start-batch-verify>>).
+Verifies an _ed25519_ signature.
 
 ===== Version 1 - Prototype
 ----
@@ -131,8 +122,32 @@ Arguments::
 * `msg`: a pointer-size (<<defn-runtime-pointer>>) indicating the
 message that is to be verified.
 * `key`: a 32-bit pointer to the buffer containing the 256-bit public key.
-* `return`: a i32 integer value equal to if the signature is valid or batched or
-a value equal to if otherwise.
+* `return`: a i32 integer value equal to _1_ if the signature is valid or a
+value equal to _0_ if otherwise.
+
+==== `ext_crypto_ed25519_batch_verify`
+
+Registers a ed25519 signature for batch verification. Batch verification is
+enabled by calling `ext_crypto_start_batch_verify`
+(<<sect-ext-crypto-start-batch-verify>>). The result of the verification is
+returned by `ext_crypto_finish_batch_verify`
+(<<sect-ext-crypto-finish-batch-verify>>). If batch verification is not enabled,
+the signature is verified immediately.
+
+===== Version 1
+----
+(func $ext_crypto_ed25519_batch_verify_version_1
+	(param $sig i32) (param $msg i64) (param $key i32) (return i32))
+----
+
+Arguments::
+
+* `sig`: a 32-bit pointer to the buffer containing the 64-byte signature.
+* `msg`: a pointer-size (<<defn-runtime-pointer>>) indicating the
+message that is to be verified.
+* `key`: a 32-bit pointer to the buffer containing the 256-bit public key.
+* `return`: a i32 integer value equal to _1_ if the signature is valid or
+batched or a value equal _0_ to if otherwise.
 
 ==== `ext_crypto_sr25519_public_keys`
 

--- a/ab_host-api/storage.adoc
+++ b/ab_host-api/storage.adoc
@@ -170,20 +170,19 @@ root.
 [#sect-ext-storage-changes-root]
 ==== `ext_storage_changes_root`
 
-Compute the root of the changes trie (<<sect-changes-trie>>). The parent hash is
-a SCALE encoded block hash.
+NOTE: This function is not longer used and only exists for compatibiltiy reasons.
 
 ===== Version 1 - Prototype
 ----
 (func $ext_storage_changes_root_version_1
-	(param $parent_hash i64) (return i32))
+	(param $parent_hash i64) (return i64))
 ----
 
 Arguments::
 * `parent_hash`: a pointer-size (<<defn-runtime-pointer>>) indicating the
 SCALE encoded block hash.
-* `return`: a 32-bit pointer to the buffer containing the 256-bit Blake2 changes
-root.
+* `return`: a pointer-size (<<defn-runtime-pointer>>) to an _Option_ type
+(<<defn-option-type>>) that's always _None_.
 
 ==== `ext_storage_next_key`
 

--- a/ab_host-api/storage.adoc
+++ b/ab_host-api/storage.adoc
@@ -101,6 +101,32 @@ Arguments::
 * `prefix`: a pointer-size (<<defn-runtime-pointer>>) containing
 the prefix.
 
+===== Version 2 - Prototype
+----
+(func $ext_storage_clear_prefix_version_2
+	(param $prefix i64) (param $limit i64)
+	(return i64))
+----
+
+Arguments::
+* `prefix`: a pointer-size (<<defn-runtime-pointer>>) containing
+the prefix.
+* `limit`: a pointer-size (<<defn-runtime-pointer>>) to an _Option_ type
+(<<defn-option-type>>) containing an unsigned 32-bit integer indicating the
+limit on how many keys should be deleted. No limit is applied if this is _None_.
+Any keys created during the current block execution do not count towards the
+limit.
+* `return`: a pointer-size (<<defn-runtime-pointer>>) to the following variant, stem:[k]:
++
+[stem]
+++++
+k = {(0,-> c),(1,-> c):}
+++++
++
+where _0_ indicates that all keys of the child storage have been removed,
+followed by the number of removed keys, stem:[c]. The variant _1_ indicates that
+there are remaining keys, followed by the number of removed keys.
+
 ==== `ext_storage_append`
 
 Append the SCALE encoded value to a SCALE encoded sequence (<<defn-scale-list>>)


### PR DESCRIPTION
Closes #462. This PR also adds new Host API functions:

* `ext_default_child_storage_storage_kill_version_2`
* `ext_default_child_storage_storage_kill_version_3`
* `ext_default_child_storage_clear_prefix_version_2`
* `ext_crypto_secp256k1_ecdsa_recover_version_2`
* `ext_crypto_secp256k1_ecdsa_recover_compressed_version_2`
* `ext_storage_clear_prefix_version_2`
* deprecate `ext_storage_changes_root_version_1`