### PR TITLE
docs(runtime/tx-payment-call-api): exported names

### DIFF
--- a/docs/chap-runtime-api.md
+++ b/docs/chap-runtime-api.md
@@ -1163,7 +1163,7 @@ All calls in this module require `Core_initialize_block` ([Section -sec-num-ref-
 TODO clarify differences between *RuntimeCall* and *Extrinsics*
 :::
 
-### -sec-num- `TransactionPaymentApi_query_call_info` {#sect-rte-transactionpaymentapi-query-call-info}
+### -sec-num- `TransactionPaymentCallApi_query_call_info` {#sect-rte-transactionpaymentcallapi-query-call-info}
 
 Query information of a dispatch class, weight, and fee of a given encoded `Call`.
 
@@ -1191,7 +1191,7 @@ Query information of a dispatch class, weight, and fee of a given encoded `Call`
     $$
   - $f$ is the partial-fee of the call. This does not include a tip or anything else that depends on the signature.
 
-### -sec-num- `TransactionPaymentApi_query_call_fee_details` {#sect-rte-transactionpaymentapi-query-call-fee-details}
+### -sec-num- `TransactionPaymentCallApi_query_call_fee_details` {#sect-rte-transactionpaymentcallapi-query-call-fee-details}
 
 Query the fee details of a given encoded `Call` including tip. 
 


### PR DESCRIPTION
**Detailed description**:
* typo in exported TransactionPaymentCallApi functions

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:
Inspected wasm - 0.9.42
<img width="535" alt="wasm-runtime-inspect-exported-funcs" src="https://github.com/w3f/polkadot-spec/assets/20928965/acbbe198-6328-4e83-beec-ee5071b3d412">
[link to source](https://github.com/paritytech/polkadot/blob/master/runtime/polkadot/src/lib.rs#L2054)

**Checklist**
- [x] Documentation added