### PR TITLE
Bnb/not actively maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> The Polkadot Protocol Specifications are not actively maintained by the Web3 Foundation as of 02 October 2024.
+
 # Polkadot Protocol Specification
 
 - [Introduction](#introduction)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!NOTE]
-> The Polkadot Protocol Specifications are not actively maintained by the Web3 Foundation as of 02 October 2024.
+> The Polkadot Protocol Specifications are not actively maintained by the Web3 Foundation as of 02 October 2024. Please follow the [RFC process](https://github.com/polkadot-fellows/RFCs) for information on latest protocol updates. 
 
 # Polkadot Protocol Specification
 

--- a/docs/id-polkadot-protocol.md
+++ b/docs/id-polkadot-protocol.md
@@ -1,8 +1,8 @@
 ---
 title: Polkadot Protocol
 ---
-:::caution
-This specification is **Work-In-Progress** and any content, structure, design and/or hyper/anchor-link **is subject to change**.
+:::note
+The specifications are not actively maintained by the Web3 Foundation as of 02/10/2024. Please follow the [RCF Process](https://github.com/polkadot-fellows/RFCs) for latest protocol updates. 
 :::
 
 Formally, Polkadot is a replicated sharded state machine designed to resolve the scalability and interoperability among blockchains. In Polkadot vocabulary, shards are called *parachains* and Polkadot *relay chain* is part of the protocol ensuring global consensus among all the parachains. The Polkadot relay chain protocol, henceforward called *Polkadot protocol*, can itself be considered as a replicated state machine on its own. As such, the protocol can be specified by identifying the state machine and the replication strategy.


### PR DESCRIPTION
Added a note to the README and the landing page that the spec is not actively maintained and a forward link to the Fellowship's RFC repo. 