### PR TITLE
Host: State: Node header fixes

### DIFF
--- a/01_host/02_state/state_storage_trie.adoc
+++ b/01_host/02_state/state_storage_trie.adoc
@@ -258,8 +258,8 @@ where::
 .<<defn-node-header, Node Header>>
 ====
 The *node header*, consisting of stem:[>= 1] bytes, stem:[N_1...N_n], specifies
-the node variant and the length of the partial key length (<<defn-node-key>>) in
-4-bit nibbles. Both pieces of information can be represented in bits within a
+the node variant and the partial key length (<<defn-node-key>>).
+Both pieces of information can be represented in bits within a
 single byte, stem:[N_1], where the amount of bits of the variant, stem:[v], and
 the bits of the partial key length, stem:[p_l] varies.
 


### PR DESCRIPTION
- Fix possible typo `length of the partial key length` to `length of the partial key`
- Remove `in 4-bit nibbles` since the node variant can be expressed using 2 to 8 bits, and the partial key length in 2 to 8 bits + N*8 bits

Let me know if I misunderstood anything, I would happy to re-clarify my understanding or the text :+1: