### PR TITLE
Host: State: Node headers containing hashes

### DIFF
--- a/01_host/02_state/state_storage_trie.adoc
+++ b/01_host/02_state/state_storage_trie.adoc
@@ -269,8 +269,8 @@ v = {
     (01, "Leaf", p_l = 2^6),
     (10, "Branch Node with" k_N !in cc K, p_l = 2^6),
     (11, "Branch Node with" k_N in cc K, p_l = 2^6),
-    (001, "Leaf containing hashes", p_l = 2^5),
-    (0001, "Branch containing hashes", p_l = 2^4),
+    (001, "Leaf containing a hashed subvalue", p_l = 2^5),
+    (0001, "Branch containing a hashed subvalue", p_l = 2^4),
     (0000 0000, "Empty", p_l = 0),
     (0001 0000, "Reserved for compact encoding",)
     :}


### PR DESCRIPTION
Correct if I'm wrong but from what I understand, these two new node headers for leaves and branches mean their value is hashed, not that they contain hashes (especially plural hashes)?