### PR TITLE
Bnb/C1-C2-polishing

### DIFF
--- a/01_host/01_background/01_bootstrapping.adoc
+++ b/01_host/01_background/01_bootstrapping.adoc
@@ -9,7 +9,7 @@ where they are defined. In short, the following steps should be taken by all
 bootstrapping nodes:
 
 . The node must populate the state storage with the official genesis state,
-clarifier further in <<chapter-genesis>>.
+clarified further in <<chapter-genesis>>.
 . The node should maintain a set of around 50 active peers at any time. New
 peers can be found using the discovery protocols (<<sect-discovery-mechanism>>)
 . The node should open and maintain the various required streams

--- a/01_host/01_background/02_definitions.adoc
+++ b/01_host/01_background/02_definitions.adoc
@@ -14,7 +14,7 @@ Formally, it is a tuple of
 ++++
 where
 
-* stem:[\Sigma] is the countable set of all possible transitions.
+* stem:[\Sigma] is the countable set of all possible inputs.
 * stem:[S] is a countable set of all possible states.
 * stem:[s_0 in S] is the initial state.
 * stem:[\delta] is the state-transition function, known as *Runtime* in the

--- a/01_host/02_state/01_state-storage-trie.adoc
+++ b/01_host/02_state/01_state-storage-trie.adoc
@@ -35,7 +35,7 @@ keys and values stored in the state storage. stem:[cc V] can be an empty value.
 ==== The General Tree Structure
 
 In order to ensure the integrity of the state of the system, the stored data
-needs to be re-arranged and hashed in a _modified Merkle Patricia Tree_, which
+needs to be re-arranged and hashed in a _modified Merkle Radix Tree_, which
 hereafter we refer to as the *_State Trie_* or just *_Trie_*. This rearrangment
 is necessary to be able to compute the Merkle hash of the whole or part of the
 state storage, consistently and efficiently at any given time.

--- a/01_host/02_state/01_state-storage-trie.adoc
+++ b/01_host/02_state/01_state-storage-trie.adoc
@@ -163,7 +163,7 @@ to stem:[N] and another part of stem:[k_N] is stored in stem:[N] (<<defn-node-ke
 ====
 For any stem:[N in cc N], its key stem:[k_N] is divided into an *aggregated
 prefix key, stem:["pk"_N^("Agr")]*, aggregated by <<algo-aggregate-key>> and
-a *partial key*, *stem:["pk"_N]* of length stem:[0 <= l_("pk"_N) <= 65535]
+a *partial key*, *stem:["pk"_N]* of length stem:[0 <= l_("pk"_N) < 2^(16)]
 in nibbles such that:
 
 [stem]


### PR DESCRIPTION
Several minor polishing and clarifications in Chapter 1 and 2
-> clarified why nibbles are used
-> removed reference to 'Patricia Tries'. According to terminology in literature, our storage tires are just modified Radix tries and not Patricia tries as there is only one layer of compaction. 
-> Typos in State machine definition
