### PR TITLE
Update Runtime APIs 

### DIFF
--- a/01_host/07_lightclient/01_requirements.adoc
+++ b/01_host/07_lightclient/01_requirements.adoc
@@ -6,7 +6,7 @@ We list requirements of a Light Client categorized along the the three dimension
 
 * *Functional Requirements:* 
     . Update state (<<sect-state-storage>>) to reflect the latest view of the blockchain via synchronization with full nodes.
-    . (Optional) Verify validity of runtime transitions (<<sec-runtime-interaction>>). 
+    . (Optional) Verify validity of runtime transitions (<<sect-runtime-interaction>>). 
     . Make queries for data at the latest block height or across a range of blocks.
     . Append extrinsics (<<sect-extrinsics>>) to the blockchain via full nodes. 
 

--- a/ac_runtime-api/modules/_modules.adoc
+++ b/ac_runtime-api/modules/_modules.adoc
@@ -21,3 +21,5 @@ include::sessionkeys.adoc[]
 include::accountnonce.adoc[]
 
 include::txpayment.adoc[]
+
+include::nominationpools.adoc[]

--- a/ac_runtime-api/modules/accountnonce.adoc
+++ b/ac_runtime-api/modules/accountnonce.adoc
@@ -1,3 +1,4 @@
+[#sect-runtime-accountnonceapi-module]
 === Module AccountNonceApi
 
 IMPORTANT: This section describes *Version 1* of this API. Please check `Core_version` (<<defn-rt-core-version>>) to ensure compatibility.

--- a/ac_runtime-api/modules/babe.adoc
+++ b/ac_runtime-api/modules/babe.adoc
@@ -1,3 +1,4 @@
+[#sect-runtime-babeapi-module]
 === Module BabeApi
 
 IMPORTANT: This section describes *Version 2* of this API. Please check `Core_version` (<<defn-rt-core-version>>) to ensure compatibility.
@@ -49,6 +50,7 @@ requires the inclusion of an auxiliary VRF output (<<sect-block-production-lotte
 |A one-byte enum as defined in <<defn-consensus-message-babe>> as stem:[2_("nd")]. 
 |===
 
+[#sect-babeapi_current_epoch_start]
 ==== `BabeApi_current_epoch_start`
 
 Finds the start slot of the current epoch.
@@ -81,6 +83,7 @@ where:::
 ** latexmath:[A] is an authority list as defined in <<defn-authority-list>>.
 ** latexmath:[r] is an 256-bit array containing the randomness for the epoch as defined in <<defn-epoch-randomness>>.
 
+[#sect-babeapi_next_epoch]
 ==== `BabeApi_next_epoch`
 
 Produces information about the next epoch.

--- a/ac_runtime-api/modules/blockbuilder.adoc
+++ b/ac_runtime-api/modules/blockbuilder.adoc
@@ -216,13 +216,3 @@ where:::
 ** latexmath:[f_e] is a boolean indicating whether a fatal error was encountered.
 ** latexmath:[e] is a Inherents-Data structure as defined in <<defn-inherent-data>>
 containing any errors created by this Runtime function.
-
-==== `BlockBuilder_random_seed`
-
-Generates a random seed.
-
-Arguments::
-* None
-
-Return::
-* A 32-byte array containing the random seed.

--- a/ac_runtime-api/modules/grandpa.adoc
+++ b/ac_runtime-api/modules/grandpa.adoc
@@ -21,7 +21,7 @@ Return::
 * An authority list as defined in <<defn-authority-list>>.
 
 [#sect-grandpa-current-set-id]
-==== `GrandpaApi_current_set_id`ac
+==== `GrandpaApi_current_set_id`
 
 This entry fetches the list of GRANDPA authority set ID (<<defn-authority-set-id>>).
 Any future authority changes get tracked via Runtime-to-consensus engine

--- a/ac_runtime-api/modules/grandpa.adoc
+++ b/ac_runtime-api/modules/grandpa.adoc
@@ -1,3 +1,4 @@
+[#sect-runtime-grandpaapi-module]
 === Module GrandpaApi
 
 IMPORTANT: This section describes *Version 2* of this API. Please check `Core_version` (<<defn-rt-core-version>>) to ensure compatibility.
@@ -20,7 +21,7 @@ Return::
 * An authority list as defined in <<defn-authority-list>>.
 
 [#sect-grandpa-current-set-id]
-==== `GrandpaApi_current_set_id`
+==== `GrandpaApi_current_set_id`ac
 
 This entry fetches the list of GRANDPA authority set ID (<<defn-authority-set-id>>).
 Any future authority changes get tracked via Runtime-to-consensus engine

--- a/ac_runtime-api/modules/grandpa.adoc
+++ b/ac_runtime-api/modules/grandpa.adoc
@@ -19,6 +19,19 @@ Arguments::
 Return::
 * An authority list as defined in <<defn-authority-list>>.
 
+[#sect-grandpa-current-set-id]
+==== `GrandpaApi_current_set_id`
+
+This entry fetches the list of GRANDPA authority set ID (<<defn-authority-set-id>>).
+Any future authority changes get tracked via Runtime-to-consensus engine
+messages, as described in <<sect-consensus-message-digest>>.
+
+Arguments::
+* None.
+
+Return::
+* An authority set ID as defined in <<defn-authority-set-id>>.
+
 [#sect-grandpaapi_submit_report_equivocation_unsigned_extrinsic]
 ==== `GrandpaApi_submit_report_equivocation_unsigned_extrinsic`
 

--- a/ac_runtime-api/modules/nominationpools.adoc
+++ b/ac_runtime-api/modules/nominationpools.adoc
@@ -1,7 +1,7 @@
 [#sect-runtime-nomination-pools-module]
 === Module Nomination Pools
 
-IMPORTANT: This section describes *Version 2* of this API. Please check `Core_version` (<<defn-rt-core-version>>) to ensure compatibility. Currently supports only one RPC endpoint. 
+IMPORTANT: This section describes *Version 1* of this API. Please check `Core_version` (<<defn-rt-core-version>>) to ensure compatibility. Currently supports only one RPC endpoint. 
 
 
 [#sect-rte-pending-rewards]

--- a/ac_runtime-api/modules/nominationpools.adoc
+++ b/ac_runtime-api/modules/nominationpools.adoc
@@ -5,7 +5,7 @@ IMPORTANT: This section describes *Version 1* of this API. Please check `Core_ve
 
 
 [#sect-rte-pending-rewards]
-==== `NominationPools_pending_rewards`
+==== `NominationPoolsApi_pending_rewards`
 
 Runtime API for accessing information about the nomination pools. Returns the pending rewards for the member that the Account ID was given for.
 

--- a/ac_runtime-api/modules/nominationpools.adoc
+++ b/ac_runtime-api/modules/nominationpools.adoc
@@ -1,0 +1,16 @@
+[#sect-runtime-nomination-pools-module]
+=== Module Nomination Pools
+
+IMPORTANT: This section describes *Version 2* of this API. Please check `Core_version` (<<defn-rt-core-version>>) to ensure compatibility. Currently supports only one RPC endpoint. 
+
+
+[#sect-rte-pending-rewards]
+==== `NominationPools_pending_rewards`
+
+Runtime API for accessing information about the nomination pools. Returns the pending rewards for the member that the Account ID was given for.
+
+Arguments::
+* The account ID as a SCALE encoded 32-byte address of the sender (<<defn-extrinsic-address>>).
+
+Return::
+* the SCALE encoded balance of type `u128` representing the pending reward of the account ID. The default value is Zero incase of errors in fetching the rewards. 

--- a/ac_runtime-api/modules/parachain.adoc
+++ b/ac_runtime-api/modules/parachain.adoc
@@ -342,14 +342,14 @@ Arguments::
 * None
 
 Return::
-* An _Option_ type which can contain the Scraped OnChainVotes data (<<defn-scraped-on-chain-vote>>). 
+* An _Option_ (<<defn-option-type>>) type which can contain the scraped on-chain votes data (<<defn-scraped-on-chain-vote>>). 
 
 [#defn-scraped-on-chain-vote]
 .<<defn-scraped-on-chain-vote, Scraped On Chain Vote>>
 ====
 Contains the scraped runtime backing votes and resolved disputes.
 
-The ScrapedOnChainVotes, stem:[SOCV], is a datastructure of the following format:
+The scraped on-chain votes data, stem:[SOCV], is a datastructure of the following format:
 
 [stem]
 ++++
@@ -359,7 +359,7 @@ BV = [C_r, [(i,a)]]
 
 where::
 * stem:[S_i] is the u32 integer representing the session index in which block was introduced.
-* stem:[BV] is the set of backing validators for each candidate, represented by its candidate receipt (<<defn-candidate-receipt>>). Each candidate stem:[C_r] has the list [stem:[(i,a)]], the pair of validator index and validation attestations (<<defn-parachain-inherent-data>>).
+* stem:[BV] is the set of backing validators for each candidate, represented by its candidate receipt (<<defn-candidate-receipt>>). Each candidate stem:[C_r] has a list of stem:[(i,a)], the pair of validator index and validation attestations (<<defn-parachain-inherent-data>>).
 * stem:[d] is a set of dispute statements (<<net-msg-dispute-request>>). Note that the above stem:[BV] is are unrelated to the backers of the dispute candidates. 
 ====
 
@@ -395,7 +395,7 @@ Return::
 [#defn-pvf-check-statement]
 .<<defn-pvf-check-statement, PVF Check Statement>>
 ====
-This is a statement by the validator who ran the pre-checking process for a PVF. A PVF is identified by the `ValidationCodeHash`. The statement is valid only during a single session, specified in the `session_index`.
+This is a statement by the validator who ran the pre-checking process for a PVF. A PVF is identified by the _ValidationCodeHash_. The statement is valid only during a single session, specified in the `session_index`.
 
 The PVF Check Statement stem:[S_{pvf}], is a datastructure of the following format:
 

--- a/ac_runtime-api/modules/parachain.adoc
+++ b/ac_runtime-api/modules/parachain.adoc
@@ -155,7 +155,7 @@ Arguments::
 
 Return::
 * An _Option_ value (<<defn-option-type>>) which can contain the pair of persisted
-validation data (<<defn-persisted-validation-data>>) and Validation Code Hash. The value is empty if the
+validation data (<<defn-persisted-validation-data>>) and Validation Code Hash. The value is `None` if the
 parachain Id is not registered or the validation data hash does not match the expected one.
 
 

--- a/ac_runtime-api/modules/parachain.adoc
+++ b/ac_runtime-api/modules/parachain.adoc
@@ -144,6 +144,21 @@ The persisted validation data is fetched via the Runtime API
 (<<sect-rt-api-persisted-validation-data>>).
 ====
 
+[#sect-rt-api-assumed-validation-data]
+==== `ParachainHost_assumed_validation_data`
+
+Returns the persisted validation data for the given parachain Id along with the corresponding Validation Code Hash. Instead of accepting validation about para, matches the validation data hash against an expected one and yields `None` if they are unequal. 
+
+Arguments::
+* The Parachain Id (<<defn-para-id>>).
+* Expected Persistent Validation Data Hash (<<defn-persisted-validation-data>>).
+
+Return::
+* An _Option_ value (<<defn-option-type>>) which can contain the pair of persisted
+validation data (<<defn-persisted-validation-data>>) and Validation Code Hash. The value is empty if the
+parachain Id is not registered or the validation data hash does not match the expected one.
+
+
 ==== `ParachainHost_check_validation_outputs`
 
 Checks if the given validation outputs pass the acceptance criteria.
@@ -193,6 +208,18 @@ Return::
 * An _Option_ value (<<defn-option-type>>) containing the full validation code
 in an byte array. This value is empty if the parachain Id cannot be found or the
 assumption is wrong.
+
+[#sect-rt-api-validation-code-hash]
+==== `ParachainHost_validation_code_hash`
+
+Returns the validation code hash of a parachain.
+
+Arguments::
+* The parachain Id (<<defn-para-id>>).
+* An occupied core assumption (<<defn-occupied-core-assumption>>).
+
+Return::
+* An _Option_ value (<<defn-option-type>>) containing the hash value of the validation code. This value is empty if the parachain Id cannot be found or the assumption is wrong.
 
 ==== `ParachainHost_candidate_pending_availability`
 
@@ -305,3 +332,83 @@ Arguments::
 
 Return::
 * An array of inbound HRMP messages (<<defn-inbound-hrmp-message>>).
+
+
+==== `ParachainHost_on_chain_votes`
+
+Returns disputes relevant from on-chain, backing votes, and resolved disputes. 
+
+Arguments::
+* None
+
+Return::
+* An _Option_ type which can contain the Scraped OnChainVotes data (<<defn-scraped-on-chain-vote>>). 
+
+[#defn-scraped-on-chain-vote]
+.<<defn-scraped-on-chain-vote, Scraped On Chain Vote>>
+====
+Contains the scraped runtime backing votes and resolved disputes.
+
+The ScrapedOnChainVotes, stem:[SOCV], is a datastructure of the following format:
+
+[stem]
+++++
+SOCV = (S_i,BV,d)\
+BV = [C_r, [(i,a)]]
+++++
+
+where::
+* stem:[S_i] is the u32 integer representing the session index in which block was introduced.
+* stem:[BV] is the set of backing validators for each candidate, represented by its candidate receipt (<<defn-candidate-receipt>>). Each candidate stem:[C_r] has the list [stem:[(i,a)]], the pair of validator index and validation attestations (<<defn-parachain-inherent-data>>).
+* stem:[d] is a set of dispute statements (<<net-msg-dispute-request>>). Note that the above stem:[BV] is are unrelated to the backers of the dispute candidates. 
+====
+
+WARNING: PVF Pre-Checker subsystem is still Work-in-Progress, hence the below APIs are subject to change. 
+
+[#sect-rt-api-pvfs-require-precheck]
+==== `ParachainHost_pvfs_require_precheck`
+
+This runtime API fetches all PVFs that require pre-checking voting. The PVFs are
+identified by their code hashes. As soon as the PVF gains required support, the runtime API will
+not return the PVF anymore.
+
+Arguments::
+* None
+
+Return::
+* A list of validation code hashes that require prechecking of votes by validator in the active set. 
+
+[#sect-rt-api-submit-pvf-check-statment]
+==== `ParachainHost_submit_pvf_check_statement`
+
+This runtime API submits the judgement for a PVF, whether it is approved or not. The voting process uses unsigned transactions. The check is circulated through the network via gossip similar to a normal transaction. At some point the validator
+will include the statement in the block, where it will be processed by the runtime. If that was the
+last vote before gaining the super-majority, this PVF will not be returned by `pvfs_require_precheck` (<<sect-rt-api-pvfs-require-precheck>>) anymore.
+
+Arguments::
+* A PVF pre checking statement (<<defn-pvf-check-statement>>) to be submitted into the transaction pool.
+* Validator Signature (<<defn-parachain-inherent-data>>).
+
+Return::
+* None
+
+[#defn-pvf-check-statement]
+.<<defn-pvf-check-statement, PVF Check Statement>>
+====
+This is a statement by the validator who ran the pre-checking process for a PVF. A PVF is identified by the `ValidationCodeHash`. The statement is valid only during a single session, specified in the `session_index`.
+
+The PVF Check Statement stem:[S_{pvf}], is a datastructure of the following format:
+
+[stem]
+++++
+S_{pvf} = (b,VC_H,S_i,V_i)
+++++
+
+where::
+* stem:[b] is a boolean denoting if the subject passed pre-checking.
+* stem:[VC_H] is the validation code hash.
+* stem:[S_i] is u32 integer representing the session index.
+* stem:[V_i] is the validator index (<<defn-parachain-inherent-data>>). 
+====
+
+

--- a/ac_runtime-api/modules/parachain.adoc
+++ b/ac_runtime-api/modules/parachain.adoc
@@ -378,7 +378,7 @@ Arguments::
 Return::
 * A list of validation code hashes that require prechecking of votes by validator in the active set. 
 
-[#sect-rt-api-submit-pvf-check-statment]
+[#sect-rt-api-submit-pvf-check-statement]
 ==== `ParachainHost_submit_pvf_check_statement`
 
 This runtime API submits the judgement for a PVF, whether it is approved or not. The voting process uses unsigned transactions. The check is circulated through the network via gossip similar to a normal transaction. At some point the validator

--- a/ac_runtime-api/modules/sessionkeys.adoc
+++ b/ac_runtime-api/modules/sessionkeys.adoc
@@ -1,12 +1,12 @@
 [#sect-runtime-sessionkeys-module]
-==== Module SessionKeys
+=== Module SessionKeys
 
 IMPORTANT: This section describes *Version 1* of this API. Please check `Core_version` (<<defn-rt-core-version>>) to ensure compatibility.
 
 
 All calls in this module require `Core_initialize_block` (<<sect-rte-core-initialize-block>>) to be called beforehand.
 
-===== `SessionKeys_generate_session_keys`
+==== `SessionKeys_generate_session_keys`
 
 Generates a set of session keys with an optional seed. The keys should
 be stored within the keystore exposed by the Host Api. The seed needs to
@@ -18,7 +18,7 @@ Arguments::
 Return::
 * A byte array of varying size containing the encoded session keys.
 
-===== `SessionKeys_decode_session_keys`
+==== `SessionKeys_decode_session_keys`
 
 Decodes the given public session keys. Returns a list of raw public keys including their key type.
 

--- a/ac_runtime-api/modules/txpayment.adoc
+++ b/ac_runtime-api/modules/txpayment.adoc
@@ -1,11 +1,12 @@
-==== Module TransactionPaymentApi
+[#sect-runtime-transactionpaymentapi-module]
+=== Module TransactionPaymentApi
 
 IMPORTANT: This section describes *Version 2* of this API. Please check `Core_version` (<<defn-rt-core-version>>) to ensure compatibility.
 
-
 All calls in this module require `Core_initialize_block` (<<sect-rte-core-initialize-block>>) to be called beforehand.
 
-===== `TransactionPaymentApi_query_info`
+[#sect-rte-transactionpaymentapi-query-info]
+==== `TransactionPaymentApi_query_info`
 
 Returns information of a given extrinsic. This function is not aware of
 the internals of an extrinsic, but only interprets the extrinsic as some
@@ -42,7 +43,8 @@ c = \left\{\begin{array}{l}
 ** latexmath:[f] is the inclusion fee of the extrinsic. This does not
 include a tip or anything else that depends on the signature.
 
-===== `TransactionPaymentApi_query_fee_details`
+[#sect-rte-transactionpaymentapi-query-fee-details]
+==== `TransactionPaymentApi_query_fee_details`
 
 Query the detailed fee of a given extrinsic. This function can be used
 by the Polkadot Host implementation when it seems appropriate, such as
@@ -74,8 +76,8 @@ where::::
 *** latexmath:[f_a] is the "`adjusted weight fee`", which is a multiplication of the fee multiplier and the weight fee. The fee multiplier varies depending on the usage of the network.
 ** latexmath:[t] is the tip for the block author.
 
-
-===== `TransactionPaymentApi_query_call_info`
+[#sect-rte-transactionpaymentapi-query-call-info]
+==== `TransactionPaymentApi_query_call_info`
 
 Query information of a dispatch class, weight, and fee of a given encoded `Call`.
 
@@ -106,7 +108,8 @@ c = \left\{\begin{array}{l}
 ** latexmath:[f] is the partial-fee of the call. This does not
 include a tip or anything else that depends on the signature.
 
-===== `TransactionPaymentApi_query_call_fee_details`
+[#sect-rte-transactionpaymentapi-query-call-fee-details]
+==== `TransactionPaymentApi_query_call_fee_details`
 
 Query the fee details of a given encoded `Call` including tip. 
 
@@ -135,3 +138,4 @@ where::::
 *** latexmath:[f_l] is the length fee, the amount paid for the encoded length (in bytes) of the `Call`.
 *** latexmath:[f_a] is the "`adjusted weight fee`", which is a multiplication of the fee multiplier and the weight fee. The fee multiplier varies depending on the usage of the network.
 ** latexmath:[t] is the tip for the block author.
+he 

--- a/ac_runtime-api/modules/txpayment.adoc
+++ b/ac_runtime-api/modules/txpayment.adoc
@@ -1,6 +1,6 @@
 ==== Module TransactionPaymentApi
 
-IMPORTANT: This section describes *Version 1* of this API. Please check `Core_version` (<<defn-rt-core-version>>) to ensure compatibility.
+IMPORTANT: This section describes *Version 2* of this API. Please check `Core_version` (<<defn-rt-core-version>>) to ensure compatibility.
 
 
 All calls in this module require `Core_initialize_block` (<<sect-rte-core-initialize-block>>) to be called beforehand.
@@ -71,5 +71,67 @@ where:::
 where::::
 *** latexmath:[f_b] is the minimum required fee for an extrinsic.
 *** latexmath:[f_l] is the length fee, the amount paid for the encoded length (in bytes) of the extrinsic.
+*** latexmath:[f_a] is the "`adjusted weight fee`", which is a multiplication of the fee multiplier and the weight fee. The fee multiplier varies depending on the usage of the network.
+** latexmath:[t] is the tip for the block author.
+
+
+===== `TransactionPaymentApi_query_call_info`
+
+Query information of a dispatch class, weight, and fee of a given encoded `Call`.
+
+Arguments::
+* A byte array of varying sizes containing the `Call`.
+* The length of the Call. 
+
+Return::
+* A data structure of the following format:
++
+[latexmath]
+++++
+(w, c, f)
+++++
++
+where:::
+** latexmath:[w] is the weight of the call.
+** latexmath:[c] is the "class" of the call, where class is a  varying data (<<defn-varrying-data-type>>) type defined as:
++
+[latexmath]
+++++
+c = \left\{\begin{array}{l}
+       0 \quad \textrm{Normal dispatch}\\
+       1 \quad \textrm{Operational dispatch}\\
+       2 \quad \textrm{Mandatory dispatch, which is always included regardless of their weight}
+     \end{array}\right.
+++++
+** latexmath:[f] is the partial-fee of the call. This does not
+include a tip or anything else that depends on the signature.
+
+===== `TransactionPaymentApi_query_call_fee_details`
+
+Query the fee details of a given encoded `Call` including tip. 
+
+Arguments::
+* A byte array of varying sizes containing the `Call`.
+* The length of the `Call`.
+
+Return::
+* A data structure of the following format:
++
+[latexmath]
+++++
+(f, t)
+++++
++
+where:::
+** latexmath:[f] is a SCALE encoded as defined in <<defn-option-type>> containing the following data structure:
++
+[latexmath]
+++++
+ f = (f_b, f_l, f_a)
+++++
++
+where::::
+*** latexmath:[f_b] is the minimum required fee for the `Call`.
+*** latexmath:[f_l] is the length fee, the amount paid for the encoded length (in bytes) of the `Call`.
 *** latexmath:[f_a] is the "`adjusted weight fee`", which is a multiplication of the fee multiplier and the weight fee. The fee multiplier varies depending on the usage of the network.
 ** latexmath:[t] is the tip for the block author.


### PR DESCRIPTION
Addresses issues raised in https://github.com/w3f/polkadot-spec/issues/604 and https://github.com/w3f/polkadot-spec/issues/605.
Adds spec for APIs regarding ParachainHost, TransacationPayment, NominationPools, and Grandpa.
Does not include Beefy and MMR related API as the spec for these chapters is WIP, makes sense to include them only after key definitions have been added in Spec .