### PR TITLE
extrinsics: Clarify bit positioning

### DIFF
--- a/02_runtime/07-extrinsics.adoc
+++ b/02_runtime/07-extrinsics.adoc
@@ -32,7 +32,7 @@ latexmath:[T_v] is a 8-bit bitfield and defines the extrinsic version. The
 required format of an extrinsic body, latexmath:[T_b], is dictated by the
 Runtime. Older or unsupported version are rejected.
 
-The first bit of latexmath:[T_v] indicates whether the transaction is
+The most significant bit of latexmath:[T_v] indicates whether the transaction is
 *signed* (latexmath:[1]) or *unsigned* (latexmath:[0]). The
 remaining 7-bits represent the version number. As an example, for
 extrinsic format version 4, an signed extrinsic represents


### PR DESCRIPTION
We have noted that the first bit of the extrinsic might cause confusion.

To clarify the documentation, use MSB instead to indicate the signed
or unsigned extrinsic payload. 
