### PR TITLE
[WIP] Describe implementation assumptions of Substrate regarding (child) storages

### DIFF
--- a/ab_host-api/child_storage.adoc
+++ b/ab_host-api/child_storage.adoc
@@ -3,6 +3,9 @@
 
 Interface for accessing the child storage from within the runtime.
 
+IMPORTANT: Do note that this API must implement some specific behaviors,
+described further in <<sect-storage-assumptions>>
+
 [#defn-child-storage-type]
 .<<defn-child-storage-type, Child Storage>>
 ====
@@ -25,6 +28,7 @@ child storage key (<<defn-child-storage-type>>).
 * `key`: a pointer-size (<<defn-runtime-pointer-size>>) to the key.
 * `value`: a pointer-size (<<defn-runtime-pointer-size>>) to the value.
 
+[#sect-ext-default-child-storage-get]
 ==== `ext_default_child_storage_get`
 Retrieves the value associated with the given key from the child storage.
 
@@ -212,6 +216,7 @@ where _0_ indicates that all keys of the child storage have been removed,
 followed by the number of removed keys, stem:[c]. The variant _1_ indicates that
 there are remaining keys, followed by the number of removed keys.
 
+[#ext-default-child-storage-root]
 ==== `ext_default_child_storage_root`
 
 Commits all existing operations and computes the resulting child storage

--- a/ab_host-api/storage.adoc
+++ b/ab_host-api/storage.adoc
@@ -3,6 +3,7 @@
 
 Interface for accessing the storage from within the runtime.
 
+[#sect-storage-assumptions]
 ==== Implementation Assumptions
 The storage and child storage (<<sect-child-storage-api>>) API in the Substrate
 implementation makes some behavioral assumptions on the underlying storage
@@ -15,26 +16,33 @@ child storage. However, the storage API described in this section and the child
 storage API share the same database. This means that the storage API can
 retrieve child storage entries.
 
-For example, calling `ext_storage_get_version_1` with the key
-`:child_storage:default:some_child:some_key` is equivalent to calling
-`ext_default_child_storage_get_version_1` with child storage key `some_child`
-and key `some_key`.
+For example, calling `ext_storage_get_version_1` (<<sect-ext-storage-get>>) with
+the key `:child_storage:default:some_child:some_key` is equivalent to calling
+`ext_default_child_storage_get_version_1`
+(<<sect-ext-default-child-storage-get>>) with child storage key `some_child` and
+key `some_key`.
 
 Importantly, the storage API can only _read_ child storage entries, but must
 implement write protection. Any function that modifies data must silently ignore
-any keys that start with the `:child_storage:` prefix or any keys that are a
-substring of that prefix, such as `:child_sto` (but not `:other`, for example).
-If the function expects a return value, then _None_ (<<defn-option-type>>)
-should be returned.
+any keys that start with the `:child_storage:` prefix. For
+`ext_storage_clear_prefix` (<<sect-ext-storage-clear-prefix>>) specifically,
+this also applies to any key that is a substring of `:child_storage:` prefix,
+such as `:child_sto` (but not `:other`, for example). If the function expects a
+return value, then _None_ (<<defn-option-type>>) should be returned.
 
 Additionally, calling `ext_storage_get_version_1` on a child storage key
 directly (without a key within the child storage), such as
-`:child_storage:defaut:some_child`, retuns the root of the child storage. This
-is described in TODO.
+`:child_storage:defaut:some_child`, the function returns the root of the child
+storage from when `ext_default_child_storage_root`
+(<<ext-default-child-storage-root>>) _has been last called_ or _None_
+(<<defn-option-type>>) if it has never been called yet. Respectively, that root
+value is cached. Calling `ext_default_child_storage_root` directly always
+recomputes the current root value.
 
-See the https://github.com/w3f/polkadot-spec/issues/575[polkadot-spec issue
-#575] and the https://github.com/paritytech/substrate/issues/12461[substrate
-issue #12461] for more info.
+See the following issues for more information:
+* https://github.com/w3f/polkadot-spec/issues/575
+* https://github.com/w3f/polkadot-spec/issues/577
+* https://github.com/paritytech/substrate/issues/12461
 
 [#defn-state-version]
 .<<defn-state-version, State Version>>
@@ -56,8 +64,8 @@ merkle proof (<<defn-hashed-subvalue>>).
 ==== `ext_storage_set`
 Sets the value under a given key into storage.
 
-IMPORTANT: Please note the section disclaimer (<<sect-storage-api>>) regarding
-child storage keys.
+IMPORTANT: Do note that this API must implement some specific behaviors,
+described further in <<sect-storage-assumptions>>
 
 ===== Version 1 - Prototype
 ----
@@ -70,11 +78,12 @@ Arguments::
 * `value`: a pointer-size (<<defn-runtime-pointer-size>>) containing the
 value.
 
+[#sect-ext-storage-get]
 ==== `ext_storage_get`
 Retrieves the value associated with the given key from storage.
 
-IMPORTANT: Please note the section disclaimer (<<sect-storage-api>>) regarding
-child storage keys.
+IMPORTANT: Do note that this API must implement some specific behaviors,
+described further in <<sect-storage-assumptions>>
 
 ===== Version 1 - Prototype
 ----
@@ -140,13 +149,14 @@ Arguments::
 * `return`: an i32 integer value equal to _1_ if the key exists or a value equal
 to _0_ if otherwise.
 
+[#sect-ext-storage-clear-prefix]
 ==== `ext_storage_clear_prefix`
 
 Clear the storage of each key/value pair where the key starts with the given
 prefix.
 
-IMPORTANT: Please note the section disclaimer (<<sect-storage-api>>) regarding
-child storage keys.
+IMPORTANT: Do note that this API must implement some specific behaviors,
+described further in <<sect-storage-assumptions>>
 
 ===== Version 1 - Prototype
 ----

--- a/ab_host-api/storage.adoc
+++ b/ab_host-api/storage.adoc
@@ -4,10 +4,13 @@
 Interface for accessing the storage from within the runtime.
 
 IMPORTANT: As of now, the storage API should silently ignore any keys that start
-with the `:child_storage:default:` prefix. This applies to reading and writing.
-If the function expects a return value, then _None_ (<<defn-option-type>>)
-should be returned. See
-https://github.com/paritytech/substrate/issues/12461[substrate issue #12461].
+with the `:child_storage:` prefix or any keys that are a substring of that
+prefix, such as `:child_sto` (but not `:other`, for example). This applies to
+reading and writing. If the function expects a return value, then _None_
+(<<defn-option-type>>) should be returned. See the
+https://github.com/w3f/polkadot-spec/issues/575[polkadot-spec issue #575] and
+the https://github.com/paritytech/substrate/issues/12461[substrate issue #12461]
+for more info.
 
 [#defn-state-version]
 .<<defn-state-version, State Version>>
@@ -29,6 +32,9 @@ merkle proof (<<defn-hashed-subvalue>>).
 ==== `ext_storage_set`
 Sets the value under a given key into storage.
 
+IMPORTANT: Please note the section disclaimer (<<sect-storage-api>>) regarding
+child storage keys.
+
 ===== Version 1 - Prototype
 ----
 (func $ext_storage_set_version_1
@@ -42,6 +48,9 @@ value.
 
 ==== `ext_storage_get`
 Retrieves the value associated with the given key from storage.
+
+IMPORTANT: Please note the section disclaimer (<<sect-storage-api>>) regarding
+child storage keys.
 
 ===== Version 1 - Prototype
 ----
@@ -111,6 +120,9 @@ to _0_ if otherwise.
 
 Clear the storage of each key/value pair where the key starts with the given
 prefix.
+
+IMPORTANT: Please note the section disclaimer (<<sect-storage-api>>) regarding
+child storage keys.
 
 ===== Version 1 - Prototype
 ----

--- a/ab_host-api/storage.adoc
+++ b/ab_host-api/storage.adoc
@@ -26,7 +26,7 @@ Importantly, the storage API can only _read_ child storage entries, but must
 implement write protection. Any function that modifies data must **silently ignore**
 any keys that start with the `:child_storage:` prefix. For
 `ext_storage_clear_prefix` (<<sect-ext-storage-clear-prefix>>) specifically,
-this also applies to any key that is a substring of `:child_storage:` prefix,
+this also applies to any key that is a substring of the `:child_storage:` prefix,
 such as `:child_sto` (but not `:other`, for example). If the function expects a
 return value, then _None_ (<<defn-option-type>>) should be returned.
 
@@ -40,6 +40,7 @@ value is cached. Calling `ext_default_child_storage_root` directly always
 recomputes the current root value.
 
 See the following issues for more information:
+
 * https://github.com/w3f/polkadot-spec/issues/575
 * https://github.com/w3f/polkadot-spec/issues/577
 * https://github.com/paritytech/substrate/issues/12461

--- a/ab_host-api/storage.adoc
+++ b/ab_host-api/storage.adoc
@@ -23,7 +23,7 @@ the key `:child_storage:default:some_child:some_key` is equivalent to calling
 key `some_key`.
 
 Importantly, the storage API can only _read_ child storage entries, but must
-implement write protection. Any function that modifies data must silently ignore
+implement write protection. Any function that modifies data must **silently ignore**
 any keys that start with the `:child_storage:` prefix. For
 `ext_storage_clear_prefix` (<<sect-ext-storage-clear-prefix>>) specifically,
 this also applies to any key that is a substring of `:child_storage:` prefix,
@@ -34,8 +34,8 @@ Additionally, calling `ext_storage_get_version_1` on a child storage key
 directly (without a key within the child storage), such as
 `:child_storage:defaut:some_child`, the function returns the root of the child
 storage from when `ext_default_child_storage_root`
-(<<ext-default-child-storage-root>>) _has been last called_ or _None_
-(<<defn-option-type>>) if it has never been called yet. Respectively, that root
+(<<ext-default-child-storage-root>>) has been **last called** or _None_
+(<<defn-option-type>>) if it has never been called. Respectively, that root
 value is cached. Calling `ext_default_child_storage_root` directly always
 recomputes the current root value.
 

--- a/ab_host-api/storage.adoc
+++ b/ab_host-api/storage.adoc
@@ -4,16 +4,16 @@
 Interface for accessing the storage from within the runtime.
 
 ==== Implementation Assumptions
-The storage and child storage (<<sect-child-storage-api>>) functionality in the
-Substrate implementation is based on a couple of assumptions in order for the
-Runtime to behave deterministically. While Polkadot Host implementers can decide
-for themselves on how those APIs are implemented - as long as the interface is
-corerct - those behaviors must be replicated. In Substrate, child storages are
-namespaces respectively segregated by attaching the `:child_storage:default:`
-prefix to every child storage keys "<CHILD-STORAGE>", followed by `:<KEY>` for
-the key within that child storage. However, the storage API described in this
-section and the child storage API share the same database. This means that the
-storage API can retrieve child storage entries.
+The storage and child storage (<<sect-child-storage-api>>) API in the Substrate
+implementation makes some behavioral assumptions on the underlying storage
+architecture. While Polkadot Host implementers can decide for themselves on how
+those APIs are implemented, those behaviors must be replicated in order for the
+Runtime to be executed deterministically. In Substrate, child storages are
+namespaced respectively segregated by attaching the `:child_storage:default:`
+prefix to every child storage keys, followed by `:<KEY>` for the key within that
+child storage. However, the storage API described in this section and the child
+storage API share the same database. This means that the storage API can
+retrieve child storage entries.
 
 For example, calling `ext_storage_get_version_1` with the key
 `:child_storage:default:some_child:some_key` is equivalent to calling

--- a/ab_host-api/storage.adoc
+++ b/ab_host-api/storage.adoc
@@ -3,14 +3,38 @@
 
 Interface for accessing the storage from within the runtime.
 
-IMPORTANT: As of now, the storage API should silently ignore any keys that start
-with the `:child_storage:` prefix or any keys that are a substring of that
-prefix, such as `:child_sto` (but not `:other`, for example). This applies to
-reading and writing. If the function expects a return value, then _None_
-(<<defn-option-type>>) should be returned. See the
-https://github.com/w3f/polkadot-spec/issues/575[polkadot-spec issue #575] and
-the https://github.com/paritytech/substrate/issues/12461[substrate issue #12461]
-for more info.
+==== Implementation Assumptions
+The storage and child storage (<<sect-child-storage-api>>) functionality in the
+Substrate implementation is based on a couple of assumptions in order for the
+Runtime to behave deterministically. While Polkadot Host implementers can decide
+for themselves on how those APIs are implemented - as long as the interface is
+corerct - those behaviors must be replicated. In Substrate, child storages are
+namespaces respectively segregated by attaching the `:child_storage:default:`
+prefix to every child storage keys "<CHILD-STORAGE>", followed by `:<KEY>` for
+the key within that child storage. However, the storage API described in this
+section and the child storage API share the same database. This means that the
+storage API can retrieve child storage entries.
+
+For example, calling `ext_storage_get_version_1` with the key
+`:child_storage:default:some_child:some_key` is equivalent to calling
+`ext_default_child_storage_get_version_1` with child storage key `some_child`
+and key `some_key`.
+
+Importantly, the storage API can only _read_ child storage entries, but must
+implement write protection. Any function that modifies data must silently ignore
+any keys that start with the `:child_storage:` prefix or any keys that are a
+substring of that prefix, such as `:child_sto` (but not `:other`, for example).
+If the function expects a return value, then _None_ (<<defn-option-type>>)
+should be returned.
+
+Additionally, calling `ext_storage_get_version_1` on a child storage key
+directly (without a key within the child storage), such as
+`:child_storage:defaut:some_child`, retuns the root of the child storage. This
+is described in TODO.
+
+See the https://github.com/w3f/polkadot-spec/issues/575[polkadot-spec issue
+#575] and the https://github.com/paritytech/substrate/issues/12461[substrate
+issue #12461] for more info.
 
 [#defn-state-version]
 .<<defn-state-version, State Version>>


### PR DESCRIPTION
Fixes #575  and #577 (#540 should be later completed here, too).

@tomaka I would appreciate if you could quickly double check this, especially my claim on how child storage keys are constructed and that `get` returns _None_ if `child_storage_root` has never been called. Those are random guesses of mine :)

![image](https://user-images.githubusercontent.com/42901763/200367076-564f740d-537e-4748-a43b-5998a262ece4.png)
