### PR TITLE
Fix `ext_default_child_storage_root_version_2` signature

### DIFF
--- a/ab_host-api/child_storage.adoc
+++ b/ab_host-api/child_storage.adoc
@@ -234,7 +234,7 @@ SCALE encoded storage root.
 ----
 (func $ext_default_child_storage_root_version_2
 	(param $child_storage_key i64) (param $version i32)
-	(return i64))
+	(return i32))
 ----
 
 Arguments::


### PR DESCRIPTION
Return `i32` (pointer) instead of `i64` (pointer-size)