### PR TITLE
Add missing host apis

### DIFF
--- a/ab_host-api/child_storage.adoc
+++ b/ab_host-api/child_storage.adoc
@@ -243,16 +243,7 @@ Arguments::
 
 * `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
 child storage key (<<defn-child-storage-type>>).
-* `version`: a pointer (<<defn-runtime-pointer>>) to the state version of the following format:
-+
-[stem]
-++++
-v = {(0, "state version 1"),(1, "node hashes"):}
-++++
-where stem:[0] behaves like version 1
-(<<sect-ext-default-child-storage-root-version-1>>) of this function and
-stem:[1] makes use of "node hashes" when calculating the merkle proof
-(<<defn-node-hashes>>).
+* `version`: a pointer (<<defn-runtime-pointer>>) to the state version (<<defn-state-version>>).
 * `return`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit Blake2 storage
 root.
 

--- a/ab_host-api/child_storage.adoc
+++ b/ab_host-api/child_storage.adoc
@@ -22,10 +22,10 @@ Sets the value under a given key into the child storage.
 
 Arguments::
 
-* `child_storage_key` : a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `child_storage_key` : a pointer-size (<<defn-runtime-pointer-size>>) to the
 child storage key (<<defn-child-storage-type>>).
-* `key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the key.
-* `value`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the value.
+* `key`: a pointer-size (<<defn-runtime-pointer-size>>) to the key.
+* `value`: a pointer-size (<<defn-runtime-pointer-size>>) to the value.
 
 ==== `ext_default_child_storage_get`
 Retrieves the value associated with the given key from the child storage.
@@ -38,10 +38,10 @@ Retrieves the value associated with the given key from the child storage.
 
 Arguments::
 
-* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 child storage key (<<defn-child-storage-type>>).
-* `key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the key. 
-* `result`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `key`: a pointer-size (<<defn-runtime-pointer-size>>) to the key. 
+* `result`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Option_ value (<<defn-option-type>>) containing the value.
 
 ==== `ext_default_child_storage_read`
@@ -58,15 +58,15 @@ the number of bytes that the entry in storage has beyond the offset.
 
 Arguments::
 
-* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 child storage key (<<defn-child-storage-type>>).
-* `key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the key.
-* `value_out`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the buffer
+* `key`: a pointer-size (<<defn-runtime-pointer-size>>) to the key.
+* `value_out`: a pointer-size (<<defn-runtime-pointer-size>>) to the buffer
 to which the value will be written to. This function will never write more then
 the length of the buffer, even if the value’s length is bigger.
 * `offset`: an u32 integer containing the offset beyond the value should be read
 from.
-* `result`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `result`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Option_ value (<<defn-option-type>>) containing the number of bytes
 written into the *value_out* buffer. Returns if the entry does not exists.
 
@@ -82,9 +82,9 @@ Clears the storage of the given key and its value from the child storage.
 
 Arguments::
 
-* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 child storage key (<<defn-child-storage-type>>).
-* `key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the key.
+* `key`: a pointer-size (<<defn-runtime-pointer-size>>) to the key.
 
 ==== `ext_default_child_storage_storage_kill`
 
@@ -98,7 +98,7 @@ Clears an entire child storage.
 
 Arguments::
 
-* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 child storage key (<<defn-child-storage-type>>).
 
 ===== Version 2 - Prototype
@@ -111,7 +111,7 @@ child storage key (<<defn-child-storage-type>>).
 
 Arguments::
 
-* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 child storage key (<<defn-child-storage-type>>).
 * `limit`: a pointer-size (<<defn-runtime-pointer-size>>) to an _Option_ type
 (<<defn-option-type>>) containing an unsigned 32-bit integer indicating the
@@ -130,7 +130,7 @@ deleted or a value equal to _0_ if there are remaining keys.
 
 Arguments::
 
-* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 child storage key (<<defn-child-storage-type>>).
 * `limit`: a pointer-size (<<defn-runtime-pointer-size>>) to an _Option_ type
 (<<defn-option-type>>) containing an unsigned 32-bit integer indicating the
@@ -160,9 +160,9 @@ Checks whether the given key exists in the child storage.
 
 Arguments::
 
-* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 child storage key (<<defn-child-storage-type>>).
-* `key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the key.
+* `key`: a pointer-size (<<defn-runtime-pointer-size>>) to the key.
 * `return`: an i32 integer value equal to _1_ if the key exists or a value equal
 to _0_ if otherwise.
 
@@ -179,9 +179,9 @@ given prefix.
 
 Arguments::
 
-* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 child storage key (<<defn-child-storage-type>>).
-* `prefix`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `prefix`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 prefix.
 
 ===== Version 2 - Prototype
@@ -193,9 +193,9 @@ prefix.
 
 Arguments::
 
-* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 child storage key (<<defn-child-storage-type>>).
-* `prefix`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `prefix`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 prefix.
 * `limit`: a pointer-size (<<defn-runtime-pointer-size>>) to an _Option_ type
 (<<defn-option-type>>) containing an unsigned 32-bit integer indicating the
@@ -226,9 +226,9 @@ root.
 
 Arguments::
 
-* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 child storage key (<<defn-child-storage-type>>).
-* `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `return`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 SCALE encoded storage root.
 
 ===== Version 2 - Prototype
@@ -240,7 +240,7 @@ SCALE encoded storage root.
 
 Arguments::
 
-* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 child storage key (<<defn-child-storage-type>>).
 * `version`: a pointer-size (<<defn-runtime-pointer>>) to the state version (<<defn-state-version>>).
 * `return`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit Blake2 storage
@@ -260,10 +260,10 @@ The key provided to this function may or may not exist in storage.
 
 Arguments::
 
-* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 child storage key (<<defn-child-storage-type>>).
-* `key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the key. 
-* `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `key`: a pointer-size (<<defn-runtime-pointer-size>>) to the key. 
+* `return`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded as defined in <<defn-option-type>>
 containing the next key in lexicographic order. Returns if the entry cannot be
 found.

--- a/ab_host-api/child_storage.adoc
+++ b/ab_host-api/child_storage.adoc
@@ -218,6 +218,7 @@ there are remaining keys, followed by the number of removed keys.
 Commits all existing operations and computes the resulting child storage
 root.
 
+[#sect-ext-default-child-storage-root-version-1]
 ===== Version 1 - Prototype
 ----
 (func $ext_default_child_storage_root_version_1
@@ -230,6 +231,30 @@ Arguments::
 child storage key (<<defn-child-storage-type>>).
 * `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
 SCALE encoded storage root.
