### PR TITLE
Improve the language when duplicate libp2p key

### DIFF
--- a/01_host/04_networking/01_fundamentals.adoc
+++ b/01_host/04_networking/01_fundamentals.adoc
@@ -51,12 +51,12 @@ Each Polkadot Host node maintains an ED25519 key pair which is used to
 identify the node. The public key is shared with the rest of the network
 allowing the nodes to establish secure communication channels.
 
-Each node must have its own unique ED25519 key pair. When two or more nodes use
+Each node must have its own unique ED25519 key pair. If two or more nodes use
 the same key, the network will interpret those nodes as a single node, which
-will result in undefined behavior and can result in equivocation. Furthermore,
-the node’s _PeerId_ as defined in <<defn-peer-id>> is derived from its public
-key. _PeerId_ is used to identify each node when they are discovered in the
-course of the discovery mechanism described in <<sect-discovery-mechanism>>.
+will result in unspecified behavior. Furthermore, the node’s _PeerId_ as
+defined in <<defn-peer-id>> is derived from its public key. _PeerId_ is used
+to identify each node when they are discovered in the course of the discovery
+mechanism described in <<sect-discovery-mechanism>>.
 
 [#defn-peer-id]
 .<<defn-peer-id,PeerId>>


### PR DESCRIPTION
PR does two things:

- Replace "undefined behavior" with "unspecified behavior". I understand that you mean "the behavior can be anything", but the words "undefined behavior" are really scary in IT. The behavior is not actually "undefined", as the node still does a specific thing, it's just that what it does might not conform to the spec.
- Remove " and can result in equivocation", because that's not actually true. Right now you can never be equivocated for using the same libp2p key multiple times. Even if this could result in an equivocation somehow, this is covered by the words "unspecified behavior".