### PR TITLE
Updated "Fast Sync" section

### DIFF
--- a/docs/chap-sync.md
+++ b/docs/chap-sync.md
@@ -15,7 +15,7 @@ Warp sync ([Section -sec-num-ref-](chap-networking#sect-msg-warp-sync)) only dow
 
 ## -sec-num- Fast Sync {#sect-sync-fast}
 
-Fast sync works by downloading the block header history and validating the authority set changes ([Section -sec-num-ref-](chap-sync#sect-authority-set)) in order to arrive at a specific (usually the most recent) header. After the desired header has been reached and verified, the state can be downloaded and imported ([Section -sec-num-ref-](chap-networking#sect-msg-state-request)). Once this process has been completed, the node can proceed with a full sync.
+Fast sync works by downloading the block header history and validating the authority set changes ([Section -sec-num-ref-](chap-sync#sect-authority-set)) in order to arrive at a specific (usually the most recent) header. After the desired header has been reached and verified, the state can be downloaded and imported ([Section -sec-num-ref-](chap-networking#sect-msg-state-request)). Once this process has been completed, the node will automatically switch to a full sync.
 
 ## -sec-num- Full Sync {#id-full-sync}
 


### PR DESCRIPTION
### Description
As it is stated right now in the "Fast Sync" section, it is unclear, once fast sync is completed, if : 
- the node will automatically switch to full sync 
- or the node operator needs to stop the node and start it again with the flag `--sync=full`

So, we think it is better to explicitly mention this fact in order to avoid any confusion.

Credits to @altonen for the feedback!

cc: @IkerAlus 