+
+===== Version 2 - Prototype
+----
+(func $ext_default_child_storage_root_version_2
+	(param $child_storage_key i64) (param $version i32)
+	(return i64))
+----
+
+Arguments::
+
+* `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+child storage key (<<defn-child-storage-type>>).
+* `version`: a pointer (<<defn-runtime-pointer>>) to the state version of the following format:
++
+[stem]
+++++
+v = {(0, "state version 1"),(1, "node hashes"):}
+++++
+where stem:[0] behaves like version 1
+(<<sect-ext-default-child-storage-root-version-1>>) of this function and
+stem:[1] makes use of "node hashes" when calculating the merkle proof
+(<<defn-node-hashes>>).
+* `return`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit Blake2 storage
+root.
 
 ==== `ext_default_child_storage_next_key`
 

--- a/ab_host-api/child_storage.adoc
+++ b/ab_host-api/child_storage.adoc
@@ -243,7 +243,7 @@ Arguments::
 
 * `child_storage_key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
 child storage key (<<defn-child-storage-type>>).
-* `version`: a pointer (<<defn-runtime-pointer>>) to the state version (<<defn-state-version>>).
+* `version`: a pointer-size (<<defn-runtime-pointer>>) to the state version (<<defn-state-version>>).
 * `return`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit Blake2 storage
 root.
 

--- a/ab_host-api/child_storage.adoc
+++ b/ab_host-api/child_storage.adoc
@@ -218,7 +218,6 @@ there are remaining keys, followed by the number of removed keys.
 Commits all existing operations and computes the resulting child storage
 root.
 
