### PR TITLE
Change `offset` parameter from `u32` to `i32`

### DIFF
--- a/ab_host-api/child_storage.adoc
+++ b/ab_host-api/child_storage.adoc
@@ -62,7 +62,7 @@ child storage key (<<defn-child-storage-type>>).
 * `value_out`: a pointer-size (<<defn-runtime-pointer-size>>) to the buffer
 to which the value will be written to. This function will never write more then
 the length of the buffer, even if the value’s length is bigger.
-* `offset`: an i32 integer containing the offset beyond the value should be read
+* `offset`: an u32 integer (typed as i32 due to wasm types) containing the offset beyond the value should be read
 from.
 * `result`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Option_ value (<<defn-option-type>>) containing the number of bytes

--- a/ab_host-api/child_storage.adoc
+++ b/ab_host-api/child_storage.adoc
@@ -51,7 +51,7 @@ the number of bytes that the entry in storage has beyond the offset.
 ----
 (func $ext_default_child_storage_read_version_1
 	(param $child_storage_key i64) (param $key i64) (param $value_out i64)
-	(param $offset u32) (result i64))
+	(param $offset i32) (result i64))
 ----
 
 Arguments::
@@ -62,7 +62,7 @@ child storage key (<<defn-child-storage-type>>).
 * `value_out`: a pointer-size (<<defn-runtime-pointer-size>>) to the buffer
 to which the value will be written to. This function will never write more then
 the length of the buffer, even if the value’s length is bigger.
-* `offset`: an u32 integer containing the offset beyond the value should be read
+* `offset`: an i32 integer containing the offset beyond the value should be read
 from.
 * `result`: a pointer-size (<<defn-runtime-pointer-size>>) to the SCALE
 encoded _Option_ value (<<defn-option-type>>) containing the number of bytes

--- a/ab_host-api/storage.adoc
+++ b/ab_host-api/storage.adoc
@@ -65,7 +65,7 @@ Arguments::
 * `value_out`: a pointer-size (<<defn-runtime-pointer-size>>) containing the
 buffer to which the value will be written to. This function will never write
 more then the length of the buffer, even if the value’s length is bigger.
-* `offset`: an i32 integer containing the offset beyond the value should be read
+* `offset`: an u32 integer (typed as i32 due to wasm types) containing the offset beyond the value should be read
 from.
 * `result`: a pointer-size (<<defn-runtime-pointer-size>>) pointing to a SCALE
 encoded _Option_ value (<<defn-option-type>>) containing an unsigned 32-bit

--- a/ab_host-api/storage.adoc
+++ b/ab_host-api/storage.adoc
@@ -57,7 +57,7 @@ offset.
 ===== Version 1 - Prototype
 ----
 (func $ext_storage_read_version_1
-	(param $key i64) (param $value_out i64) (param $offset u32) (result i64))
+	(param $key i64) (param $value_out i64) (param $offset i32) (result i64))
 ----
 
 Arguments::
@@ -65,7 +65,7 @@ Arguments::
 * `value_out`: a pointer-size (<<defn-runtime-pointer-size>>) containing the
 buffer to which the value will be written to. This function will never write
 more then the length of the buffer, even if the value’s length is bigger.
-* `offset`: an u32 integer containing the offset beyond the value should be read
+* `offset`: an i32 integer containing the offset beyond the value should be read
 from.
 * `result`: a pointer-size (<<defn-runtime-pointer-size>>) pointing to a SCALE
 encoded _Option_ value (<<defn-option-type>>) containing an unsigned 32-bit


### PR DESCRIPTION
- WASM does not support `u32`, see
https://www.w3.org/TR/wasm-core-1/#value-types%E2%91%A0
- Affects `ext_default_child_storage_read_version_1`
- Affects `ext_storage_read_version_1`

❓  Although it this offset is meant to be `u32`, this is a bit problematic since in our implementation it's really cut down to the max i32 (due to the function signature) which is lower than max u32. Should we document to treat the 32 bits as `uint32` within the function body? 🤔 