### PR TITLE
Base fee calculation update

### DIFF
--- a/docs/id-extrinsics.md
+++ b/docs/id-extrinsics.md
@@ -43,7 +43,7 @@ $$
 $$
 
 **where**  
-- ${A}_{{i}}$: the 32-byte address of the sender ([Definition -def-num-ref-](id-extrinsics#defn-extrinsic-address)).
+- ${A}_{{i}}$ is the multi-address of the sender defined in [Definition -def-num-ref-](id-extrinsics#defn-extrinsic-address).
 
 - ${Sig}$: the signature of the sender ([Definition -def-num-ref-](id-extrinsics#defn-extrinsic-signature)).
 

--- a/docs/id-weights.md
+++ b/docs/id-weights.md
@@ -716,7 +716,7 @@ $$
 
 The Polkadot Runtime defines the following values:
 
-- Base fee: 100 uDOTs
+- Base fee: 1 mDOTs $(10^{-3}DOT)$. Base Fee is defined as the fee for a No-op extrinsic (for e.g., an empty System::Remark call, currently with a weight of 126 micro Seconds).   
 
 - Length fee: 0.1 uDOTs
 
@@ -724,7 +724,7 @@ The Polkadot Runtime defines the following values:
 
   ${weight}$ fee = weight \times (100${u}{D}{O}{T}{s}\div{\left({10}\times{10}'{000}\right)}{)}$
 
-  A weight of 10’000 (the smallest non-zero weight) is mapped to ${\frac{{{1}}}{{{10}}}}$ of 100 uDOT. This fee will never exceed the max size of an unsigned 128 bit integer.
+  A weight of 126’000 nS is mapped to 1 mDOT. This fee will never exceed the max size of an unsigned 128 bit integer.
 
 ### -sec-num- Fee Multiplier {#id-fee-multiplier}
 

--- a/docs/id-weights.md
+++ b/docs/id-weights.md
@@ -722,7 +722,7 @@ The Polkadot Runtime defines the following values:
 
 - Weight to fee conversion:
 
-  ${weight}$ fee = weight \times (100${u}{D}{O}{T}{s}\div{\left({10}\times{10}'{000}\right)}{)}$
+  ${weight}$ fee = $weight/1.26 * (10^{-8})$ where $weight$ is in nS.
 
   A weight of 126’000 nS is mapped to 1 mDOT. This fee will never exceed the max size of an unsigned 128 bit integer.
 


### PR DESCRIPTION
The earlier definition of Base Fee was off by a factor of more than 10. This PR addresses it with the latest empirical value of the weigh_to_fee ratio from Polkadot Runtime.  