### PR TITLE
fix genesis state

### DIFF
--- a/docs/id-cryptography-encoding.md
+++ b/docs/id-cryptography-encoding.md
@@ -689,11 +689,11 @@ The Polkadot genesis header is a data structure conforming to block header forma
 ###### Table -tab-num- Table of Genesis Header Values {#tab-genesis-header-values}
 | Block header field | Genesis Header Value                                                                                                                |
 |--------------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| `parent_hash`      | *0*                                                                                                                                 |
-| `number`           | *0*                                                                                                                                 |
+| `parent_hash`      | $0_{\mathbb{B}_{32}}$                                                                                                               |
+| `number`           | $0$                                                                                                                                 |
 | `state_root`       | Merkle hash of the state storage trie ([Definition -def-num-ref-](chap-state#defn-merkle-value)) after inserting the genesis state in it. |
 | `extrinsics_root`  | Merkle hash of an empty trie: $\text{Blake2b}{\left(0_{\mathbb{B}_1}\right)}$                                                       |
-| `digest`           | *0*                                                                                                                                 |
+| `digest`           | $0$                                                                                                                                 |
 
 :::
 

--- a/docs/id-cryptography-encoding.md
+++ b/docs/id-cryptography-encoding.md
@@ -692,7 +692,7 @@ The Polkadot genesis header is a data structure conforming to block header forma
 | `parent_hash`      | *0*                                                                                                                                 |
 | `number`           | *0*                                                                                                                                 |
 | `state_root`       | Merkle hash of the state storage trie ([Definition -def-num-ref-](chap-state#defn-merkle-value)) after inserting the genesis state in it. |
-| `extrinsics_root`  | *0*                                                                                                                                 |
+| `extrinsics_root`  | Merkle hash of an empty trie: $\text{Blake2b}{\left(0_{\mathbb{B}_1}\right)}$                                                       |
 | `digest`           | *0*                                                                                                                                 |
 
 :::


### PR DESCRIPTION
At least for Polkadot, the genesis header's `extrinsic_root` is not set to `[0; 32]`, but rather `blake2b([0])` (see e.g. [here](https://explorer.polkascan.io/polkadot/block/0)).

This PR also clarifies the size of the zero values for the other fields (with notation used elsewhere in the spec) – this is subjective, but I feel it is clearer this way. That change is made in a separate commit, though, so it can be easily removed.