### PR TITLE
Fix block header digest item and consensus message

### DIFF
--- a/01_host/03_transition/state_replication.adoc
+++ b/01_host/03_transition/state_replication.adoc
@@ -60,25 +60,33 @@ where each digest item can hold one of the following type identifiers:
 
 [stem]
 ++++
-H_d^n = {(2,bbb B_32),(4,(E_("id"),bbb B)),(5,(E_("id"),bbb B)),(6,(E_("id"),bbb B)):}
+H_d^n = {
+	(0,m),
+	(4,(E_("id"),"CM")),
+	(5,(E_("id"),S)),
+	(6,(E_("id"),P)),
+	(8,phi)
+	:}
 ++++
 
 Where stem:[E_(id)] is the unique consensus engine identifier
 (<<defn-consensus-message-digest>>) and stem:[bbb B]:
 
-* Id _2_, the *Changes trie root*, contains the root of the Changes Trie at
-block stem:[B] (<<sect-changes-trie>>). Note that this is future-reserved and
-currently *not* used in Polkadot.
-* Id _4_, the *Consensus Message*, represents messages from the Runtime to the
+* Id _0_, the *non-system item*, which is opaque to the native code. stem:[m] is
+an opaque byte array.
+* Id _4_, the *Consensus Message*, contains messages from the Runtime to the
 consensus engine (<<sect-consensus-message-digest>>).
 * Id _5_, the *Seal*, is the data produced by the consensus engine and proving