-[#sect-ext-default-child-storage-root-version-1]
 ===== Version 1 - Prototype
 ----
 (func $ext_default_child_storage_root_version_1

--- a/ab_host-api/crypto.adoc
+++ b/ab_host-api/crypto.adoc
@@ -360,7 +360,7 @@ public key cannot be found in the key store.
 [#sect-ext-crypto-ecdsa-verify]
 ==== `ext_crypto_ecdsa_verify`
 
-Verifies an ECDSA signature.
+Verifies the hash of the given message against a ECDSA signature.
 
 ===== Version 1 - Prototype
 
@@ -406,6 +406,27 @@ and the other 8 bits represent the recovery ID.
 message that is to be verified.
 * `key`: a pointer to the buffer containing the 33-byte compressed public
 key.
+* `return`: a i32 integer value equal _1_ to if the signature is valid or a
+value equal to _0_ if otherwise.
+
+==== `ext_crypto_ecdsa_verify_prehashed`
+
+Verifies the prehashed message against a ECDSA signature.
+
+===== Version 1 - Prototype
+
+----
+(func $ext_crypto_ecdsa_verify_prehashed_version_1
+	(param $sig i32) (param $msg i32) (param $key i32) (return i32))
+----
+
+Arguments::
+
+* `sig`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 65-byte signature. The
+signature is 65-bytes in size, where the first 512-bits represent the signature
+and the other 8 bits represent the recovery ID.
+* `msg`: a pointer to the 32-bit prehashed message to be verified.
+* `key`: a pointer to the 33-byte compressed public key.
 * `return`: a i32 integer value equal _1_ to if the signature is valid or a
 value equal to _0_ if otherwise.
 

--- a/ab_host-api/crypto.adoc
+++ b/ab_host-api/crypto.adoc
@@ -78,7 +78,7 @@ Arguments::
 
 * `key_type_id`: a pointer (<<defn-runtime-pointer>>) to the key type identifier
 (<<defn-key-type-id>>).
-* `seed`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE encoded
+* `seed`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE encoded
 _Option_ value (<<defn-option-type>>) containing the BIP-39 seed which must be
 valid UTF8.
 * `return`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit public key.
@@ -99,9 +99,9 @@ Arguments::
 * `key_type_id`: a pointer (<<defn-runtime-pointer>>) to the key type identifier
 (<<defn-key-type-id>>).
 * `key`: a pointer to the buffer containing the 256-bit public key.
-* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 message that is to be signed.
-* `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `return`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Option_ value (<<defn-option-type>>) containing the 64-byte signature.
 This function returns if the public key cannot be found in the key store.
 
@@ -119,7 +119,7 @@ Verifies an _ed25519_ signature.
 Arguments::
 
 * `sig`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 64-byte signature.
-* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 message that is to be verified.
 * `key`: a pointer to the buffer containing the 256-bit public key.
 * `return`: a i32 integer value equal to _1_ if the signature is valid or a
@@ -144,7 +144,7 @@ the signature is verified immediately.
 Arguments::
 
 * `sig`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 64-byte signature.
-* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 message that is to be verified.
 * `key`: a pointer to the buffer containing the 256-bit public key.
 * `return`: a i32 integer value equal to _1_ if the signature is valid or
@@ -164,7 +164,7 @@ Arguments::
 
 * `key_type_id`: a pointer (<<defn-runtime-pointer>>) to the key type identifier
 (<<defn-key-type-id>>).
-* `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `return`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 SCALE encoded 256-bit public keys.
 
 ==== `ext_crypto_sr25519_generate`
@@ -184,7 +184,7 @@ or invalid seed was provided.
 Arguments::
 
 * `key_type_id`: a pointer (<<defn-runtime-pointer>>) to the key identifier (<<defn-key-type-id>>).
-* `seed`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE encoded
+* `seed`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE encoded
 _Option_ value (<<defn-option-type>>) containing the BIP-39 seed which must be
 valid UTF8.
 * `return`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit public key.
@@ -204,9 +204,9 @@ Arguments::
 
 * `key_type_id`: a pointer (<<defn-runtime-pointer>>) to the key identifier (<<defn-key-type-id>>).
 * `key`: a pointer to the buffer containing the 256-bit public key.
-* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 message that is to be signed.
-* `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `return`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Option_ value (<<defn-option-type>>) containing the 64-byte signature.
 This function returns _None_ if the public key cannot be found in the key store.
 
@@ -224,7 +224,7 @@ Verifies an sr25519 signature.
 Arguments::
 
 * `sig`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 64-byte signature.
-* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 message that is to be verified.
 * `key`: a pointer to the buffer containing the 256-bit public key.
 * `return`: a i32 integer value equal to _1_ if the signature is valid or a
@@ -239,7 +239,7 @@ value equal to _0_ if otherwise.
 Arguments::
 
 * `sig`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 64-byte signature.
-* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 message that is to be verified.
 * `key`: a pointer to the buffer containing the 256-bit public key.
 * `return`: a i32 integer value equal to _1_ if the signature is valid or a
@@ -264,7 +264,7 @@ the signature is verified immediately.
 Arguments::
 
 * `sig`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 64-byte signature.
-* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 message that is to be verified.
 * `key`: a pointer to the buffer containing the 256-bit public key.
 * `return`: a i32 integer value equal to _1_ if the signature is valid or
@@ -283,7 +283,7 @@ Returns all _ecdsa_ public keys for the given key id from the keystore.
 Arguments::
 
 * `key_type_id`: a pointer (<<defn-runtime-pointer>>) to the key type identifier (<<defn-key-type-id>>).
-* `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `return`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 SCALE encoded 33-byte compressed public keys.
 
 ==== `ext_crypto_ecdsa_generate`
@@ -303,7 +303,7 @@ or invalid seed was provided.
 Arguments::
 
 * `key_type_id`: a pointer (<<defn-runtime-pointer>>) to the key identifier (<<defn-key-type-id>>).
-* `seed`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE encoded
+* `seed`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE encoded
 _Option_ value (<<defn-option-type>>) containing the BIP-39 seed which must be
 valid UTF8.
 * `return`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 33-byte compressed
@@ -325,9 +325,9 @@ Arguments::
 * `key_type_id`: a pointer (<<defn-runtime-pointer>>) to the key identifier (<<defn-key-type-id>>).
 * `key`: a pointer to the buffer containing the 33-byte compressed public
 key.
-* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 message that is to be signed.
-* `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `return`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Option_ value (<<defn-option-type>>) containing the signature. The
 signature is 65-bytes in size, where the first 512-bits represent the signature
 and the other 8 bits represent the recovery ID. This function returns if the
@@ -349,9 +349,9 @@ Arguments::
 * `key_type_id`: a pointer-size (<<defn-runtime-pointer>>) to the key identifier
 (<<defn-key-type-id>>).
 * `key`: a pointer to the buffer containing the 33-byte compressed public key.
-* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 message that is to be signed.
-* `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `return`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Option_ value (<<defn-option-type>>) containing the signature. The
 signature is 65-bytes in size, where the first 512-bits represent the signature
 and the other 8 bits represent the recovery ID. This function returns if the
@@ -381,7 +381,7 @@ Arguments::
 * `sig`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 65-byte signature. The
 signature is 65-bytes in size, where the first 512-bits represent the signature
 and the other 8 bits represent the recovery ID.
-* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 message that is to be verified.
 * `key`: a pointer to the buffer containing the 33-byte compressed public
 key.
@@ -402,7 +402,7 @@ Arguments::
 * `sig`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 65-byte signature. The
 signature is 65-bytes in size, where the first 512-bits represent the signature
 and the other 8 bits represent the recovery ID.
-* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 message that is to be verified.
 * `key`: a pointer to the buffer containing the 33-byte compressed public
 key.
@@ -449,7 +449,7 @@ the signature is verified immediately.
 Arguments::
 
 * `sig`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 64-byte signature.
-* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 message that is to be verified.
 * `key`: a pointer to the buffer containing the 256-bit public key.
 * `return`: a i32 integer value equal to _1_ if the signature is valid or
@@ -479,7 +479,7 @@ Arguments::
 format. V should be either or .
 * `msg`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit Blake2 hash of
 the message.
-* `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `return`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Result_ (<<defn-result-type>>). On success it contains the 64-byte
 recovered public key or an error type (<<defn-ecdsa-verify-error>>) on failure.
 
@@ -498,7 +498,7 @@ Arguments::
 format. V should be either or .
 * `msg`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit Blake2 hash of
 the message.
-* `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `return`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Result_ (<<defn-result-type>>). On success it contains the 64-byte
 recovered public key or an error type (<<defn-ecdsa-verify-error>>) on failure.
 
@@ -526,7 +526,7 @@ Arguments::
 format. V should be either `0/1` or `27/28`.
 * `msg`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit Blake2 hash of
 the message.
-* `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `return`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded `Result` value (<<defn-result-type>>). On success it contains the
 33-byte recovered public key in compressed form on success or an error type
 (<<defn-ecdsa-verify-error>>) on failure.
@@ -546,7 +546,7 @@ Arguments::
 format. V should be either `0/1` or `27/28`.
 * `msg`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit Blake2 hash of
 the message.
-* `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `return`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded `Result` value (<<defn-result-type>>). On success it contains the
 33-byte recovered public key in compressed form on success or an error type
 (<<defn-ecdsa-verify-error>>) on failure.

--- a/ab_host-api/crypto.adoc
+++ b/ab_host-api/crypto.adoc
@@ -98,7 +98,7 @@ Arguments::
 
 * `key_type_id`: a pointer (<<defn-runtime-pointer>>) to the key type identifier
 (<<defn-key-type-id>>).
-* `key`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit public key.
+* `key`: a pointer to the buffer containing the 256-bit public key.
 * `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
 message that is to be signed.
 * `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
@@ -121,7 +121,7 @@ Arguments::
 * `sig`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 64-byte signature.
 * `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
 message that is to be verified.
-* `key`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit public key.
+* `key`: a pointer to the buffer containing the 256-bit public key.
 * `return`: a i32 integer value equal to _1_ if the signature is valid or a
 value equal to _0_ if otherwise.
 
@@ -146,7 +146,7 @@ Arguments::
 * `sig`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 64-byte signature.
 * `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
 message that is to be verified.
-* `key`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit public key.
+* `key`: a pointer to the buffer containing the 256-bit public key.
 * `return`: a i32 integer value equal to _1_ if the signature is valid or
 batched or a value equal _0_ to if otherwise.
 
@@ -203,7 +203,7 @@ public key and key type in the keystore.
 Arguments::
 
 * `key_type_id`: a pointer (<<defn-runtime-pointer>>) to the key identifier (<<defn-key-type-id>>).
-* `key`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit public key.
+* `key`: a pointer to the buffer containing the 256-bit public key.
 * `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
 message that is to be signed.
 * `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
@@ -226,7 +226,7 @@ Arguments::
 * `sig`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 64-byte signature.
 * `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
 message that is to be verified.
-* `key`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit public key.
+* `key`: a pointer to the buffer containing the 256-bit public key.
 * `return`: a i32 integer value equal to _1_ if the signature is valid or a
 value equal to _0_ if otherwise.
 
@@ -241,7 +241,7 @@ Arguments::
 * `sig`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 64-byte signature.
 * `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
 message that is to be verified.
-* `key`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit public key.
+* `key`: a pointer to the buffer containing the 256-bit public key.
 * `return`: a i32 integer value equal to _1_ if the signature is valid or a
 value equal to _0_ if otherwise.
 
@@ -266,7 +266,7 @@ Arguments::
 * `sig`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 64-byte signature.
 * `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
 message that is to be verified.
-* `key`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit public key.
+* `key`: a pointer to the buffer containing the 256-bit public key.
 * `return`: a i32 integer value equal to _1_ if the signature is valid or
 batched or a value equal _0_ to if otherwise.
 
@@ -311,8 +311,8 @@ public key.
 
 ==== `ext_crypto_ecdsa_sign`
 
-Signs the given message with the _ecdsa_ key that corresponds to the given
-public key and key type in the keystore.
+Signs the hash of the given message with the _ecdsa_ key that corresponds to the
+given public key and key type in the keystore.
 
 ===== Version 1 - Prototype
 ----
@@ -323,8 +323,32 @@ public key and key type in the keystore.
 Arguments::
 
 * `key_type_id`: a pointer (<<defn-runtime-pointer>>) to the key identifier (<<defn-key-type-id>>).
-* `key`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 33-byte compressed public
+* `key`: a pointer to the buffer containing the 33-byte compressed public
 key.
+* `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+message that is to be signed.
+* `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+encoded _Option_ value (<<defn-option-type>>) containing the signature. The
+signature is 65-bytes in size, where the first 512-bits represent the signature
+and the other 8 bits represent the recovery ID. This function returns if the
+public key cannot be found in the key store.
+
+==== `ext_crypto_ecdsa_sign_prehashed`
+
+Signs the prehashed message with the _ecdsa_ key that corresponds to the given
+public key and key type in the keystore.
+
+===== Version 1 - Prototype
+----
+(func $ext_crypto_ecdsa_sign_prehashed_version_1
+	(param $key_type_id i32) (param $key i32) (param $msg i64) (return i64))
+----
+
+Arguments::
+
+* `key_type_id`: a pointer-size (<<defn-runtime-pointer>>) to the key identifier
+(<<defn-key-type-id>>).
+* `key`: a pointer to the buffer containing the 33-byte compressed public key.
 * `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
 message that is to be signed.
 * `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
@@ -359,7 +383,7 @@ signature is 65-bytes in size, where the first 512-bits represent the signature
 and the other 8 bits represent the recovery ID.
 * `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
 message that is to be verified.
-* `key`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 33-byte compressed public
+* `key`: a pointer to the buffer containing the 33-byte compressed public
 key.
 * `return`: a i32 integer value equal _1_ to if the signature is valid or a
 value equal to _0_ if otherwise.
@@ -380,7 +404,7 @@ signature is 65-bytes in size, where the first 512-bits represent the signature
 and the other 8 bits represent the recovery ID.
 * `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
 message that is to be verified.
-* `key`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 33-byte compressed public
+* `key`: a pointer to the buffer containing the 33-byte compressed public
 key.
 * `return`: a i32 integer value equal _1_ to if the signature is valid or a
 value equal to _0_ if otherwise.
@@ -406,7 +430,7 @@ Arguments::
 * `sig`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 64-byte signature.
 * `msg`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
 message that is to be verified.
-* `key`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit public key.
+* `key`: a pointer to the buffer containing the 256-bit public key.
 * `return`: a i32 integer value equal to _1_ if the signature is valid or
 batched or a value equal _0_ to if otherwise.
 

--- a/ab_host-api/hashing.adoc
+++ b/ab_host-api/hashing.adoc
@@ -17,7 +17,7 @@ Conducts a 256-bit Keccak hash.
 
 Arguments::
 
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the data
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to the data
 to be hashed.
 * `return`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit hash result.
 
@@ -33,7 +33,7 @@ Conducts a 512-bit Keccak hash.
 
 Arguments::
 
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the data
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to the data
 to be hashed.
 * `return`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 512-bit hash result.
 
@@ -49,7 +49,7 @@ Conducts a 256-bit Sha2 hash.
 
 Arguments::
 
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the data
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to the data
 to be hashed.
 * `return`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit hash result.
 
@@ -65,7 +65,7 @@ Conducts a 128-bit Blake2 hash.
 
 Arguments::
 
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the data
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to the data
 to be hashed.
 * `return`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 128-bit hash result.
 
@@ -81,7 +81,7 @@ Conducts a 256-bit Blake2 hash.
 
 Arguments::
 
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the data
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to the data
 to be hashed.
 * `return`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit hash result.
 
@@ -97,7 +97,7 @@ Conducts a 64-bit xxHash hash.
 
 Arguments::
 
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the data
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to the data
 to be hashed.
 * `return`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 64-bit hash result.
 
@@ -113,7 +113,7 @@ Conducts a 128-bit xxHash hash.
 
 Arguments::
 
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the data
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to the data
 to be hashed.
 * `return`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 128-bit hash result.
 
@@ -129,6 +129,6 @@ Conducts a 256-bit xxHash hash.
 
 Arguments::
 
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the data
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to the data
 to be hashed.
 * `return`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit hash result.

--- a/ab_host-api/logging.adoc
+++ b/ab_host-api/logging.adoc
@@ -33,8 +33,8 @@ target.
 Arguments::
 
 * `level`: the log level (<<defn-logging-log-level>>).
-* `target`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `target`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 string which contains the path, module or location from where the log was
 executed.
-* `message`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the log
+* `message`: a pointer-size (<<defn-runtime-pointer-size>>) to the log
 message.

--- a/ab_host-api/main.adoc
+++ b/ab_host-api/main.adoc
@@ -2,7 +2,7 @@
 .<<defn-state-version, State Version>>
 ====
 The state version, stem:[v], dictates how a merkle root should be constructed.
-The datastructure is of the following format:
+The datastructure is a varying type of the following format:
 
 [stem]
 ++++

--- a/ab_host-api/main.adoc
+++ b/ab_host-api/main.adoc
@@ -1,3 +1,19 @@
+[#defn-state-version]
+.<<defn-state-version, State Version>>
+====
+The state version, stem:[v], dictates how a merkle root should be constructed.
+The datastructure is of the following format:
+
+[stem]
+++++
+v = {(0, "full values"),(1, "node hashes"):}
+++++
+
+where stem:[0] indicates that the values of the keys should be inserted into the
+trie directly and stem:[1] makes use of "node hashes" when calculating the
+merkle proof (<<defn-node-hashes>>).
+====
+
 include::intro.adoc[]
 
 include::storage.adoc[]

--- a/ab_host-api/misc.adoc
+++ b/ab_host-api/misc.adoc
@@ -6,19 +6,6 @@ runtime and the node.
 
 === Functions
 
-==== `ext_misc_chain_id`
-
-Returns the current relay chain identifier.
-
-===== Version 1 - Prototype
-----
-(func $ext_misc_chain_id_version_1 (result i64))
-----
-
-Arguments::
-
-* `result`: the current relay chain identifier.
-
 ==== `ext_misc_print_num`
 
 Print a number.
@@ -82,4 +69,4 @@ Arguments::
 blob.
 * `result`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
 encoded _Option_ value (<<defn-option-type>>) containing the Runtime version of
-the given Wasm blob.
+the given Wasm blob which is encoded as a byte array.

--- a/ab_host-api/misc.adoc
+++ b/ab_host-api/misc.adoc
@@ -30,7 +30,7 @@ Print a valid UTF8 encoded buffer.
 
 *Arguments*:
 
-* : a pointer-size (<<defn-runtime-pointer-size>>) indicating
+* : a pointer-size (<<defn-runtime-pointer-size>>) to
 the valid buffer to be printed.
 
 ==== `ext_misc_print_hex`
@@ -44,7 +44,7 @@ Print any buffer in hexadecimal representation.
 
 *Arguments*:
 
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to
 the buffer to be printed.
 
 ==== `ext_misc_runtime_version`
@@ -65,8 +65,8 @@ Wasm blob (<<sect-loading-runtime-code>>) and calling a function in this blob.
 
 Arguments::
 
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the Wasm
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to the Wasm
 blob.
-* `result`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `result`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Option_ value (<<defn-option-type>>) containing the Runtime version of
 the given Wasm blob which is encoded as a byte array.

--- a/ab_host-api/offchain.adoc
+++ b/ab_host-api/offchain.adoc
@@ -93,9 +93,9 @@ Host's transaction pool, ready to be propagated to remote peers.
 ----
 
 Arguments::
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the byte array
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to the byte array
 storing the encoded extrinsic.
-* `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `return`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Result_ value (<<defn-result-type>>). Neither on success or failure is
 there any additional data provided. The cause of a failure is implementation
 specific.
@@ -135,7 +135,7 @@ this function.
 ----
 
 Arguments::
-* `result`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `result`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded `Result` value (<<defn-result-type>>). On success it contains the
 _Opaque network state_ structure (<<defn-opaque-network-state>>). On failure, an
 empty value is yielded where its cause is implementation specific.
@@ -193,8 +193,8 @@ Arguments::
 * `kind`: an i32 integer indicating the storage kind. A value equal to _1_ is
 used for a persistent storage (<<defn-offchain-persistent-storage>>) and a value
 equal to _2_ for local storage (<<defn-offchain-local-storage>>).
-* `key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the key.
-* `value`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the value.
+* `key`: a pointer-size (<<defn-runtime-pointer-size>>) to the key.
+* `value`: a pointer-size (<<defn-runtime-pointer-size>>) to the value.
 
 ==== `ext_offchain_local_storage_clear`
 
@@ -210,7 +210,7 @@ Arguments::
 * `kind`: an i32 integer indicating the storage kind. A value equal to _1_ is
 used for a persistent storage (<<defn-offchain-persistent-storage>>) and a value
 equal to _2_ for local storage (<<defn-offchain-local-storage>>).
-* `key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the key.
+* `key`: a pointer-size (<<defn-runtime-pointer-size>>) to the key.
 
 ==== `ext_offchain_local_storage_compare_and_set`
 
@@ -227,10 +227,10 @@ Arguments::
 * `kind`: an i32 integer indicating the storage kind. A value equal to _1_ is
 used for a persistent storage (<<defn-offchain-persistent-storage>>) and a value
 equal to _2_ for local storage (<<defn-offchain-local-storage>>).
-* `key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the key.
-* `old_value`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `key`: a pointer-size (<<defn-runtime-pointer-size>>) to the key.
+* `old_value`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Option_ value (<<defn-option-type>>) containing the old key.
-* `new_value`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the new value.
+* `new_value`: a pointer-size (<<defn-runtime-pointer-size>>) to the new value.
 * `result`: an i32 integer equal to _1_ if the new value has been set or a value
 equal to _0_ if otherwise.
 
@@ -248,8 +248,8 @@ Arguments::
 * `kind`: an i32 integer indicating the storage kind. A value equal to _1_ is
 used for a persistent storage (<<defn-offchain-persistent-storage>>) and a value
 equal to _2_ for local storage (<<defn-offchain-local-storage>>).
-* `key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the key.
-* `result`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `key`: a pointer-size (<<defn-runtime-pointer-size>>) to the key.
+* `result`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Option_ value (<<defn-option-type>>) containing the value or the
 corresponding key.
 
@@ -265,12 +265,12 @@ a newly started request.
 ----
 
 Arguments::
-* `method`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the HTTP
+* `method`: a pointer-size (<<defn-runtime-pointer-size>>) to the HTTP
 method. Possible values are “GET” and “POST”.
-* `uri`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the URI.
+* `uri`: a pointer-size (<<defn-runtime-pointer-size>>) to the URI.
 * `meta`: a future-reserved field containing additional, SCALE encoded
 parameters. Currently, an empty array should be passed.
-* `result`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `result`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Result_ value (<<defn-result-type>>) containing the i16 ID of the newly
 started request. On failure no additionally data is provided. The cause of
 failure is implementation specific.
@@ -290,9 +290,9 @@ remote has closed the connection).
 
 Arguments::
 * `request_id`: an i32 integer indicating the ID of the started request.
-* `name`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the HTTP header name.
-* `value`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the HTTP header value.
-* `result`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `name`: a pointer-size (<<defn-runtime-pointer-size>>) to the HTTP header name.
+* `value`: a pointer-size (<<defn-runtime-pointer-size>>) to the HTTP header value.
+* `result`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Result_ value (<<defn-result-type>>). Neither on success or failure is
 there any additional data provided. The cause of failure is implementation
 specific.
@@ -310,12 +310,12 @@ deadline is reached or the chunk could not be written.
 
 Arguments::
 * `request_id`: an i32 integer indicating the ID of the started request.
-* `chunk`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the chunk of
+* `chunk`: a pointer-size (<<defn-runtime-pointer-size>>) to the chunk of
 bytes. Writing an empty chunk finalizes the request.
-* `deadline`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `deadline`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Option_ value (<<defn-option-type>>) containing the UNIX timestamp
 (<<defn-unix-time>>). Passing _None_ blocks indefinitely.
-* `result`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `result`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Result_ value (<<defn-result-type>>). On success, no additional data is
 provided. On error it contains the HTTP error type (<<defn-http-error>>).
 
@@ -332,12 +332,12 @@ unready responses will produce DeadlineReached status.
 ----
 
 Arguments::
-* `ids`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `ids`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded array of started request IDs.
-* `deadline`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `deadline`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Option_ value (<<defn-option-type>>) containing the UNIX timestamp
 (<<defn-unix-time>>). Passing None blocks indefinitely.
-* `result`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `result`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded array of request statuses (<<defn-http-status-codes>>).
 
 ==== `ext_offchain_http_response_headers`
@@ -353,7 +353,7 @@ headers must be read before the response body.
 
 Arguments::
 * `request_id`: an i32 integer indicating the ID of the started request.
-* `result`: a pointer-size (<<defn-runtime-pointer-size>>) indicating a SCALE encoded array of key/value pairs.
+* `result`: a pointer-size (<<defn-runtime-pointer-size>>) to a SCALE encoded array of key/value pairs.
 
 ==== `ext_offchain_http_response_read_body`
 
@@ -371,12 +371,12 @@ read before draining the body.
 
 Arguments::
 * `request_id`: an i32 integer indicating the ID of the started request.
-* `buffer`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the buffer
+* `buffer`: a pointer-size (<<defn-runtime-pointer-size>>) to the buffer
 where the body gets written to.
-* `deadline`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `deadline`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Option_ value (<<defn-option-type>>) containing the UNIX timestamp
 (<<defn-unix-time>>). Passing _None_ will block indefinitely.
-* `result`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `result`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Result_ value (<<defn-result-type>>). On success it contains an i32
 integer specifying the number of bytes written or a HTTP error type
 (<<defn-http-error>>) on failure.

--- a/ab_host-api/storage.adoc
+++ b/ab_host-api/storage.adoc
@@ -192,7 +192,7 @@ NOTE: This function is not longer used and only exists for compatibiltiy reasons
 ----
 
 Arguments::
-* `parent_hash`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `parent_hash`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 SCALE encoded block hash.
 * `return`: a pointer-size (<<defn-runtime-pointer-size>>) to an _Option_ type
 (<<defn-option-type>>) that's always _None_.
@@ -210,8 +210,8 @@ not exist in storage.
 ----
 
 Arguments::
-* `key`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the key.
-* `return`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the SCALE
+* `key`: a pointer-size (<<defn-runtime-pointer-size>>) to the key.
+* `return`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Option_ value (<<defn-option-type>>) containing the next key in
 lexicographic order.
 

--- a/ab_host-api/storage.adoc
+++ b/ab_host-api/storage.adoc
@@ -176,7 +176,7 @@ the 256-bit Blake2 storage root.
 ----
 
 Arguments::
-* `version`: a pointer (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
+* `version`: a pointer-size (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
 * `return`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit Blake2 storage
 root.
 

--- a/ab_host-api/storage.adoc
+++ b/ab_host-api/storage.adoc
@@ -176,15 +176,7 @@ the 256-bit Blake2 storage root.
 ----
 
 Arguments::
-* `version`: a pointer (<<defn-runtime-pointer>>) to the state version of the following format:
-+
-[stem]
-++++
-v = {(0, "state version 1"),(1, "node hashes"):}
-++++
-where stem:[0] behaves like version 1 (<<sect-ext-storage-root-version-1>>) of
-this function and stem:[1] makes use of "node hashes" when calculating the
-merkle proof (<<defn-node-hashes>>).
+* `version`: a pointer (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
 * `return`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit Blake2 storage
 root.
 

--- a/ab_host-api/storage.adoc
+++ b/ab_host-api/storage.adoc
@@ -157,6 +157,17 @@ value to be appended.
 
 Compute the storage root.
 
+[#sect-ext-storage-root-version-1]
+===== Version 1 - Prototype
+----
+(func $ext_storage_root_version_1
+	(return i64))
+----
+
+Arguments::
+* `return`: a pointer-size (<<defn-runtime-pointer-size>>) to a buffer containing
+the 256-bit Blake2 storage root.
+
 [#sect-ext-storage-root-version-2]
 ===== Version 2 - Prototype
 ----
@@ -176,17 +187,6 @@ this function and stem:[1] makes use of "node hashes" when calculating the
 merkle proof (<<defn-node-hashes>>).
 * `return`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit Blake2 storage
 root.
-
-[#sect-ext-storage-root-version-1]
-===== Version 1 - Prototype
-----
-(func $ext_storage_root_version_1
-	(return i64))
-----
-
-Arguments::
-* `return`: a pointer-size (<<defn-runtime-pointer-size>>) to a buffer containing 
-the 256-bit Blake2 storage root.
 
 [#sect-ext-storage-changes-root]
 ==== `ext_storage_changes_root`

--- a/ab_host-api/trie.adoc
+++ b/ab_host-api/trie.adoc
@@ -17,7 +17,7 @@ Compute a 256-bit Blake2 trie root formed from the iterated items.
 
 Arguments::
 
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 iterated items from which the trie root gets formed. The items consist of a
 SCALE encoded array containing arbitrary key/value pairs (tuples).
 * `result`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit trie root.
@@ -31,7 +31,7 @@ SCALE encoded array containing arbitrary key/value pairs (tuples).
 
 Arguments::
 
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 iterated items from which the trie root gets formed. The items consist of a
 SCALE encoded array containing arbitrary key/value pairs (tuples).
 * `version`: a pointer-size (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
@@ -49,7 +49,7 @@ Compute a 256-bit Blake2 trie root formed from the enumerated items.
 
 Arguments::
 
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the enumerated
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to the enumerated
 items from which the trie root gets formed. The items consist of a SCALE encoded
 array containing only values, where the corresponding key of each value is the
 index of the item in the array, starting at 0. The keys are compact encoded
@@ -66,7 +66,7 @@ result.
 
 Arguments::
 
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the enumerated
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to the enumerated
 items from which the trie root gets formed. The items consist of a SCALE encoded
 array containing only values, where the corresponding key of each value is the
 index of the item in the array, starting at 0. The keys are compact encoded
@@ -87,7 +87,7 @@ Compute a 256-bit Keccak trie root formed from the iterated items.
 
 Arguments::
 
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 iterated items from which the trie root gets formed. The items consist of a
 SCALE encoded array containing arbitrary key/value pairs.
 * `result`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit trie root.
@@ -101,7 +101,7 @@ SCALE encoded array containing arbitrary key/value pairs.
 
 Arguments::
 
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to the
 iterated items from which the trie root gets formed. The items consist of a
 SCALE encoded array containing arbitrary key/value pairs.
 * `version`: a pointer-size (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
@@ -119,7 +119,7 @@ Compute a 256-bit Keccak trie root formed from the enumerated items.
 
 Arguments::
 
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the enumerated
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to the enumerated
 items from which the trie root gets formed. The items consist of a SCALE encoded
 array containing only values, where the corresponding key of each value is the
 index of the item in the array, starting at 0. The keys are compact encoded
@@ -136,7 +136,7 @@ result.
 
 Arguments::
 
-* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the enumerated
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) to the enumerated
 items from which the trie root gets formed. The items consist of a SCALE encoded
 array containing only values, where the corresponding key of each value is the
 index of the item in the array, starting at 0. The keys are compact encoded

--- a/ab_host-api/trie.adoc
+++ b/ab_host-api/trie.adoc
@@ -183,3 +183,42 @@ the node proofs.
 * `version`: a pointer-size (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
 * `return`: a value equal to _1_ if the proof could be succesfully verified or a
 value equal to _0_ if otherwise.
+
+==== `ext_trie_keccak_256_verify_proof`
+
+Verifies a key/value pair against a Keccak 256-bit merkle root.
+
+===== Version 1 - Prototype
+----
+(func $ext_trie_keccak_256_verify_proof_version_1
+	(param $root i32) (param $proof i64)
+	(param $key i64) (param $value i64)
+	(result i32))
+----
+
+Arguments::
+* `root`: a pointer to the 256-bit merkle root.
+* `proof`: a pointer-size (<<defn-runtime-pointer-size>>) to an array containing
+the node proofs.
+* `key`: a pointer-size (<<defn-runtime-pointer-size>>) to the key.
+* `value`: a pointer-size (<<defn-runtime-pointer-size>>) to the value.
+* `return`: a value equal to _1_ if the proof could be succesfully verified or a
+value equal to _0_ if otherwise.
+
+===== Version 2 - Prototype
+----
+(func $ext_trie_keccak_256_verify_proof_version_2
+	(param $root i32) (param $proof i64)
+	(param $key i64) (param $value i64)
+	(param $version i32) (result i32))
+----
+
+Arguments::
+* `root`: a pointer to the 256-bit merkle root.
+* `proof`: a pointer-size (<<defn-runtime-pointer-size>>) to an array containing
+the node proofs.
+* `key`: a pointer-size (<<defn-runtime-pointer-size>>) to the key.
+* `value`: a pointer-size (<<defn-runtime-pointer-size>>) to the value.
+* `version`: a pointer-size (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
+* `return`: a value equal to _1_ if the proof could be succesfully verified or a
+value equal to _0_ if otherwise.

--- a/ab_host-api/trie.adoc
+++ b/ab_host-api/trie.adoc
@@ -34,7 +34,7 @@ Arguments::
 * `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
 iterated items from which the trie root gets formed. The items consist of a
 SCALE encoded array containing arbitrary key/value pairs (tuples).
-* `version`: a pointer (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
+* `version`: a pointer-size (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
 * `result`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit trie root.
 
 ==== `ext_trie_blake2_256_ordered_root`
@@ -71,7 +71,7 @@ items from which the trie root gets formed. The items consist of a SCALE encoded
 array containing only values, where the corresponding key of each value is the
 index of the item in the array, starting at 0. The keys are compact encoded
 integers (<<defn-sc-len-encoding>>).
-* `version`: a pointer (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
+* `version`: a pointer-size (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
 * `result`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit trie root
 result.
 
@@ -104,7 +104,7 @@ Arguments::
 * `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
 iterated items from which the trie root gets formed. The items consist of a
 SCALE encoded array containing arbitrary key/value pairs.
-* `version`: a pointer (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
+* `version`: a pointer-size (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
 * `result`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit trie root.
 
 ==== `ext_trie_keccak_256_ordered_root`
@@ -141,6 +141,45 @@ items from which the trie root gets formed. The items consist of a SCALE encoded
 array containing only values, where the corresponding key of each value is the
 index of the item in the array, starting at 0. The keys are compact encoded
 integers (<<defn-sc-len-encoding>>).
-* `version`: a pointer (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
+* `version`: a pointer-size (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
 * `result`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit trie root
 result.
+
+==== `ext_trie_blake2_256_verify_proof`
+
+Verifies a key/value pair against a Blake2 256-bit merkle root.
+
+===== Version 1 - Prototype
+----
+(func $ext_trie_blake2_256_verify_proof_version_1
+	(param $root i32) (param $proof i64)
+	(param $key i64) (param $value i64)
+	(result i32))
+----
+
+Arguments::
+* `root`: a pointer to the 256-bit merkle root.
+* `proof`: a pointer-size (<<defn-runtime-pointer-size>>) to an array containing
+the node proofs.
+* `key`: a pointer-size (<<defn-runtime-pointer-size>>) to the key.
+* `value`: a pointer-size (<<defn-runtime-pointer-size>>) to the value.
+* `return`: a value equal to _1_ if the proof could be succesfully verified or a
+value equal to _0_ if otherwise.
+
+===== Version 2 - Prototype
+----
+(func $ext_trie_blake2_256_verify_proof_version_2
+	(param $root i32) (param $proof i64)
+	(param $key i64) (param $value i64)
+	(param $version i32) (result i32))
+----
+
+Arguments::
+* `root`: a pointer to the 256-bit merkle root.
+* `proof`: a pointer-size (<<defn-runtime-pointer-size>>) to an array containing
+the node proofs.
+* `key`: a pointer-size (<<defn-runtime-pointer-size>>) to the key.
+* `value`: a pointer-size (<<defn-runtime-pointer-size>>) to the value.
+* `version`: a pointer-size (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
+* `return`: a value equal to _1_ if the proof could be succesfully verified or a
+value equal to _0_ if otherwise.

--- a/ab_host-api/trie.adoc
+++ b/ab_host-api/trie.adoc
@@ -19,7 +19,22 @@ Arguments::
 
 * `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
 iterated items from which the trie root gets formed. The items consist of a
-SCALE encoded array containing arbitrary key/value pairs.
+SCALE encoded array containing arbitrary key/value pairs (tuples).
+* `result`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit trie root.
+
+===== Version 2 - Prototype
+----
+(func $ext_trie_blake2_256_root_version_2
+	(param $data i64) (param $version i32)
+	(result i32))
+----
+
+Arguments::
+
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+iterated items from which the trie root gets formed. The items consist of a
+SCALE encoded array containing arbitrary key/value pairs (tuples).
+* `version`: a pointer (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
 * `result`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit trie root.
 
 ==== `ext_trie_blake2_256_ordered_root`
@@ -42,6 +57,24 @@ integers (<<defn-sc-len-encoding>>).
 * `result`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit trie root
 result.
 
+===== Version 2 - Prototype
+----
+(func $ext_trie_blake2_256_ordered_root_version_2
+	(param $data i64) (param $version i32)
+	(result i32))
+----
+
+Arguments::
+
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the enumerated
+items from which the trie root gets formed. The items consist of a SCALE encoded
+array containing only values, where the corresponding key of each value is the
+index of the item in the array, starting at 0. The keys are compact encoded
+integers (<<defn-sc-len-encoding>>).
+* `version`: a pointer (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
+* `result`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit trie root
+result.
+
 ==== `ext_trie_keccak_256_root`
 
 Compute a 256-bit Keccak trie root formed from the iterated items.
@@ -57,6 +90,21 @@ Arguments::
 * `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
 iterated items from which the trie root gets formed. The items consist of a
 SCALE encoded array containing arbitrary key/value pairs.
+* `result`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit trie root.
+
+===== Version 2 - Prototype
+----
+(func $ext_trie_keccak_256_root_version_2
+	(param $data i64) (param $version i32)
+	(result i32))
+----
+
+Arguments::
+
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the
+iterated items from which the trie root gets formed. The items consist of a
+SCALE encoded array containing arbitrary key/value pairs.
+* `version`: a pointer (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
 * `result`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit trie root.
 
 ==== `ext_trie_keccak_256_ordered_root`
@@ -76,5 +124,23 @@ items from which the trie root gets formed. The items consist of a SCALE encoded
 array containing only values, where the corresponding key of each value is the
 index of the item in the array, starting at 0. The keys are compact encoded
 integers (<<defn-sc-len-encoding>>).
+* `result`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit trie root
+result.
+
+===== Version 2 - Prototype
+----
+(func $ext_trie_keccak_256_ordered_root_version_2
+	(param $data i64) (param $version i32)
+	(result i32))
+----
+
+Arguments::
+
+* `data`: a pointer-size (<<defn-runtime-pointer-size>>) indicating the enumerated
+items from which the trie root gets formed. The items consist of a SCALE encoded
+array containing only values, where the corresponding key of each value is the
+index of the item in the array, starting at 0. The keys are compact encoded
+integers (<<defn-sc-len-encoding>>).
+* `version`: a pointer (<<defn-runtime-pointer>>) to the state version <<defn-state-version>>.
 * `result`: a pointer (<<defn-runtime-pointer>>) to the buffer containing the 256-bit trie root
 result.


### PR DESCRIPTION
Added a bunch of missing Host APIs:

* `ext_default_child_storage_root_version_2`
* `ext_crypto_ecdsa_sign_prehashed_version_1`
* `ext_crypto_ecdsa_verify_prehashed_version_1`
* `ext_trie_blake2_256_root_version_2`
* `ext_trie_blake2_256_ordered_root_version_2`
* `ext_trie_keccak_256_root_version_2`
* `ext_trie_keccak_256_ordered_root_version_2`
* `ext_trie_blake2_256_verify_proof_version_1`
* `ext_trie_blake2_256_verify_proof_version_2`
* `ext_trie_keccak_256_verify_proof_version_1`
* `ext_trie_keccak_256_verify_proof_version_2`
* deprecate `ext_misc_chain_id_version_1`
* unify "state version", create a proper definition and reference it.
* rephrases some sentences.