### PR TITLE
fix: change `>=` to `<` in `defn-observed-votes`

### DIFF
--- a/01_host/05_consensus/03_finality.adoc
+++ b/01_host/05_consensus/03_finality.adoc
@@ -218,7 +218,7 @@ descendants defined formally as:
 
 [stem]
 ++++
-V_("obs"(v))^(r,"stage")(B) := uuu_(v_i in bbb V, B >= B') "VD"_("obs"(v))^(r,"stage")(B')
+V_("obs"(v))^(r,"stage")(B) := uuu_(v_i in bbb V, B < B') "VD"_("obs"(v))^(r,"stage")(B')
 ++++
 
 The *total number of observed votes for Block stem:[B] in round stem:[r]* is


### PR DESCRIPTION
In the definition of [Set of Total Observed Votes](https://spec.polkadot.network/#defn-observed-votes) there is the following definition set of all observed votes by `v` in the sub-round stage of round `r` for block `B` as:
> is equal to all of the observed direct votes cast for block B  and all of the B’s descendants

However, in the formal definition, bellow the union symbol, is defined `B >= B'` but should the descendants be greater than B (`B < B'` instead)?