-the authorship of the block producer. In particular, the Seal digest item must
-be the last item in the digest array and must be stripped off by the Polkadot
-Host before the block is submitted to any Runtime function including for
-validation. The Seal (defn-babe-seal) must be added back to the digest
-afterward.
-* Id _6_, the *Pre-runtime* digest, represents messages from a consensus engine
-to the Runtime (e.g. <<defn-babe-header>>).
+the authorship of the block producer, where stem:[S] is the signature
+(<<defn-block-signature>>) of the block author. In particular, the Seal digest
+item must be the last item in the digest array and must be stripped off by the
+Polkadot Host before the block is submitted to any Runtime function including
+for validation. The Seal must be added back to the digest afterward.
+* Id _6_, the *Pre-Runtime* digest, contains the BABE Pre-Digest item
+(<<defn-babe-header>>).
+* Id _8_, the *Runtime Environment Updated* digest, indicates that changes
+regarding the Runtime code or heap pages (<<sect-memory-management>>) occured.
+No additional data is provided.
 ====
 
 [#defn-block-header-hash]

--- a/01_host/03_transition/state_replication.adoc
+++ b/01_host/03_transition/state_replication.adoc
@@ -63,7 +63,7 @@ where each digest item can hold one of the following type identifiers:
 H_d^n = {
 	(0,m),
 	(4,(E_("id"),"CM")),
-	(5,(E_("id"),S)),
+	(5,(E_("id"),S_B)),
 	(6,(E_("id"),P)),
 	(8,phi)
 	:}
@@ -77,8 +77,8 @@ an opaque byte array.
 * Id _4_, the *Consensus Message*, contains messages from the Runtime to the
 consensus engine (<<sect-consensus-message-digest>>).
 * Id _5_, the *Seal*, is the data produced by the consensus engine and proving
-the authorship of the block producer, where stem:[S] is the signature
-(<<defn-block-signature>>) of the block author. In particular, the Seal digest
+the authorship of the block producer. Respectively, stem:[S_B] is the signature
+(<<defn-block-signature>>) of the block producer. In particular, the Seal digest
 item must be the last item in the digest array and must be stripped off by the
 Polkadot Host before the block is submitted to any Runtime function including
 for validation. The Seal must be added back to the digest afterward.

--- a/01_host/03_transition/state_replication.adoc
+++ b/01_host/03_transition/state_replication.adoc
@@ -72,7 +72,7 @@ H_d^n = {
 Where stem:[E_(id)] is the unique consensus engine identifier
 (<<defn-consensus-message-digest>>) and stem:[bbb B]:
 
-* Id _0_, the *non-system item*, which is opaque to the native code. stem:[m] is
+* Id _0_, the *Non-System* digest, which is opaque to the native code. stem:[m] is
 an opaque byte array.
 * Id _4_, the *Consensus Message*, contains messages from the Runtime to the
 consensus engine (<<sect-consensus-message-digest>>).

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -98,9 +98,9 @@ the lottery.
 In order to ensure consistent block production, BABE uses secondary slots in
 case no authority won the (primary) block production lottery. Unlike the
 lottery, secondary slot assignees are know upfront publically
-(<<block-production-secondary-slots>>). The Runtime provides information on how
+(<<defn-babe-secondary-slots>>). The Runtime provides information on how
 or if secondary slots are executed (<<sect-rte-babeapi-epoch>>), explained
-further in <<block-production-secondary-slots>>.
+further in <<defn-babe-secondary-slots>>.
 
 [#defn-babe-constant]
 .<<defn-babe-constant, BABE Constant>>
@@ -155,12 +155,12 @@ stem:[p_k] is the secret key respectively the public key of the authority. For
 any slot stem:[s] in epoch stem:[n] where stem:[d < r], the block producer is
 required to produce a block.
 
-Note that the secondary slots (<<block-production-secondary-slots>>) are running
+Note that the secondary slots (<<defn-babe-secondary-slots>>) are running
 along side the primary block production lottery and mainly serve as a fallback
 to in case no authority was selected in the primary lottery.
 ****
 
-[#block-production-secondary-slots]
+[#defn-babe-secondary-slots]
 ===== Secondary Slots
 ****
 **Secondary slots** work along side primary slot to ensure consistent block
@@ -199,7 +199,7 @@ VRF is skipped.
 The BABE block production lottery requires a specific transcript structure
 (<<defn-vrf-transcript>>). That structure is used by both primary slots
 (<<algo-block-production-lottery>>) and secondary slots
-(<<block-production-secondary-slots>>).
+(<<defn-babe-secondary-slots>>).
 
 [stem]
 ++++
@@ -385,9 +385,9 @@ authority in the authority set (<<sect-authority-set>>) who authored the
 block.
 * stem:[s] is the slot number (<<defn-epoch-slot>>).
 * stem:[o] is VRF output (<<algo-block-production-lottery>> respectively
-<<block-production-secondary-slots>>).
+<<defn-babe-secondary-slots>>).
 * stem:[p] is VRF proof (<<algo-block-production-lottery>> respectively
-<<block-production-secondary-slots>>).
+<<defn-babe-secondary-slots>>).
 
 The Pre-Digest must be included as a digest item of Pre-Runtime type in the
 header digest (<<defn-digest>>) stem:[H_d(B)].
@@ -450,9 +450,11 @@ stem:[cc E_(n+1)] from the Runtime, through the consensus message
 [#defn-epoch-randomness]
 .<<defn-epoch-randomness, Randomness Seed>>
 ====
-For epoch stem:[cc E], there is a 32-byte stem:[cc R_(cc E)] computed
-based on the previous epochs VRF outputs. For stem:[cc E_0] and stem:[cc
-E_1], the randomness seed is provided in the genesis state.
+For epoch stem:[cc E], there is a 32-byte stem:[cc R_(cc E)] computed based on
+the previous epochs VRF outputs. For stem:[cc E_0] and stem:[cc E_1], the
+randomness seed is provided in the genesis state (<<sect-rte-babeapi-epoch>>).
+For any further epochs, the randomness is retrieved from the consensus message
+(<<defn-consensus-message-digest>>).
 ====
 
 [#sect-verifying-authorship]

--- a/01_host/05_consensus/block_production.adoc
+++ b/01_host/05_consensus/block_production.adoc
@@ -365,7 +365,7 @@ during that epoch. The produced block needs to carry the _Pre-Digest_
 [#defn-babe-header]
 .<<defn-babe-header, Pre-Digest>>
 ====
-The *Pre-Digest*, or BABE header, of, stem:[P], is a varying datatype of the
+The *Pre-Digest*, or BABE header, stem:[P], is a varying datatype of the
 following format:
 
 [stem]

--- a/01_host/05_consensus/common.adoc
+++ b/01_host/05_consensus/common.adoc
@@ -68,7 +68,7 @@ string which serves as an identifier.
 "CM" = {(,("'BABE'", "CM"_b)),(,("'FRNK'", "CM"_g)),(,("'BEEF'", "CM"_y)):}
 ++++
 
-stem:["CM"_b], the consensus message for GRANDPA, is of the following format:
+stem:["CM"_b], the consensus message for BABE, is of the following format:
 
 [stem]
 ++++

--- a/01_host/05_consensus/common.adoc
+++ b/01_host/05_consensus/common.adoc
@@ -59,78 +59,81 @@ came into effect would get rejected.
 [#defn-consensus-message-digest]
 .<<defn-consensus-message-digest, Consensus Message>>
 ====
-A *consensus message* is a digest item (<<defn-digest>>) of type _4_ and
-consists of the pair:
+A *consensus message*, stem:["CM"], is a digest item (<<defn-digest>>) of type
+_4_ and consists one of the following tuple pairs, where the first item is a
+string which serves as an identifier.
 
 [stem]
 ++++
-(E_("id"), CM)
+"CM" = {(,("'BABE'", "CM"_b)),(,("'FRNK'", "CM"_g)),(,("'BEEF'", "CM"_y)):}
 ++++
 
-where stem:[E_("id") in bbb B_4] is the consensus engine unique identifier
-which can hold the following possible values
-
-[stem]
-++++
-E_("id") = {("'BABE'"),("'FRNK'"):}
-++++
-
-where stem:["'BABE'"] is for messages related to the BABE protocol, referred to
-as stem:[E_("id")("BABE")] and stem:["'FRNK"] is for messages related to the
-GRANDPA protocol, referred to as stem:[E_("id")("FRNK")]. stem:[CM] is a varying
-datatype (<<defn-varrying-data-type>>) which can be one of the following values,
-appended by additional data:
+stem:["CM"_b], the consensus message for GRANDPA, is of the following format:
 
 [stem]
 ++++
-CM = {(1, ("Auth"_("BABE"),R)),(2,"Auth"_("id")),(3,(c,s_("2nd"))):}
+"CM"_b = {(1,("Auth"_C, r)),(2,A_i),(3,D):}
 ++++
 
 where
 
-* stem:[CM]:
-+
-** _1_ implies *next epoch data*: The Runtime issues this message on every first
-block of an epoch stem:[cc E_n]. The supplied authority set and randomness are
-intended to be used in the next epoch stem:[cc E_n + 1].  
-** _2_ implies *on disabled*: 
-*This message is currently ignored by the Polkadot Host and will be for the forseeable future.* 
-An index to the individual authority in the current authority list that should
-be immediately disabled until the next authority set changes. This message 
-initial intension was to cause an imediatly suspension of all authority 
-functionality with the specified  authority.
-** _3_ implies *next config data*: These messages are only issued on
+* _1_ implies *next epoch data*: The Runtime issues this message on every first
+block of an epoch. The supplied authority set (<<defn-authority-list>>),
+stem:["Auth"_C], and randomness (<<defn-epoch-randomness>>), stem:[r], are used
+in the next epoch stem:[cc E_n + 1].
+* _2_ implies *on disabled*: A 32-bit integer, stem:[A_i], indicating the
+individual authority in the current authority list that should be immediately
+disabled until the next authority set changes. This message initial intension
+was to cause an imediatly suspension of all authority functionality with the
+specified authority.
+* _3_ implies *next epoch descriptor*: These messages are only issued on
 configuration change and in the first block of an epoch. The supplied
 configuration data are intended to be used from the next epoch onwards.
-* stem:["Auth"_("BABE")] is the authority list (<<defn-authority-list>>) for the next epoch.
-* stem:[R] is the 32-byte randomness seed for the next epoch (<<defn-epoch-randomness>>).
-* stem:["Auth"_("id")] is an unsigned 64-bit integer pointing to an individual
-authority in the current authority list.
-* stem:[c] is the probability that a slot will not be empty
-(<<defn-babe-constant>>). It is encoded as a tuple of two unsigned 64-bit
-integers stem:[(c_("nominator"),c_("denominator"))] which are used to compute
-the rational stem:[c = c_("nominator")/c_("denominator")].
-* stem:[s_("2nd")] is a varying datatype followed by additional data indicating
-the second slot configuration:
++
+stem:[D] is a varying datatype of the following format:
 +
 [stem]
 ++++
-s_("2nd") = {(1,("Auth"_C,N_("delay"))),(2,("Auth"_C,N_("delay"))),(3,"Auth"_("id")),(4,N_("delay")),(5,N_("delay")):}
+D = {(1, (c,2_("nd"))):}
 ++++
 +
-where:
+where stem:[c] is the probability that a slot will not be empty
+(<<defn-babe-constant>>). It is encoded as a tuple of two unsigned 64-bit
+integers stem:[(c_("nominator"),c_("denominator"))] which are used to compute
+the rational stem:[c = c_("nominator")/c_("denominator")].
 +
-** stem:[Auth_C] is the authority list (<<defn-authority-list>>).
-** stem:[N_("delay")] is an unsigned 32-bit integer indicating how deep in the
+stem:[2_("nd")] describes what secondary slot (<<defn-babe-secondary-slots>>),
+if any, is to be used. It is encoded as one-byte varying datatype:
++
+[stem]
+++++
+s_"2nd" = {
+	(0,->,"no secondary slot"),
+	(1,->,"plain secondary slot"),
+	(2,->,"secondary slot with VRF output")
+:}
+++++
+
+stem:["CM"_g], the consensus message for GRANDPA, is of the following format:
+
+[stem]
+++++
+"CM"_g = {(1,("Auth"_C,N_("delay"))),(2,("Auth"_C,N_("delay"))),(3,"Auth"_("id")),(4,N_("delay")),(5,N_("delay")):}
+++++
+
+where:
+
+* stem:[Auth_C] is the authority list (<<defn-authority-list>>).
+* stem:[N_("delay")] is an unsigned 32-bit integer indicating how deep in the
 chain the announcing block must be before the change is applied.
-** _1_ implies *scheduled change*: Schedule an authority set change after the
+* _1_ implies *scheduled change*: Schedule an authority set change after the
 given delay of stem:[N_("delay") := |"SubChain"(B,B')|] where stem:[B'] in the
 definition of stem:[N_("delay")], is a block _finalized_ by the finality
 consensus engine. The earliest digest of this type in a single block will be
 respected. No change should be scheduled if one is already finalized and the
 delay has not passed completely. If such an inconsistency occurs, the scheduled
 change should be ignored.
-** _2_ implies *forced change*: Force an authority set change after the given
+* _2_ implies *forced change*: Force an authority set change after the given
 delay of stem:[N_("delay") := |"SubChain"(B,B')|] where stem:[B'] in the
 definition of stem:[N_("delay")], is an _imported_ block that has been validated
 by the block production consensus engine. Hence, the authority changeset is
@@ -140,19 +143,19 @@ authority set change should be disregarded. The earliest digest of this type in
 a single block will be respected. No change should be scheduled if one is
 already finalized and the delay has not passed completely. If such an
 inconsistency occurs, the scheduled change should be ignored.
-** _3_ implies *on disabled*: An index to the individual authority in the
+* _3_ implies *on disabled*: An index to the individual authority in the
 current authority list that should be immediately disabled until the next
 authority set changes. When an authority gets disabled, the node should stop
 performing any authority functionality from that authority, including authoring
 blocks and casting GRANDPA votes for finalization. Similarly, other nodes should
 ignore all messages from the indicated authority which pertain to their
 authority role.
-** _4_ implies *pause*: A signal to pause the current authority set after the
+* _4_ implies *pause*: A signal to pause the current authority set after the
 given delay of stem:[N_("delay") := |"SubChain"(B,B')|] where stem:[B'] in the
 definition of stem:[N_("delay")], is a block _finalized_ by the finality
 consensus engine. After finalizing block stem:[B'], the authorities should stop
 voting.
-** _5_ implies *resume*: A signal to resume the current authority set after the
+* _5_ implies *resume*: A signal to resume the current authority set after the
 given delay of stem:[N_("delay") := |"SubChain"(B,B')|] where stem:[B'] in the
 definition of stem:[N_("delay")], is an _imported_ block and validated by the
 block production consensus engine. After authoring block stem:[B'], the

--- a/01_host/05_consensus/common.adoc
+++ b/01_host/05_consensus/common.adoc
@@ -118,12 +118,11 @@ stem:["CM"_g], the consensus message for GRANDPA, is of the following format:
 
 [stem]
 ++++
-"CM"_g = {(1,("Auth"_C,N_("delay"))),(2,("Auth"_C,N_("delay"))),(3,"Auth"_("id")),(4,N_("delay")),(5,N_("delay")):}
+"CM"_g = {(1,("Auth"_C,N_("delay"))),(2,(m,"Auth"_C,N_("delay"))),(3,"A"_i),(4,N_("delay")),(5,N_("delay")):}
 ++++
 
 where:
 
-* stem:[Auth_C] is the authority list (<<defn-authority-list>>).
 * stem:[N_("delay")] is an unsigned 32-bit integer indicating how deep in the
 chain the announcing block must be before the change is applied.
 * _1_ implies *scheduled change*: Schedule an authority set change after the
@@ -143,6 +142,8 @@ authority set change should be disregarded. The earliest digest of this type in
 a single block will be respected. No change should be scheduled if one is
 already finalized and the delay has not passed completely. If such an
 inconsistency occurs, the scheduled change should be ignored.
++
+NOTE: stem:[m], which indicates the block finalization median, is to-be-defined.
 * _3_ implies *on disabled*: An index to the individual authority in the
 current authority list that should be immediately disabled until the next
 authority set changes. When an authority gets disabled, the node should stop
@@ -160,4 +161,24 @@ given delay of stem:[N_("delay") := |"SubChain"(B,B')|] where stem:[B'] in the
 definition of stem:[N_("delay")], is an _imported_ block and validated by the
 block production consensus engine. After authoring block stem:[B'], the
 authorities should resume voting.
+
+IMPORTANT: The BEEFY protocol is still under construction. The following part will be
+updated in the future and certain information will be clarified.
+
+stem:["CM"_y], the consensus message for BEEFY (<<sect-grandpa-beefy>>), is of
+the following format:
+
+[stem]
+++++
+"CM"_y = {(1,(V_B,V_i)),(2,A_i),(3,R):}
+++++
+
+where:
+
+* _1_ implies that the remote **authorities have changed**. stem:[V_B] is the
+array of the new BEEFY authorities's public keys and stem:[V_i] is the
+identifier of the remote validator set.
+* _2_ implies **on disabled**: an index to the individual authorty in stem:[V_B]
+that should be immediatly disabled until the next authority change.
+* _3_ implies **MMR root**: a 32-byte array containing the MMR root.
 ====

--- a/ac_runtime-api/modules/babe.adoc
+++ b/ac_runtime-api/modules/babe.adoc
@@ -44,26 +44,8 @@ type at genesis will be used. Dynamic slot duration may be supported in the futu
 |_SecondarySlot_
 |Whether this chain should run with round-robin-style secondary slot and if this secondary slot
 requires the inclusion of an auxilary VRF output (<<sect-block-production-lottery>>).
-|A one-byte enum as defined in <<defn-babe-secondary-enum>>. 
+|A one-byte enum as defined in <<defn-consensus-message-digest>> as stem:[2_("nd")]. 
 |===
-
-.Secondary Slot Enum
-[#defn-babe-secondary-enum]
-====
-
-The *BABE Secondary Slot enum* describes what secondary slot, if any, is to be used. 
-It is encoded as one-byte varying datatype:
-
-[asciimath]
-++++
-s_"2nd" = {
-	(0,->,"no secondary slot"),
-	(1,->,"plain secondary slot"),
-	(2,->,"secondary slot with VRF output")
-:}
-++++
-
-====
 
 ==== `BabeApi_current_epoch_start`
 


### PR DESCRIPTION
As discussed. Note that I'll have a meeting with Andre (Parity) and ChainSafe soon, so there will (probably) be upcoming changes regarding the scheduled/forced authority changes. I also added BEEFY to the consensus message definition, which is quite thin tbh.

**Header Digest**

![image](https://user-images.githubusercontent.com/42901763/162284167-71485010-c28b-4318-b44b-62e383df5d56.png)

**Consensus message** (we might want to split this into multiple definitions):

![image](https://user-images.githubusercontent.com/42901763/162285427-edc30c4d-6c82-46ef-9be7-d4b0074834be.png)
