### PR TITLE
Define secondary slots

### DIFF
--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -213,7 +213,8 @@ p larr "dleq_prove"(t_6, h)
 ++++
 
 The operators are defined in <<defn-strobe-operations>>, stem:["dleq_prove"] in
-<<defn-vrf-dleq-prove>>.
+<<defn-vrf-dleq-prove>>. The computed outputs, stem:[o] and stem:[p], are
+included in the block Pre-Digest (<<defn-babe-header>>).
 ****
 
 [#sect-slot-number-calculation]

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -177,7 +177,9 @@ where:
 * stem:[h(...)] creates a 256-bit Blake2 hash from its inner value.
 * stem:[A_l] is the lengths of the authority list (<<defn-authority-list>>).
 
-To create the necessary VRF outputs, a transcript is construced (<<sect-vrf>>).
+If stem:[i_d] points to the authority, that authority must claim the secondary
+slot by calculataing the necessary outputs for block production. To create the
+VRF outputs, a transcript is construced (<<sect-vrf>>).
 
 [stem]
 ++++

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -170,6 +170,25 @@ where:
 * stem:[h(...)] creates a 256-bit Blake2 hash from its inner value.
 * stem:[A_l] is the lengths of the authority list (<<defn-authority-list>>).
 
+Then a transcript...
+
+[stem]
+++++
+t_1 larr "Transcript"("'BABE'")\
+t_2 larr "append"(t_1, "'slot number'", s)\
+t_3 larr "append"(t_2, "'current epoch'", e_i)\
+t_4 larr "append"(t_3, "'chain randomness'", r)\
+t_5 larr "append"(t_4, "'vrf-nm-pk'", p_k)\
+t_6 larr "meta-ad"(t_5, "'VRFHash'", "False")\
+t_7 larr "meta-ad"(t_6, 64_("le"), "True")\
+i larr "prf"(t_7, "False")\
+o = s_k * i\
+p larr sf "dleq_prove"(t_6, i)
+++++
+
+The resulting value stem:[p] is the VRF proof (<<defn-vrf-proof>>).
+stem:["dleq_prove"] is described in <<defn-vrf-dleq-prove>>.
+
 ****
 
 [#sect-slot-number-calculation]

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -98,7 +98,8 @@ the lottery.
 In order to ensure consistent block production, BABE uses secondary slots in
 case no authority won the (primary) block production lottery. Unlike the
 lottery, secondary slot assignees are know upfront publically
-(<<block-production-secondary-slots>>).
+(<<block-production-secondary-slots>>). The Runtime dictates what types of
+rounds to execute (<<sect-rte-babeapi-epoch>>).
 
 [#defn-babe-constant]
 .<<defn-babe-constant, BABE Constant>>

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -141,14 +141,18 @@ the lottery.
 Algorithm: stem:["Block-Production-Lottery"(sk)]
 
 . stem:[r larr "Epoch-Randomness"(n)]
-. stem:["for " i := 1 " to " sc_n]
-. stem:["    " (pi, d) larr "VRF"(r,i,sk)]
-. stem:["    " A\[i\] larr (d, pi)]
+. stem:["for " s := 1 " to " sc_n]
+. stem:["    " (o, p) larr "VRF"(r,s,e_i,s_k, p_k)]
+. stem:["    " A\[i\] larr (o, p)]
 . stem:["return " A]
 
-For any slot stem:[i] in epoch stem:[n] where stem:[d < r], the block producer
-is required to produce a block. For the definitions of _Epoch-Randomness_
-(<<defn-epoch-randomness>>) and _VRF_ functions (<<sect-vrf>>).
+where stem:["Epoch-Randomness"] is defined in (<<defn-epoch-randomness>>),
+stem:[sc_n] is defined in <<defn-epoch-duration>> , stem:["VRF"] creates the
+BABE VRF transcript (<<defn-babe-vrf-transcript>>) and stem:[e_i] is the epoch
+index, retrieved from the Runtime (<<sect-rte-babeapi-epoch>>). stem:[s_k] and
+stem:[p_k] is the secret key respectively the public key of the authority. For
+any slot stem:[s] in epoch stem:[n] where stem:[d < r], the block producer is
+required to produce a block.
 
 Note that the secondary slots (<<block-production-secondary-slots>>) are running
 along side the primary block production lottery.
@@ -201,6 +205,32 @@ described in <<defn-vrf-dleq-prove>>. Values stem:[o] and stem:[p] are then used
 in the Pre-Digest item (<<defn-babe-header>>). In case of secondary slots with
 plain outputs, respectively the Pre-Digest being of value _2_, the transcript is
 skipped.
+****
+
+[#defn-babe-vrf-transcript]
+===== BABE Slot VRF transcript
+****
+The BABE block production lottery requires a specific transcript structure
+(<<defn-vrf-transcript>>). That structure is used by both primary slots
+(<<algo-block-production-lottery>>) and secondary slots
+(<<block-production-secondary-slots>>).
+
+[stem]
+++++
+t_1 larr "Transcript"("'BABE'")\
+t_2 larr "append"(t_1, "'slot number'", s)\
+t_3 larr "append"(t_2, "'current epoch'", e_i)\
+t_4 larr "append"(t_3, "'chain randomness'", r)\
+t_5 larr "append"(t_4, "'vrf-nm-pk'", p_k)\
+t_6 larr "meta-ad"(t_5, "'VRFHash'", "False")\
+t_7 larr "meta-ad"(t_6, 64_("le"), "True")\
+h larr "prf"(t_7, "False")\
+o = s_k * h\
+p larr "dleq_prove"(t_6, h)
+++++
+
+The operators are defined in <<defn-strobe-operations>>, stem:["dleq_prove"] in
+<<defn-vrf-dleq-prove>>.
 ****
 
 [#sect-slot-number-calculation]

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -156,9 +156,8 @@ is required to produce a block. For the definitions of _Epoch-Randomness_
 **Secondary slots** work along side primary slot to ensure consistent block
 production, as described in <<sect-block-production-lottery>>. The secondary
 assignee of a block is determined by calculating a specific value, stem:[i_d],
-which indicates the index in the authority set. The corresponding authority,
-represented by its public key, stem:[a_("id")], has the right to produce a block
-for that slot.
+which indicates the index in the authority set (<<defn-authority-list>>). The
+corresponding authority in that set has the right to author a secondary block.
 
 [stem]
 ++++
@@ -174,7 +173,7 @@ where:
 * stem:[h(...)] creates a 256-bit Blake2 hash from its inner value.
 * stem:[A_l] is the lengths of the authority list (<<defn-authority-list>>).
 
-Then a transcript...
+To create the necessary VRF outputs, a transcript is construced (<<sect-vrf>>).
 
 [stem]
 ++++
@@ -190,9 +189,12 @@ o = s_k * i\
 p larr sf "dleq_prove"(t_6, i)
 ++++
 
-The resulting value stem:[p] is the VRF proof (<<defn-vrf-proof>>).
-stem:["dleq_prove"] is described in <<defn-vrf-dleq-prove>>.
-
+stem:[e_i] is the epoch index (<<defn-epoch-slot>>), stem:[s_k] is the private
+key and stem:[p_k] is the public key of the authority. stem:["dleq_prove"] is
+described in <<defn-vrf-dleq-prove>>. Values stem:[o] and stem:[p] are then used
+in the Pre-Digest item (<<defn-babe-header>>). In case of secondary slots with
+plain outputs, respectively the Pre-Digest being of value _2_, the transcript is
+skipped.
 ****
 
 [#sect-slot-number-calculation]

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -79,6 +79,7 @@ submit those to the Runtime as described in
 <<sect-babeapi_submit_report_equivocation_unsigned_extrinsic>>.
 ====
 
+[#sect-block-production-lottery]
 ==== Block Production Lottery
 
 The babe constant (<<defn-babe-constant>>) is initialized at genesis to the
@@ -93,6 +94,11 @@ it is awarded. These are the slots during which the block producer is allowed to
 build a block. The stem:[sk] is the block producer lottery secret key and
 stem:[n] is the index of the epoch for whose slots the block producer is running
 the lottery.
+
+In order to ensure consistent block production, BABE uses secondary slots in
+case no authority won the (primary) block production lottery. Unlike the
+lottery, secondary slot assignees are know upfront publically
+(<<block-production-secondary-slots>>).
 
 [#defn-babe-constant]
 .<<defn-babe-constant, BABE Constant>>
@@ -147,19 +153,17 @@ is required to produce a block. For the definitions of _Epoch-Randomness_
 [#block-production-secondary-slots]
 ===== Secondary Slots
 ****
-In order to ensure consistent block production, BABE uses secondary slots in
-case no authority won the (primary) block production lottery. Unlike the
-lottery, secondary slot assignees are know upfront publically.
-
-The assignee is determined by calculating a specific value, stem:[x], which
-indicates the index in the authority set. The corresponding authority,
+**Secondary slots** work along side primary slot to ensure consistent block
+production, as described in <<sect-block-production-lottery>>. The secondary
+assignee of a block is determined by calculating a specific value, stem:[i_d],
+which indicates the index in the authority set. The corresponding authority,
 represented by its public key, stem:[a_("id")], has the right to produce a block
 for that slot.
 
 [stem]
 ++++
 p larr h("Enc"_("SC")(r,s))\
-x larr p mod A_l
+i_d larr p mod A_l
 ++++
 
 where:
@@ -347,7 +351,8 @@ P = {(1,->,(a_("id"),s,o,p)),(2,->,(a_("id"),s)),(3,->,(a_("id"),s,o,p)):}
 where:
 
 * _1_ indicates a primary slot with VRF outputs, _2_ a secondary slot with plain
-outputs and _3_ a secondary slot with VRF output.
+outputs and _3_ a secondary slot with VRF output
+(<<sect-block-production-lottery>>).
 * stem:[a_("id")] is the unsigned 32-bit integer indicating the index of the
 authority in the authority set (<<<<sect-authority-set>>>>) who authored the
 block.

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -334,22 +334,22 @@ during that epoch. The produced block needs to carry the _BABE header_
 (<<defn-block-signature>>) as Pre-Runtime and Seal digest items.
 
 [#defn-babe-header]
-.<<defn-babe-header, BABE Header>>
+.<<defn-babe-header, Pre-Digest>>
 ====
-The *BABE Header* of block stem:[B], referred to formally by
-stem:[H_("BABE")(B)] is a tuple and consists of the following components:
+The *Pre-Digest*, or BABE header, of, stem:["P"], is a varying datatype of the
+following format:
 
 [stem]
 ++++
-(d,pi,j,s)
+P = {(1,->,(a_("id"),s,o,p)),(2,->,(a_("id"),s)),(3,->,(a_("id"),s,o,p)):}
 ++++
 
 where:
 
-* stem:[pi, d] are the results of the block lottery for slot stem:[s].
-* stem:[j] is the index of the block producer in the authority directory of the
-current epoch.
-* stem:[s] is the slot at which the block is produced.
+* stem:[a_("id")] is the unsigned 32
+* stem:[s] is ...
+* stem:[o] is ...
+* stem:[p] is ...
 
 stem:[H_("BABE")(B)] must be included as a digest item of Pre-Runtime type in
 the header digest (<<defn-digest>>) stem:[H_d(B)].

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -99,7 +99,8 @@ In order to ensure consistent block production, BABE uses secondary slots in
 case no authority won the (primary) block production lottery. Unlike the
 lottery, secondary slot assignees are know upfront publically
 (<<block-production-secondary-slots>>). The Runtime dictates what types of
-rounds to execute (<<sect-rte-babeapi-epoch>>).
+secondary slots to execute (<<sect-rte-babeapi-epoch>>), explained further in
+<<block-production-secondary-slots>>.
 
 [#defn-babe-constant]
 .<<defn-babe-constant, BABE Constant>>
@@ -187,7 +188,8 @@ If stem:[i_d] points to the authority, that authority must claim the secondary
 slot by creating a BABE VRF transcript (<<defn-babe-vrf-transcript>>). The
 resulting values stem:[o] and stem:[p] are then used in the Pre-Digest item
 (<<defn-babe-header>>). In case of secondary slots with plain outputs,
-respectively the Pre-Digest being of value _2_, the transcript is skipped.
+respectively the Pre-Digest being of value _2_, the transcript respectively the
+VRF is skipped.
 ****
 
 [#defn-babe-vrf-transcript]

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -144,6 +144,34 @@ is required to produce a block. For the definitions of _Epoch-Randomness_
 (<<defn-epoch-randomness>>) and _VRF_ functions (<<sect-vrf>>).
 ****
 
+[#algo-block-production-secondary-slots]
+===== Secondary Slots
+****
+In order to ensure consistent block production, BABE uses secondary slots in
+case no authority won the (primary) block production lottery. Unlike the
+lottery, secondary slot assignees are know upfront publically.
+
+The assignee is determined by calculating a specific value, stem:[x], which
+indicates the index in the authority set. The corresponding authority,
+represented by its public key, stem:[a_("id")], has the right to produce a block
+for that slot.
+
+[stem]
+++++
+p larr h("Enc"_("SC")(r,s))\
+x larr p mod A_l
+++++
+
+where:
+
+* stem:[r] is the Epoch randomness (<<defn-epoch-randomness>>).
+* stem:[s] is the slot number (<<defn-epoch-slot>>).
+* stem:["Enc"_("SC")(...)] encodes its inner value to the corresponding SCALE value.
+* stem:[h(...)] creates a 256-bit Blake2 hash from its inner value.
+* stem:[A_l] is the lengths of the authority list (<<defn-authority-list>>).
+
+****
+
 [#sect-slot-number-calculation]
 ==== Slot Number Calculation
 

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -129,12 +129,12 @@ for epoch stem:[cc E_n] and stem:[c in (0, 1)] is the BABE constant
 ====
 
 [#algo-block-production-lottery]
-===== Block Production Lottery
+===== Primary Block Production Lottery
 ****
-A block producer aiming to produce a block during stem:[cc E_n] should run
-the Algorithm as defined in <<>> to identify the slots it is awarded. These are
-the slots during which the block producer is allowed to build a block. The
-session secret key, stem:[sk], is the block producer lottery secret key and
+A block producer aiming to produce a block during stem:[cc E_n] should run the
+stem:["Block-Production-Lottery"] algorithm to identify the slots it is awarded.
+These are the slots during which the block producer is allowed to build a block.
+The session secret key, stem:[sk], is the block producer lottery secret key and
 stem:[n] is the index of the epoch for whose slots the block producer is running
 the lottery.
 
@@ -149,6 +149,9 @@ Algorithm: stem:["Block-Production-Lottery"(sk)]
 For any slot stem:[i] in epoch stem:[n] where stem:[d < r], the block producer
 is required to produce a block. For the definitions of _Epoch-Randomness_
 (<<defn-epoch-randomness>>) and _VRF_ functions (<<sect-vrf>>).
+
+Note that the secondary slots (<<block-production-secondary-slots>>) are running
+along side the primary block production lottery.
 ****
 
 [#block-production-secondary-slots]
@@ -185,8 +188,8 @@ t_4 larr "append"(t_3, "'chain randomness'", r)\
 t_5 larr "append"(t_4, "'vrf-nm-pk'", p_k)\
 t_6 larr "meta-ad"(t_5, "'VRFHash'", "False")\
 t_7 larr "meta-ad"(t_6, 64_("le"), "True")\
-i larr "prf"(t_7, "False")\
-o = s_k * i\
+h larr "prf"(t_7, "False")\
+o = s_k * h\
 p larr sf "dleq_prove"(t_6, i)
 ++++
 

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -362,7 +362,7 @@ during that epoch. The produced block needs to carry the _Pre-Digest_
 [#defn-babe-header]
 .<<defn-babe-header, Pre-Digest>>
 ====
-The *Pre-Digest*, or BABE header, of, stem:["P"], is a varying datatype of the
+The *Pre-Digest*, or BABE header, of, stem:[P], is a varying datatype of the
 following format:
 
 [stem]

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -166,6 +166,8 @@ production, as described in <<sect-block-production-lottery>>. The secondary
 assignee of a block is determined by calculating a specific value, stem:[i_d],
 which indicates the index in the authority set (<<defn-authority-list>>). The
 corresponding authority in that set has the right to author a secondary block.
+This calculation is done for every slot in the epoch, stem:[s in sc_n]
+(<<defn-epoch-duration>>).
 
 [stem]
 ++++
@@ -182,29 +184,10 @@ where:
 * stem:[A_l] is the lengths of the authority list (<<defn-authority-list>>).
 
 If stem:[i_d] points to the authority, that authority must claim the secondary
-slot by calculataing the necessary outputs for block production. To create the
-VRF outputs, a transcript is construced (<<sect-vrf>>).
-
-[stem]
-++++
-t_1 larr "Transcript"("'BABE'")\
-t_2 larr "append"(t_1, "'slot number'", s)\
-t_3 larr "append"(t_2, "'current epoch'", e_i)\
-t_4 larr "append"(t_3, "'chain randomness'", r)\
-t_5 larr "append"(t_4, "'vrf-nm-pk'", p_k)\
-t_6 larr "meta-ad"(t_5, "'VRFHash'", "False")\
-t_7 larr "meta-ad"(t_6, 64_("le"), "True")\
-h larr "prf"(t_7, "False")\
-o = s_k * h\
-p larr sf "dleq_prove"(t_6, i)
-++++
-
-stem:[e_i] is the epoch index (<<defn-epoch-slot>>), stem:[s_k] is the private
-key and stem:[p_k] is the public key of the authority. stem:["dleq_prove"] is
-described in <<defn-vrf-dleq-prove>>. Values stem:[o] and stem:[p] are then used
-in the Pre-Digest item (<<defn-babe-header>>). In case of secondary slots with
-plain outputs, respectively the Pre-Digest being of value _2_, the transcript is
-skipped.
+slot by creating a BABE VRF transcript (<<defn-babe-vrf-transcript>>). The
+resulting values stem:[o] and stem:[p] are then used in the Pre-Digest item
+(<<defn-babe-header>>). In case of secondary slots with plain outputs,
+respectively the Pre-Digest being of value _2_, the transcript is skipped.
 ****
 
 [#defn-babe-vrf-transcript]

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -381,7 +381,7 @@ outputs and _3_ a secondary slot with VRF outputs
 and only exist for backwards compatibility reasons, respectively to sync old
 blocks.
 * stem:[a_("id")] is the unsigned 32-bit integer indicating the index of the
-authority in the authority set (<<<<sect-authority-set>>>>) who authored the
+authority in the authority set (<<sect-authority-set>>) who authored the
 block.
 * stem:[s] is the slot number (<<defn-epoch-slot>>).
 * stem:[o] is VRF output (<<algo-block-production-lottery>> respectively

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -370,7 +370,7 @@ following format:
 
 [stem]
 ++++
-P = {(1,->,(a_("id"),s,o,p)),(2,->,(a_("id"),s)),(3,->,(a_("id"),s,o,p)):}
+P = {(1,->,(a_"id",s,o,p)),(2,->,(a_"id",s)),(3,->,(a_"id",s,o,p)):}
 ++++
 
 where:
@@ -380,7 +380,7 @@ outputs and _3_ a secondary slot with VRF outputs
 (<<sect-block-production-lottery>>). Plain outputs are no longer actively used
 and only exist for backwards compatibility reasons, respectively to sync old
 blocks.
-* stem:[a_("id")] is the unsigned 32-bit integer indicating the index of the
+* stem:[a_"id"] is the unsigned 32-bit integer indicating the index of the
 authority in the authority set (<<sect-authority-set>>) who authored the
 block.
 * stem:[s] is the slot number (<<defn-epoch-slot>>).
@@ -405,7 +405,7 @@ Algorithm: stem:["Invoke-Block-Authoring"(sk, pk, n, "BT")]
 . stem:["    " "if " d < r]
 . stem:["    " "    " C_("Best") larr "Longest-Chain"("BT")]
 . stem:["    " "    " B_s larr "Build-Block"(C_("Best"))]
-. stem:["    " "    " "Add-Digest-Item"(B_s, "Pre-Runtime", E_("id")("BABE"),H_("BABE")(B_s))]
+. stem:["    " "    " "Add-Digest-Item"(B_s, "Pre-Runtime", E_"id"("BABE"),H_("BABE")(B_s))]
 . stem:["    " "    " "Add-Digest-Item"(B_s, "Seal", S_B)]
 . stem:["    " "    " "Broadcast-Block"(B_s)]
 
@@ -434,7 +434,7 @@ stem:[S_B] should be included in stem:[H_d(B)] as the Seal digest item
 (E_(id)("BABE"),S_B)
 ++++
 
-in which, stem:[E_("id")("BABE")] is the BABE consensus engine unique identifier
+in which, stem:[E_"id"("BABE")] is the BABE consensus engine unique identifier
 (<<defn-consensus-message-digest>>). The Seal digest item is referred to as the
 *BABE Seal*.
 ====

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -353,8 +353,10 @@ P = {(1,->,(a_("id"),s,o,p)),(2,->,(a_("id"),s)),(3,->,(a_("id"),s,o,p)):}
 where:
 
 * _1_ indicates a primary slot with VRF outputs, _2_ a secondary slot with plain
-outputs and _3_ a secondary slot with VRF output
-(<<sect-block-production-lottery>>).
+outputs and _3_ a secondary slot with VRF outputs
+(<<sect-block-production-lottery>>). Plain outputs are no longer actively used
+and only exist for backwards compatibility reasons, respectively to sync old
+blocks.
 * stem:[a_("id")] is the unsigned 32-bit integer indicating the index of the
 authority in the authority set (<<<<sect-authority-set>>>>) who authored the
 block.

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -144,7 +144,7 @@ is required to produce a block. For the definitions of _Epoch-Randomness_
 (<<defn-epoch-randomness>>) and _VRF_ functions (<<sect-vrf>>).
 ****
 
-[#algo-block-production-secondary-slots]
+[#block-production-secondary-slots]
 ===== Secondary Slots
 ****
 In order to ensure consistent block production, BABE uses secondary slots in
@@ -329,7 +329,7 @@ stem:[s_(qc)]and expressed in the number of slots.
 ==== Block Production
 Throughout each epoch, each block producer should run Algorithm as defined in
 <<algo-block-production>> to produce blocks during the slots it has been awarded
-during that epoch. The produced block needs to carry the _BABE header_
+during that epoch. The produced block needs to carry the _Pre-Digest_
 (<<defn-babe-header>>) as well as the _block signature_
 (<<defn-block-signature>>) as Pre-Runtime and Seal digest items.
 
@@ -346,13 +346,19 @@ P = {(1,->,(a_("id"),s,o,p)),(2,->,(a_("id"),s)),(3,->,(a_("id"),s,o,p)):}
 
 where:
 
-* stem:[a_("id")] is the unsigned 32
-* stem:[s] is ...
-* stem:[o] is ...
-* stem:[p] is ...
+* _1_ indicates a primary slot with VRF outputs, _2_ a secondary slot with plain
+outputs and _3_ a secondary slot with VRF output.
+* stem:[a_("id")] is the unsigned 32-bit integer indicating the index of the
+authority in the authority set (<<<<sect-authority-set>>>>) who authored the
+block.
+* stem:[s] is the slot number (<<defn-epoch-slot>>).
+* stem:[o] is VRF output (<<algo-block-production-lottery>> respectively
+<<block-production-secondary-slots>>).
+* stem:[p] is VRF proof (<<algo-block-production-lottery>> respectively
+<<block-production-secondary-slots>>).
 
-stem:[H_("BABE")(B)] must be included as a digest item of Pre-Runtime type in
-the header digest (<<defn-digest>>) stem:[H_d(B)].
+The Pre-Digest must be included as a digest item of Pre-Runtime type in the
+header digest (<<defn-digest>>) stem:[H_d(B)].
 ====
 
 [#algo-block-production]

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -98,9 +98,9 @@ the lottery.
 In order to ensure consistent block production, BABE uses secondary slots in
 case no authority won the (primary) block production lottery. Unlike the
 lottery, secondary slot assignees are know upfront publically
-(<<block-production-secondary-slots>>). The Runtime dictates what types of
-secondary slots to execute (<<sect-rte-babeapi-epoch>>), explained further in
-<<block-production-secondary-slots>>.
+(<<block-production-secondary-slots>>). The Runtime provides information on how
+or if secondary slots are executed (<<sect-rte-babeapi-epoch>>), explained
+further in <<block-production-secondary-slots>>.
 
 [#defn-babe-constant]
 .<<defn-babe-constant, BABE Constant>>

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -156,7 +156,8 @@ any slot stem:[s] in epoch stem:[n] where stem:[d < r], the block producer is
 required to produce a block.
 
 Note that the secondary slots (<<block-production-secondary-slots>>) are running
-along side the primary block production lottery.
+along side the primary block production lottery and mainly serve as a fallback
+to in case no authority was selected in the primary lottery.
 ****
 
 [#block-production-secondary-slots]

--- a/01_host/06_anv/approval-voting.adoc
+++ b/01_host/06_anv/approval-voting.adoc
@@ -183,14 +183,13 @@ t_3 larr sf "append"(t_2, "'core'",c_i)\
 t_4 larr "append"(t_3, "'vrf-nm-pk'", p_k)\
 t_5 larr "meta-ad"(t_4, "'VRFHash'", "False")\
 t_6 larr "meta-ad"(t_5, 64_("le"), "True")\
-i larr larr "prf"(t_6, "False")\
+i "prf"(t_6, "False")\
 o = s_k * i\
-(p,x) larr sf "dleq_prove"(t_6, i)
+p larr sf "dleq_prove"(t_6, i)
 ++++
 
-The resulting values stem:[h] and stem:[p] are the VRF input/output pair
-respectively the VRF proof (<<defn-vrf-proof>>). stem:["dleq_prove"] is
-described in <<defn-vrf-dleq-prove>>.
+The resulting value stem:[p] is the VRF proof (<<defn-vrf-proof>>).
+stem:["dleq_prove"] is described in <<defn-vrf-dleq-prove>>.
 
 The tranche, stem:[d], is determined as:
 

--- a/ac_runtime-api/modules/babe.adoc
+++ b/ac_runtime-api/modules/babe.adoc
@@ -41,11 +41,11 @@ type at genesis will be used. Dynamic slot duration may be supported in the futu
 |The randomness for the genesis epoch
 |32-byte array
 
-|_AllowedSlots_
-|Whether this chain should run with secondary slots and wether they are assigned
-in a round-robin manner or via a second VRF (<<sect-block-production-lottery>>).
+|_SecondarySlot_
+|Whether this chain should run with round-robin-style secondary slot and if this secondary slot
+requires the inclusion of an auxilary VRF output (<<sect-block-production-lottery>>).
 |A varying datatype of the following format:
-stem:[{(0,->,phi),(1,->,"secondary with plain outputs"),(2,->,"secondary with VRF outputs"):}]
+stem:[{(0,->,phi),(1,->,"plain secondary slot"),(2,->,"secondary slot with VRF output"):}]
 |===
 
 ==== `BabeApi_current_epoch_start`

--- a/ac_runtime-api/modules/babe.adoc
+++ b/ac_runtime-api/modules/babe.adoc
@@ -41,10 +41,11 @@ type at genesis will be used. Dynamic slot duration may be supported in the futu
 |The randomness for the genesis epoch
 |32-byte array
 
-|_SecondarySlot_
+|_AllowedSlots_
 |Whether this chain should run with secondary slots and wether they are assigned
-in a round-robin manner or via a second VRF.
-| 8bit enum
+in a round-robin manner or via a second VRF (<<sect-block-production-lottery>>).
+|A varying datatype of the following format:
+stem:[{(0,->,"primary slots"),(1,->,"primary & secondary with plain outputs"),(2,->,"primary & secondary with VRF outputs"):}]
 |===
 
 ==== `BabeApi_current_epoch_start`

--- a/ac_runtime-api/modules/babe.adoc
+++ b/ac_runtime-api/modules/babe.adoc
@@ -45,7 +45,7 @@ type at genesis will be used. Dynamic slot duration may be supported in the futu
 |Whether this chain should run with secondary slots and wether they are assigned
 in a round-robin manner or via a second VRF (<<sect-block-production-lottery>>).
 |A varying datatype of the following format:
-stem:[{(0,->,"primary slots"),(1,->,"primary & secondary with plain outputs"),(2,->,"primary & secondary with VRF outputs"):}]
+stem:[{(0,->,phi),(1,->,"secondary with plain outputs"),(2,->,"secondary with VRF outputs"):}]
 |===
 
 ==== `BabeApi_current_epoch_start`


### PR DESCRIPTION
Fixes #233.

Note that I'll have to update the primary slots section since we expanded our VRF definitions since it was last written. I will do that in a separate PR.

![image](https://user-images.githubusercontent.com/42901763/159926803-51858fe2-6edd-40a8-93d0-dac5d6858143.png)

![image](https://user-images.githubusercontent.com/42901763/159926847-164c3c20-9af7-47c7-b92d-e4c679adde9a.png)

![image](https://user-images.githubusercontent.com/42901763/159939141-cbfc5521-32e1-42e0-856f-238edb1450d0.png)
