### PR TITLE
Fix duplicate function name in documentation

### DIFF
--- a/docs/chap-host-api.md
+++ b/docs/chap-host-api.md
@@ -1395,7 +1395,7 @@ Remove a key and its associated value from the Offchain DB.
 
 #### -sec-num- Version 1 - Prototype {#id-version-1-prototype-Offchain_index_clear}
 
-    (func $ext_offchain_index_set_version_1
+    (func $ext_offchain_index_clear_version_1
         (param $key i64))
 
 **Arguments**  


### PR DESCRIPTION
Change the repeated function name 'ext_offchain_index_set_version_1' to the correct 'ext_offchain_index_clear_version_1' in the relevant section of the documentation.

this closes #712 