### PR TITLE
Draft: Defining clear rules regarding merging a PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # Polkadot Protocol Specification
 
-Polkadot is a replicated sharded state machine designed to resolve the scalability and interoperability among blockchains. This repository contains the official specification for the Polkadot Protocol.
- 
-The latest releases of the *Polkadot Protocol Specification* can be found on [spec.polkadot.network](https://spec.polkadot.network) or on our [GitHub Releases page](https://github.com/w3f/polkadot-spec/releases).
+## Intorduction 
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+This repository contains the official specification for the [Polkadot Protocol](https://polkadot.network/). The latest releases of the *Polkadot Protocol Specification* can be found on [spec.polkadot.network](https://spec.polkadot.network) or our [GitHub Releases page](https://github.com/w3f/polkadot-spec/releases).
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Web3 Foundation
 - [Seyed Lavasani](https://github.com/drskalman)
 - [Heverson B. Ribeiro](https://github.com/heversonbr)
 
+Soramitsu
+- [Kamil Salakhiev](https://github.com/kamilsa)
+
 Smoldot
 - [Pierre Krieger](https://github.com/tomaka)
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The Spec Committee consists of Researchers, Researcher Engineers, and Implemente
 
 Web3 Foundation
 - [Bhargav Bhatt](https://github.com/bhargavbh)
+- [David Hawig](https://github.com/Noc2)
 - [Seyed Lavasani](https://github.com/drskalman)
 - [Heverson B. Ribeiro](https://github.com/heversonbr)
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,18 @@ Everyone, but specifically implementers and members of the [Technical Fellowship
 
 ### Spec Committee
 
-The Spec Committee consists of Researchers, Researcher Engineers, and Implementers of the Polkadot Protocol that actively contribute (= opening/contributing to PRs or issues regarding the spec) to the specification. For now and compared to the [Technical Fellowship](https://github.com/polkadot-fellows/manifesto) itself, the responsibility of the Spec Committee is clearly defined as maintaining the specification of the protocol. In case of inactivity for three months, members will be removed again. 
+The Spec Committee consists of Researchers, Researcher Engineers, and Implementers of the Polkadot Protocol that actively contribute (= opening/contributing to PRs or issues regarding the spec) to the specification. For now and compared to the [Technical Fellowship](https://github.com/polkadot-fellows/manifesto), the Spec Committee's responsibility is clearly defined as maintaining the specification of the protocol. In case of inactivity for three months, members will be removed again. 
 
+Web3 Foundation
 - [Bhargav Bhatt](https://github.com/bhargavbh)
 - [Seyed Lavasani](https://github.com/drskalman)
-- [Pierre Krieger](https://github.com/tomaka) 
 - [Heverson B. Ribeiro](https://github.com/heversonbr)
 
+Smoldot
+- [Pierre Krieger](https://github.com/tomaka)
+
+Parity 
+- [Fateme Shirazi](https://github.com/FatemeShirazi)
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Web3 Foundation
 - [Seyed Lavasani](https://github.com/drskalman)
 - [Heverson B. Ribeiro](https://github.com/heversonbr)
 
-Soramitsu
+Quadrivium
 - [Kamil Salakhiev](https://github.com/kamilsa)
 
 Smoldot

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ The Spec Committee consists of Researchers, Researcher Engineers, and Implemente
 - [Pierre Krieger](https://github.com/tomaka) 
 - [Heverson B. Ribeiro](https://github.com/heversonbr)
 
-## Spec Committee 
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,39 @@
 # Polkadot Protocol Specification
 
+- [Introduction](#intorduction)
+- [Process](#process)
+- [Local Development](#local-development)
+- [Formatting](#formatting)
+  - [LaTeX](#latex)
+  - [Numeration System](#numeration-system)
+  - [Chapters](#chapters)
+  - [Sections](#sections)
+  - [Definitions](#definitions)
+  - [Algorithms](#algorithms)
+  - [Tables and Images](#tables-and-images)
+  - [References](#references) 
+  - [Bibliography](#bibliography)
+  - [Broken Links](#broken-links)
+- [License](#license) 
+
 ## Intorduction 
 
 This repository contains the official specification for the [Polkadot Protocol](https://polkadot.network/). The latest releases of the *Polkadot Protocol Specification* can be found on [spec.polkadot.network](https://spec.polkadot.network) or our [GitHub Releases page](https://github.com/w3f/polkadot-spec/releases).
+
+## Process
+
+Everyone, but specifically implementers and members of the [Technical Fellowship](https://wiki.polkadot.network/docs/learn-polkadot-opengov#the-technical-fellowship), are welcome to open PRs to this repo and contribute to the specification. A PR is merged as soon as two members of the Spec Committee accept the PR.  
+
+### Spec Committee
+
+The Spec Committee consists of Researchers, Researcher Engineers, and Implementers of the Polkadot Protocol that actively contribute (= opening/contributing to PRs or issues regarding the spec) to the specification. For now and compared to the [Technical Fellowship](https://github.com/polkadot-fellows/manifesto) itself, the responsibility of the Spec Committee is clearly defined as maintaining the specification of the protocol. In case of inactivity for three months, members will be removed again. 
+
+- [Bhargav Bhatt](https://github.com/bhargavbh)
+- [Seyed Lavasani](https://github.com/drskalman)
+- [Pierre Krieger](https://github.com/tomaka) 
+- [Heverson B. Ribeiro](https://github.com/heversonbr)
+
+## Spec Committee 
 
 ## Local Development
 
@@ -18,23 +49,23 @@ npm run build # or build_with_kaitai to also rebuild kaitai SVG files
 npm run serve
 ```
 
-If you already have the repo cloned, remember to update it and the submodule before doing any changes:
+If you already have the repo cloned, remember to update it and the submodule before making any changes:
 
 ```bash
 git pull
 git submodule update --remote
 ```
 
-Because of the "complex" build, unfortunately you can't see the changes in real time, if you directly edit the `docs` folder. There are two workarounds:
-- use a Markdown plugin or editor (e.g. the extension [Markdown All in One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one) for VSCode) to see the changes in real time. You won't be able to see the placeholders rendered and other elements, but you'll be able to render the markdown and latex;
+Because of the "complex" build, you can't see the changes in real time if you directly edit the `docs` folder. There are two workarounds:
+- use a Markdown plugin or editor (e.g., the extension [Markdown All in One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one) for VSCode) to see the changes in real time. You won't be able to see the placeholders rendered and other elements, but you'll be able to render the markdown and latex;
   
-- build the website a first time, then run `npm run start` instead of `npm run serve`, and edit the files inside the `website/docs` folder. This will allow you to see the changes in real time, but you have to remember to bring the changes inside the `docs` folder before committing. Also, in this way, you can't put the placeholders and other elements inside the markdown files of `website/docs` as they wouldn't be rendered.
-
-## Contributing
+- build the website the first time, then run `npm run start` instead of `npm run serve,` and edit the files inside the `website/docs` folder. This will allow you to see the changes in real time, but you have to remember to bring the changes inside the `docs` folder before committing. Also, in this way, you can't put the placeholders and other elements inside the markdown files of `website/docs` as they wouldn't be rendered.
 
 You can find the markdown files inside the [`docs`](docs) folder.
 
 When building, the scripts inside [`preBuild`](https://github.com/w3f/polkadot-spec-website/tree/main/preBuild) will generate a `docs` folder, from which Docusaurus will render the website. Then, the rendered content will be modified by the [`plugins`](https://github.com/w3f/polkadot-spec-website/tree/main/plugins) in the browser.
+
+## Formatting 
 
 ### LaTeX
 
@@ -176,7 +207,7 @@ or
 ```md
 ###### Image -img-num- Name {#img-name}
 ```
-For these two entities you won't need to use any component or admonition.
+For these two entities, you won't need to use any component or admonition.
 
 #### References
 
@@ -198,8 +229,8 @@ Automatically, the bibliography will be generated at the end of the page.
 
 ### Broken Links
 
-During the `preBuild`, the external links in the markdown files will be checked.<br/>
-After the `build`, the internal links will be checked.<br/>
+During the `preBuild,` the external links in the markdown files will be checked.<br/>
+After the `build,` the internal links will be checked.<br/>
 If any link is broken, the console will show a warning.<br/>
 
 Refer to [`checkBrokenInternalLinks/index.ts`](https://github.com/w3f/polkadot-spec-website/tree/main/plugins/checkBrokenInternalLinks/index.ts) and [`checkBrokenExternalLinks/index.ts`](https://github.com/w3f/polkadot-spec-website/tree/main/preBuild/checkBrokenExternalLinks/index.ts).


### PR DESCRIPTION
Given that we now have separated the [website repo](https://github.com/w3f/polkadot-spec-website/tree/main) and the [spec repo](https://github.com/w3f/polkadot-spec), it might make sense to define clear rules regarding who decided what should be merged and what shouldn't. Therefore I quickly came up with a Spec Committee and potentially we can also integrate some additional rules (e.g., the spec needs to be based on research and/or existing implementations). My main goals here are:
- convince more implementers to actively participate when it comes to the specification
- overall improve the quality 
- an initial step to further decentralize the spec 