### PR TITLE
Incoperate feedback from parity customer

### DIFF
--- a/01_host/01_background/definitions.adoc
+++ b/01_host/01_background/definitions.adoc
@@ -88,14 +88,14 @@ For a given byte stem:[b] the *bitwise representation* of stem:[b] is defined as
 
 [stem]
 ++++
-b :=b^7 ... b^0
+b :=b_7 ... b_0
 ++++
 
 where
 
 [stem]
 ++++
-b = 2^0 b^0 + 2^1 b^1 + ... + 2^7 b^7
+b = 2_0 b_0 + 2_1 b_1 + ... + 2_7 b_7
 ++++
 ====
 

--- a/01_host/02_state/state_storage_trie.adoc
+++ b/01_host/02_state/state_storage_trie.adoc
@@ -55,7 +55,7 @@ the nodes on the path or implicitly in their position as a child of their
 parent.
 
 To identify the node corresponding to a key value, stem:[k], first we need to
-encode stem:[k] in a consistent with the Trie structure way. Because each node
+encode stem:[k] to be consistent with the Trie structure way. Because each node
 in the trie has at most 16 children, we represent the key as a sequence of 4-bit
 nibbles:
 

--- a/01_host/03_transition/runtime_interaction.adoc
+++ b/01_host/03_transition/runtime_interaction.adoc
@@ -174,7 +174,7 @@ global state of the system from being influence by the call to such a Runtime
 entry. This includes reverting the state of function calls which return errors
 or panic.
 
-As a rule of thumb, any state changes resulting from Runtime enteries are not
+As a rule of thumb, any state changes resulting from Runtime entries are not
 persistant with the exception of state changes resulting from calling
 `Core_execute_block` (<<sect-rte-core-execute-block>>) while Polkadot Host is
 importing a block (<<sect-block-validation>>).

--- a/01_host/03_transition/state_replication.adoc
+++ b/01_host/03_transition/state_replication.adoc
@@ -152,7 +152,7 @@ The Polkadot Host implements the Algorithm as defined in
 ****
 Algorithm: stem:["Import-And-Validate-Block"(B, "Just"(B))]
 
-. stem:["Set-Storage-State-At"(P(B))]
+. stem:["Set-State-At"(P(B))]
 . stem:["if Just"(B) != 0]
 . stem:["    " "Verify-Block-Justification"(B, "Just"(B))]
 . stem:["    " "if " B " is Finalized and " P(B) " is not Finalized"]

--- a/01_host/04_networking/fundamentals.adoc
+++ b/01_host/04_networking/fundamentals.adoc
@@ -221,7 +221,7 @@ blocks to connected peers. This is a _Notification substream_.
 +
 The messages are specified in <<sect-msg-block-announce>>.
 * `/dot/sync/2` - a request and response protocol that allows the Polkadot Host
-to perform information about blocks. This is a _Request-Response substream_.
+to request information about blocks. This is a _Request-Response substream_.
 +
 The messages are specified in <<sect-msg-block-request>>.
 * `/dot/transactions/1` - a substream/notification protocol which sends

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -168,11 +168,12 @@ to the rest of the network.
 
 This estimation depends on the two fixed parameters stem:[k]
 (<<defn-prunned-best>>) and stem:[s_(cq)] (<<defn-chain-quality>>). These are
-chosen based on the results of a formal security analysis, currently assuming a
-stem:[1 s]clock drift per day and targeting a probability lower than stem:[0.5%]
-for an adversary to break BABE in 3 years with resistance against a network
-delay up to stem:[1 / 3] of the slot time and a Babe constant
-(<<defn-babe-constant>>) of stem:[c = 0.38].
+chosen based on the results of a
+https://research.web3.foundation/en/latest/polkadot/block-production/Babe.html#-5.-security-analysis[formal
+security analysis], currently assuming a stem:[1 s] clock drift per day and
+targeting a probability lower than stem:[0.5%] for an adversary to break BABE in
+3 years with resistance against a network delay up to stem:[1 / 3] of the slot
+time and a Babe constant (<<defn-babe-constant>>) of stem:[c = 0.38].
 
 All validators are then required to run Algorithm as defined in
 <<algo-slot-time>> at the beginning of each sync period (<<defn-sync-period>>)

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -97,9 +97,10 @@ the lottery.
 [#defn-babe-constant]
 .<<defn-babe-constant, BABE Constant>>
 ====
-The *BABE constant* stem:[c in (0,1)] is the probability that a slot will not be
-empty and used in the winning threshold calculation
-(<<defn-winning-threshold>>).
+The *BABE constant* is the probability that a slot will not be empty and used in
+the winning threshold calculation (<<defn-winning-threshold>>). It's expressed
+as a rational, stem:[(x, y)], where stem:[x] is the numerator and stem:[y] is
+the denominator.
 ====
 
 [#defn-winning-threshold]


### PR DESCRIPTION
Fixes #492 .

## Status

 - [x] p.13 2nd paragraph "and is designed and be upgradable" - should be "and is designed to be upgradable"?
   - _This was already changed on `develop`_
 - [x] p.14 definition 1.6 the b's should have subscripted numbers, not exponentials? e.g. see 1.7
 - [x] p. 17 2.1.2 4th paragraph "in a consistent with the Trie structure way"
 - [x] p.25 3.1.2.4 2nd paragraph "any state changes resulting from Runtime enteries"
 - [x] p.25 3.2.1 3rd paragraph "the internals of each intrinsics"
   - _This is already fixed on the latest `develop`
 - [x] p.27 definition 3.6 "The header of block B, Head(B)" - there is already a definiton for "Head(B)" in definition 1.13 - this confused me.
   - _We kind of define `B := Head(C)`, head of chain `C`, but never actually use it? At the same time we define `Head(B)` to be the block header of block `B`. So this is indeed confusing. I guess we can remove `B := Head(C)` or change it?_
 - [x] p.29 alg 3.4 I believe "Set-Storage-State-At" is actually supposed to be "Set-State-At" ? For instance, see Definition 3.10 same page.
 - [x] p.36 4th bullet "to perform information about blocks" - should be request, maybe?
 - [x] p.48 def 6.11 confused me, "c ∈ (0,1)" - I did not grok that as the range of 0 to 1 but as the set of 0,1 "{0,1}?". This is probably a notational failure on my end but perhaps I'm not unique.
   - This is kind of confusing, indeed. Rust code: `pub c: (u64, u64)`. I adjusted this to: "[...] It’s expressed as a rational, (𝑥,𝑦), where 𝑥 is the numerator and 𝑦 is the denominator.".
 - [x] p.49 3rd paragraph from note 6.15 - "formal security analysis" is a pretty big claim, should back that up with a link to said analysis.
   - _Referenced the W3F research paper on BABE_.
- [x] p.64 7.2 Preliminaries - "The SCALE codec is defined in a separate document known as ``The Polkadot Host - Protocol Specification''. - Infact, that's the very document we're reading, should probably link to the appendix B.
  - _This was already changed on `develop`_