### PR TITLE
Fix Best Pre-Vote Candidate in GRANDPA Spec

### DIFF
--- a/algorithms/bestPrevoteCandidate.tex
+++ b/algorithms/bestPrevoteCandidate.tex
@@ -2,11 +2,12 @@
 \caption{Best-PreVote-Candidate}
 \begin{algorithmic}
     \input $r$
-    \state $B^{r, pv}_v \leftarrow$ \call{GRANDPA-GHOST}{$r$}
-    \if{\call{Received}{$M_{v_{primary}}^{r, prim}(B))$ \and $B^{r, pv}_v \geqslant B > L$}}
+    \state $B^{r-1, pv}_v \leftarrow$ \call{GRANDPA-GHOST}{$r-1$}
+    \if{\call{Received}{$M_{v_{primary}}^{r, prim}(B))$ \and $B^{r-1, pv}_v \geqslant B > L$}}
         \state $N \leftarrow B$
     \else
-        \state $N \leftarrow B^{r, pv}_v$
+        \state $N \leftarrow B^{r-1, pv}_v$
     \endif
+    \return \call{Best-Chain-Safe-Head}{N}
 \end{algorithmic}
 \end{algorithm}

--- a/docs/sect-finality.md
+++ b/docs/sect-finality.md
@@ -337,6 +337,8 @@ where $\#{{V}_{{\text{obv}{\left({v}\right)},{p}{o}{t}}}^{{{r},{p}{c}}}}$ is def
     algID="bestPrevoteCandidate"
     options={{ "lineNumber": true }}
 />
+
+where $\text{Best-Chain-Safe-Head}$ function is provided by the block production algorithm.
 :::
 
 ###### Algorithm -algo-num- Attempt To Finalize At Round {#algo-attempt-to–finalize}

--- a/docs/sect-finality.md
+++ b/docs/sect-finality.md
@@ -338,7 +338,7 @@ where $\#{{V}_{{\text{obv}{\left({v}\right)},{p}{o}{t}}}^{{{r},{p}{c}}}}$ is def
     options={{ "lineNumber": true }}
 />
 
-where $\text{Best-Chain-Safe-Head}$ function is provided by the block production algorithm.
+where $\text{Best-Chain-Safe-Head}$ function is provided by the block production algorithm to choose a preferred head of the best sub-chain which must contain block $N$ provided to it..
 :::
 
 ###### Algorithm -algo-num- Attempt To Finalize At Round {#algo-attempt-to–finalize}


### PR DESCRIPTION
closes #733

- Best Prevote should come from last round's GHOST.
- We should return the best chain safe head of that GHOST.
 