### PR TITLE
net: Use genesis-based kad protocol for discovery and deprecate /sup/kad

### DIFF
--- a/docs/chap-networking.md
+++ b/docs/chap-networking.md
@@ -145,7 +145,7 @@ The prefixes on those substreams are known as protocol identifiers and are used 
 
   Further specification and reference implementations are available in the [libp2p documentation](https://docs.libp2p.io/concepts/protocols/#identify).
 
-- `/dot/kad` - Open a standardized substream for Kademlia `FIND_NODE` requests. This is a *Request-Response substream*, as defined by the *libp2p* standard.
+- `/91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3/kad` - Open a standardized substream for Kademlia `FIND_NODE` requests. This is a *Request-Response substream*, as defined by the *libp2p* standard.
 
   Further specification and reference implementation are available on [Wikipedia](https://en.wikipedia.org/wiki/Kademlia) respectively the [golang Github repository](https://github.com/libp2p/go-libp2p-kad-dht).
 


### PR DESCRIPTION
This PR replaces the `/dot/kad` p2p network protocol used for discovery with the genesis-based equivalent `/91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3/kad`.

The genesis-based protocol was used for quite a while to discover substrate-based chains and the spec was not updated to reflect that.

The `/dot/kad` is no longer included as a fallback protocol (like other protocols do), to facilitate the deprecation of the legacy protocols. This has a few advantages: 
- Untangle the networks -- the current DHT of polkadot may contain nodes not responding to substrate protocols. They can be network scrapers (like Polkawatch which uses https://github.com/lexnv/subp2p-explorer), or they can be nodes part of an entirely different network.
- Reduce the complexity of substrate networking code and improve maintenance -- the code to facilitate fallbacks is not entirely trivial. For example, litep2p has a complete graph architecture to enable any protocols to interact with each other in case of fallbacks.

Deprecation plan:
1. Include in DHT only nodes that contain genesis-based KAD protocols
2. Remove `/dot/kad` support for substrate nodes
3. Create a followup PR to remove other `/dot/..` legacy protocols
4. Remove `/dot/..` legacy protocols support for substrate nodes
5. Clean-up fallback support in substrate

In response to: https://github.com/paritytech/polkadot-sdk/pull/3833

cc @dmitry-markin @bkchr @skunert
